### PR TITLE
Add new contributor guide and link from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Hello and welcome to ChattyCommander! If you're new here or revisiting after some time, this README will guide you through what the app does, its benefits, and how to get started. ChattyCommander is a voice-activated command processing system that uses machine learning models to detect wake words and execute predefined actions, making hands-free computing a reality.
 
+If you're looking to contribute, start with the [New Contributor Guide](docs/NEW_CONTRIBUTOR_GUIDE.md).
+
 ## What It Does
 
 ChattyCommander listens continuously for voice commands using ONNX-based models. It supports different states (idle, computer, chatty) and transitions between them based on detected wake words like "hey chat tee" or "hey khum puter". Once in a specific state, it can execute actions such as keypresses, API calls to home assistants, or interactions with chatbots.

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -1,5 +1,7 @@
 # ChattyCommander Developer Setup Guide
 
+For a quick project orientation, see the [New Contributor Guide](NEW_CONTRIBUTOR_GUIDE.md).
+
 ## Prerequisites
 - Python 3.11+
 - uv (pip alternative)

--- a/docs/NEW_CONTRIBUTOR_GUIDE.md
+++ b/docs/NEW_CONTRIBUTOR_GUIDE.md
@@ -1,0 +1,13 @@
+# New Contributor Guide
+
+Welcome! This brief guide highlights a few places to explore when getting started with ChattyCommander.
+
+1. **Run the CLI** to see the project in action:
+   ```bash
+   uv run python src/chatty_commander/cli.py --help
+   ```
+2. **Inspect `config.json`** in the repository root to learn how wake words, actions, and services are configured.
+3. **Explore `src/chatty_commander/web_mode.py`** to understand how the web interface and server are implemented.
+4. **Review the modules in `src/chatty_commander/advisors/`** to see how advisor behaviors and integrations are structured.
+
+Happy hacking!


### PR DESCRIPTION
## Summary
- Add NEW_CONTRIBUTOR_GUIDE with steps for exploring CLI, config, web mode, and advisors modules
- Link the guide from README and DEVELOPER_SETUP for easy discovery

## Testing
- `uv run pytest` *(fails: 2 failed, 175 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689bec37c424832c87e6f11f56af3246