### PR TITLE
Add MkDocs workflow and configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Docs
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: pip install mkdocs
+      - name: Build site
+        run: mkdocs build --site-dir site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# ChattyCommander Documentation
+
+Welcome to the documentation site for ChattyCommander.
+
+See [README](README.md) for an overview and explore other guides in this folder for more information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: Chatty Commander
+theme:
+  name: mkdocs


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy MkDocs docs
- add minimal MkDocs configuration and index page

## Testing
- `pre-commit run --files .github/workflows/docs.yml docs/index.md mkdocs.yml` *(fails: pre-commit not installed and install blocked by network policy)*
- `pytest` *(fails: required Python version and pytest missing; install blocked by network policy)*
- `mkdocs build` *(fails: mkdocs not installed and install blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_689bec368af4832c9069ae1a5ea39baf