### PR TITLE
Fix lint errors in avatar modules

### DIFF
--- a/src/chatty_commander/avatars/thinking_state.py
+++ b/src/chatty_commander/avatars/thinking_state.py
@@ -7,16 +7,17 @@ to connected avatar UIs for synchronized animations and visual feedback.
 
 import logging
 import time
-from dataclasses import dataclass, asdict
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Dict, Any, Optional, Callable, Set
-import json
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 class ThinkingState(Enum):
     """States that an agent can be in during conversation."""
+
     IDLE = "idle"
     THINKING = "thinking"
     PROCESSING = "processing"
@@ -30,26 +31,27 @@ class ThinkingState(Enum):
 @dataclass
 class AgentStateInfo:
     """Information about an agent's current state."""
+
     agent_id: str
-    avatar_id: Optional[str]
+    avatar_id: str | None
     persona_id: str
     state: ThinkingState
-    message: Optional[str] = None
-    progress: Optional[float] = None  # 0.0 to 1.0 for progress bars
+    message: str | None = None
+    progress: float | None = None  # 0.0 to 1.0 for progress bars
     timestamp: float = None
-    
+
     def __post_init__(self):
         if self.timestamp is None:
             self.timestamp = time.time()
-    
-    def to_dict(self) -> Dict[str, Any]:
+
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         data = asdict(self)
         data['state'] = self.state.value
         return data
-    
+
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AgentStateInfo':
+    def from_dict(cls, data: dict[str, Any]) -> 'AgentStateInfo':
         """Create from dictionary."""
         data['state'] = ThinkingState(data['state'])
         return cls(**data)
@@ -58,68 +60,69 @@ class AgentStateInfo:
 class ThinkingStateManager:
     """
     Manages thinking states for multiple agents and broadcasts changes to avatar UIs.
-    
     This enables synchronized animations between AI processing and avatar displays.
     """
-    
+
     def __init__(self):
-        self.agent_states: Dict[str, AgentStateInfo] = {}
-        self.avatar_mappings: Dict[str, str] = {}  # agent_id -> avatar_id
-        self.broadcast_callbacks: Set[Callable[[Dict[str, Any]], None]] = set()
-        
-    def register_agent(self, agent_id: str, persona_id: str, avatar_id: Optional[str] = None) -> None:
+        self.agent_states: dict[str, AgentStateInfo] = {}
+        self.avatar_mappings: dict[str, str] = {}  # agent_id -> avatar_id
+        self.broadcast_callbacks: set[Callable[[dict[str, Any]], None]] = set()
+
+    def register_agent(self, agent_id: str, persona_id: str, avatar_id: str | None = None) -> None:
         """Register a new agent with optional avatar mapping."""
         self.agent_states[agent_id] = AgentStateInfo(
-            agent_id=agent_id,
-            avatar_id=avatar_id,
-            persona_id=persona_id,
-            state=ThinkingState.IDLE
+            agent_id=agent_id, avatar_id=avatar_id, persona_id=persona_id, state=ThinkingState.IDLE
         )
-        
+
         if avatar_id:
             self.avatar_mappings[agent_id] = avatar_id
-            
+
         self._broadcast_state_change(agent_id)
-        
-    def set_agent_state(self, agent_id: str, state: ThinkingState, 
-                       message: Optional[str] = None, progress: Optional[float] = None) -> None:
+
+    def set_agent_state(
+        self,
+        agent_id: str,
+        state: ThinkingState,
+        message: str | None = None,
+        progress: float | None = None,
+    ) -> None:
         """Update an agent's thinking state."""
         if agent_id not in self.agent_states:
             logger.warning(f"Agent {agent_id} not registered, creating default entry")
             self.register_agent(agent_id, "default")
-            
+
         agent_info = self.agent_states[agent_id]
         agent_info.state = state
         agent_info.message = message
         agent_info.progress = progress
         agent_info.timestamp = time.time()
-        
+
         self._broadcast_state_change(agent_id)
-        
-    def get_agent_state(self, agent_id: str) -> Optional[AgentStateInfo]:
+
+    def get_agent_state(self, agent_id: str) -> AgentStateInfo | None:
         """Get current state of an agent."""
         return self.agent_states.get(agent_id)
-        
-    def get_all_states(self) -> Dict[str, AgentStateInfo]:
+
+    def get_all_states(self) -> dict[str, AgentStateInfo]:
         """Get all agent states."""
         return self.agent_states.copy()
