### PR TITLE
test: ensure intro text when CLI invoked without args

### DIFF
--- a/tests/test_cli_help_and_shell.py
+++ b/tests/test_cli_help_and_shell.py
@@ -18,6 +18,8 @@ def test_cli_help_lists_key_flags():
 
 
 def test_no_args_prints_intro_and_does_not_crash():
-    rc, out, err = run_cmd([PYTHON, 'src/chatty_commander/main.py', '--help'])
+    rc, out, err = run_cmd([PYTHON, 'src/chatty_commander/main.py'])
     assert rc == 0
-    assert 'ChattyCommander' in (out + err)
+    text = out + err
+    assert "ChattyCommander - Voice Command System" in text
+    assert "Use --help for available options" in text


### PR DESCRIPTION
## Summary
- test that running main.py with no arguments prints the intro text and exits cleanly
- keep separate test to validate --help lists key flags

## Testing
- `./.venv/bin/ruff check tests/test_cli_help_and_shell.py`
- `./.venv/bin/black tests/test_cli_help_and_shell.py --line-length=100`
- `./.venv/bin/pytest tests/test_cli_help_and_shell.py`


------
https://chatgpt.com/codex/tasks/task_e_689be6a03f78832cad06682d4197d37c