### PR TITLE
Add documentation linting and link checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Format check (black)
         run: uv run black --check .
 
+      - name: Docstring lint (pydocstyle)
+        run: uv run pydocstyle src
+
+      - name: Lint docs (doc8)
+        run: uv run doc8 README.md docs
+
+      - name: Check links
+        run: uv run pytest --check-links README.md docs -q
+
       - name: Run tests with coverage
         run: uv run pytest -q --cov=. --cov-report=term --cov-report=xml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## Documentation linting
+
+Ensure documentation stays consistent and links remain valid by running the
+following checks before pushing your changes:
+
+```bash
+uv sync --all-groups
+uv run pydocstyle src
+uv run doc8 README.md docs
+uv run pytest --check-links README.md docs -q
+```
+
+These commands verify docstring style, lint the Markdown documentation, and test
+that all referenced links resolve correctly.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ chatty-commander = "chatty_commander.cli.cli:cli_main"
 dev = [
     "ruff>=0.1.0",
     "black>=23.0.0",
+    "doc8>=1.1.1",
+    "pydocstyle>=6.0.0",
+    "pytest-check-links>=0.5.0",
 ]
 
 [tool.pytest.ini_options]
@@ -94,6 +97,22 @@ quote-style = "preserve"
 indent-style = "space"
 docstring-code-format = true
 skip-magic-trailing-comma = false
+
+[tool.pydocstyle]
+convention = "google"
+add-ignore = [
+  "D100", # Missing docstring in public module
+  "D101", # Missing docstring in public class
+  "D102", # Missing docstring in public method
+  "D103", # Missing docstring in public function
+  "D104", # Missing docstring in public package
+  "D105", # Missing docstring in magic method
+  "D107", # Missing docstring in __init__
+]
+
+[tool.doc8]
+max-line-length = 100
+ignore = ["D001"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
## Summary
- add docstring linting with pydocstyle and configure doc8
- run doc8, pydocstyle, and link checking in CI
- document local doc linting steps in CONTRIBUTING

## Testing
- `uv sync --all-groups` *(fails: Failed to fetch: https://pypi.org/simple/pywebview/)*
- `uv run pydocstyle src` *(fails: Failed to fetch: https://pypi.org/simple/pystray/)*
- `uv run doc8 README.md docs` *(fails: Failed to fetch: https://pypi.org/simple/pyjwt/)*
- `uv run pytest --check-links README.md docs -q` *(fails: Failed to fetch: https://pypi.org/simple/pydocstyle/)*
- `uv run pytest -q` *(fails: Failed to fetch: https://pypi.org/simple/doc8/)*

------
https://chatgpt.com/codex/tasks/task_e_689bec374134832cb2c8cc3af7bd1005