-        
+
     def map_agent_to_avatar(self, agent_id: str, avatar_id: str) -> None:
         """Map an agent to a specific avatar for visual correlation."""
         self.avatar_mappings[agent_id] = avatar_id
-        
+
         if agent_id in self.agent_states:
             self.agent_states[agent_id].avatar_id = avatar_id
             self._broadcast_state_change(agent_id)
-            
-    def add_broadcast_callback(self, callback: Callable[[Dict[str, Any]], None]) -> None:
+
+    def add_broadcast_callback(self, callback: Callable[[dict[str, Any]], None]) -> None:
         """Add a callback to receive state change broadcasts."""
         self.broadcast_callbacks.add(callback)
-        
-    def remove_broadcast_callback(self, callback: Callable[[Dict[str, Any]], None]) -> None:
+
+    def remove_broadcast_callback(self, callback: Callable[[dict[str, Any]], None]) -> None:
         """Remove a broadcast callback."""
         self.broadcast_callbacks.discard(callback)
-        
+
     def _broadcast(self, message: dict[str, Any]) -> None:
         for callback in self.broadcast_callbacks.copy():
             try:
@@ -141,65 +144,77 @@ class ThinkingStateManager:
 
     # Tool calling lifecycle events
     def start_tool_call(self, agent_id: str, tool_name: str | None = None) -> None:
-        self.set_agent_state(agent_id, ThinkingState.TOOL_CALLING, f"Calling tool {tool_name or ''}".strip())
-        self._broadcast({
-            "type": "tool_call_start",
-            "data": {"agent_id": agent_id, "tool": tool_name},
-            "timestamp": time.time(),
-        })
+        self.set_agent_state(
+            agent_id, ThinkingState.TOOL_CALLING, f"Calling tool {tool_name or ''}".strip()
+        )
+        self._broadcast(
+            {
+                "type": "tool_call_start",
+                "data": {"agent_id": agent_id, "tool": tool_name},
+                "timestamp": time.time(),
+            }
+        )
 
     def end_tool_call(self, agent_id: str, tool_name: str | None = None) -> None:
         # Return to processing by default
         self.set_agent_state(agent_id, ThinkingState.PROCESSING)
-        self._broadcast({
-            "type": "tool_call_end",
-            "data": {"agent_id": agent_id, "tool": tool_name},
-            "timestamp": time.time(),
-        })
+        self._broadcast(
+            {
+                "type": "tool_call_end",
+                "data": {"agent_id": agent_id, "tool": tool_name},
+                "timestamp": time.time(),
+            }
+        )
 
     # Agent handoff lifecycle
-    def handoff_start(self, agent_id: str, to_agent_persona: str, reason: str | None = None) -> None:
+    def handoff_start(
+        self, agent_id: str, to_agent_persona: str, reason: str | None = None
+    ) -> None:
         self.set_agent_state(agent_id, ThinkingState.HANDOFF, reason)
-        self._broadcast({
-            "type": "handoff_start",
-            "data": {"agent_id": agent_id, "to_persona": to_agent_persona, "reason": reason},
-            "timestamp": time.time(),
-        })
+        self._broadcast(
+            {
+                "type": "handoff_start",
+                "data": {"agent_id": agent_id, "to_persona": to_agent_persona, "reason": reason},
+                "timestamp": time.time(),
+            }
+        )
 
     def handoff_complete(self, agent_id: str, new_persona_id: str) -> None:
         # Update persona mapping and return to idle
         if agent_id in self.agent_states:
             self.agent_states[agent_id].persona_id = new_persona_id
         self.set_agent_state(agent_id, ThinkingState.IDLE)
-        self._broadcast({
-            "type": "handoff_complete",
-            "data": {"agent_id": agent_id, "persona_id": new_persona_id},
-            "timestamp": time.time(),
-        })
-                
-    def start_thinking(self, agent_id: str, message: Optional[str] = None) -> None:
+        self._broadcast(
+            {
+                "type": "handoff_complete",
+                "data": {"agent_id": agent_id, "persona_id": new_persona_id},
+                "timestamp": time.time(),
+            }
+        )
+
+    def start_thinking(self, agent_id: str, message: str | None = None) -> None:
         """Convenience method to set thinking state."""
         self.set_agent_state(agent_id, ThinkingState.THINKING, message)
-        
-    def start_processing(self, agent_id: str, message: Optional[str] = None) -> None:
+
+    def start_processing(self, agent_id: str, message: str | None = None) -> None:
         """Convenience method to set processing state."""
         self.set_agent_state(agent_id, ThinkingState.PROCESSING, message)
