### PR TITLE
tests/openapi: clean PR replacing #2

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-def pytest_ignore_collect(path: Path, config: pytest.Config) -> bool:
+def pytest_ignore_collect(collection_path: Path, config: "pytest.Config") -> bool:
     """Ignore certain paths during test collection using pathlib.Path as per pytest>=8."""
     # Keep existing logic if any; default to not ignoring.
     return False

--- a/tests/test_openapi_endpoints.py
+++ b/tests/test_openapi_endpoints.py
@@ -1,19 +1,10 @@
 import json
 from fastapi.testclient import TestClient
 
-from web_mode import create_app
+from web_mode import app
 
-client = TestClient(create_app(no_auth=True))
+client = TestClient(app)
 
-def test_swagger_ui_docs_available():
-    resp = client.get('/docs')
-    assert resp.status_code == 200
-    assert 'text/html' in resp.headers.get('content-type','')
+def test_swagger_ui_docs_available():\n    resp = client.get('/docs')\n    assert resp.status_code == 200\n    assert 'text/html' in resp.headers.get('content-type','')\n
 
-def test_openapi_json_available_and_has_paths():
-    resp = client.get('/openapi.json')
-    assert resp.status_code == 200
-    assert 'application/json' in resp.headers.get('content-type','')
-    data = resp.json()
-    assert isinstance(data, dict)
-    assert 'paths' in data and isinstance(data['paths'], dict)
+def test_openapi_json_available_and_has_paths():\n    resp = client.get('/openapi.json')\n    assert resp.status_code == 200\n    assert 'application/json' in resp.headers.get('content-type','')\n    data = resp.json()\n    assert isinstance(data, dict)\n    assert 'paths' in data and isinstance(data['paths'], dict)\n


### PR DESCRIPTION
This PR recreates the non-meta changes from #2 (chore/openapi-tests-and-pytest-fix), limited to:\n\n- conftest.py: update pytest hook signature for pytest>=8\n- tests/test_openapi_endpoints.py: use app from web_mode with TestClient\n\nExcluded meta/cache files to avoid conflicts. Supersedes and closes #2.\n\nCloses #2