-        
-    def start_responding(self, agent_id: str, message: Optional[str] = None) -> None:
+
+    def start_responding(self, agent_id: str, message: str | None = None) -> None:
         """Convenience method to set responding state."""
         self.set_agent_state(agent_id, ThinkingState.RESPONDING, message)
-        
+
     def set_idle(self, agent_id: str) -> None:
         """Convenience method to set idle state."""
         self.set_agent_state(agent_id, ThinkingState.IDLE)
-        
+
     def set_error(self, agent_id: str, error_message: str) -> None:
         """Convenience method to set error state."""
         self.set_agent_state(agent_id, ThinkingState.ERROR, error_message)
 
 
 # Global instance for application-wide use
-_global_thinking_manager: Optional[ThinkingStateManager] = None
+_global_thinking_manager: ThinkingStateManager | None = None
 
 
 def get_thinking_manager() -> ThinkingStateManager:
@@ -218,38 +233,48 @@ def reset_thinking_manager() -> None:
 
 class ThinkingStateContext:
     """Context manager for automatic thinking state transitions."""
-    
-    def __init__(self, agent_id: str, thinking_message: str = "Processing...", 
-                 responding_message: str = "Generating response..."):
+
+    def __init__(
+        self,
+        agent_id: str,
+        thinking_message: str = "Processing...",
+        responding_message: str = "Generating response...",
+    ):
         self.agent_id = agent_id
         self.thinking_message = thinking_message
         self.responding_message = responding_message
         self.manager = get_thinking_manager()
-        
+
     def __enter__(self):
         self.manager.start_thinking(self.agent_id, self.thinking_message)
         return self
-        
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None:
             self.manager.set_error(self.agent_id, f"Error: {exc_val}")
         else:
             self.manager.set_idle(self.agent_id)
-            
+
     def start_responding(self):
         """Transition to responding state."""
         self.manager.start_responding(self.agent_id, self.responding_message)
 
 
 # Decorator for automatic thinking state management
-def with_thinking_state(agent_id: str, thinking_msg: str = "Processing...", 
-                       responding_msg: str = "Generating response..."):
+def with_thinking_state(
+    agent_id: str,
+    thinking_msg: str = "Processing...",
+    responding_msg: str = "Generating response...",
+):
     """Decorator to automatically manage thinking states during function execution."""
+
     def decorator(func):
         def wrapper(*args, **kwargs):
             with ThinkingStateContext(agent_id, thinking_msg, responding_msg) as ctx:
                 result = func(*args, **kwargs)
                 ctx.start_responding()
                 return result
+
         return wrapper
+
     return decorator

--- a/src/chatty_commander/web/routes/avatar_selector.py
+++ b/src/chatty_commander/web/routes/avatar_selector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Literal
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
@@ -10,9 +11,13 @@ AllowedLabel = Literal[
     "excited", "calm", "curious", "warning", "success", "error", "neutral", "hacking"
 ]
 
+
 class AnimationChooseRequest(BaseModel):
     text: str = Field(..., description="Text to classify")
-    candidate_labels: list[str] | None = Field(default=None, description="Optional subset of allowed labels")
+    candidate_labels: list[str] | None = Field(
+        default=None, description="Optional subset of allowed labels"
+    )
+
 
 class AnimationChooseResponse(BaseModel):
     label: str
@@ -38,8 +43,10 @@ async def choose_animation(req: AnimationChooseRequest) -> Any:
         labels = set(req.candidate_labels or [])
         if labels:
             labels &= set(_HINTS.keys()) | {"neutral"}
+
         def allowed(label: str) -> bool:
             return (not labels) or (label in labels)
+
         # Hint-based deterministic classifier (placeholder for LLM)
         for label, keywords in _HINTS.items():
             if not allowed(label):
@@ -48,4 +55,4 @@ async def choose_animation(req: AnimationChooseRequest) -> Any:
                 return AnimationChooseResponse(label=label, confidence=0.8)
         return AnimationChooseResponse(label="neutral", confidence=0.5)
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e


### PR DESCRIPTION
## Summary
- remove extraneous blank line whitespace in `ThinkingStateManager`
- raise HTTPException using exception chaining in avatar selector

## Testing
- `pre-commit run --files src/chatty_commander/avatars/thinking_state.py src/chatty_commander/web/routes/avatar_selector.py`
- `python3 -m pytest` *(fails: No module named 'uvicorn', 'fastapi', 'psutil', 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689bf23bbe90832c9f6f369da8b7b372