### PR TITLE
docs: update default port references to 8100

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -44,7 +44,7 @@
 - **Symptoms**: Interface not loading or WebSocket disconnects.
 - **Solutions**:
   - Check browser console for errors.
-  - Ensure correct ports are open (default: 8000 for web).
+  - Ensure correct ports are open (default: 8100 for web).
   - Clear browser cache.
 
 ## Advanced Debugging

--- a/docs/webui/WEBUI_IMPLEMENTATION.md
+++ b/docs/webui/WEBUI_IMPLEMENTATION.md
@@ -419,7 +419,7 @@ chatty-commander/
 ```bash
 # Backend
 cd webui/backend
-uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8100
 
 # Frontend
 cd webui/frontend
@@ -439,8 +439,8 @@ npm run dev
    services:
      backend:
        build: ./backend
-       ports:
-         - "8000:8000"
+      ports:
+        - "8100:8100"
        environment:
          - DATABASE_URL=postgresql://user:pass@db:5432/chatty
      

--- a/docs/webui/WEBUI_PLAN.md
+++ b/docs/webui/WEBUI_PLAN.md
@@ -111,7 +111,7 @@ def test_update_command():
 
 # WebSocket tests
 async def test_status_websocket():
-    async with websockets.connect("ws://localhost:8000/ws/status") as websocket:
+    async with websockets.connect("ws://localhost:8100/ws/status") as websocket:
         message = await websocket.recv()
         data = json.loads(message)
         assert "status" in data

--- a/docs/webui/WEBUI_ROADMAP.md
+++ b/docs/webui/WEBUI_ROADMAP.md
@@ -35,7 +35,7 @@
 
 **Deliverables**:
 - Working development environment
-- Basic FastAPI server running on port 8000
+- Basic FastAPI server running on port 8100
 - React development server on port 3000
 - Docker Compose setup
 - Initial test suites

--- a/docs/webui/WEBUI_TEST_PLAN.md
+++ b/docs/webui/WEBUI_TEST_PLAN.md
@@ -624,7 +624,7 @@ module.exports = {
 # ChattyCommander WebUI Demo Script
 
 ## Demo Environment Setup
-1. **Backend Service**: Running on http://localhost:8000
+1. **Backend Service**: Running on http://localhost:8100
 2. **Frontend Application**: Running on http://localhost:3000
 3. **Test Data**: Pre-configured with sample commands and states
 4. **Audio Setup**: Microphone connected for voice testing

--- a/src/chatty_commander/tools/bridge_nodejs.py
+++ b/src/chatty_commander/tools/bridge_nodejs.py
@@ -45,7 +45,7 @@ def generate_env_template() -> str:
     return """# Node.js Bridge Configuration
 
 # Python Advisor API
-ADVISOR_API_URL=http://localhost:8000
+ADVISOR_API_URL=http://localhost:8100
 BRIDGE_TOKEN=your_shared_secret_here
 
 # Discord Bot Configuration
@@ -111,7 +111,7 @@ const slackApp = new App({
 // Advisor API client
 class AdvisorAPIClient {
   constructor() {
-    this.baseURL = process.env.ADVISOR_API_URL || 'http://localhost:8000';
+    this.baseURL = process.env.ADVISOR_API_URL || 'http://localhost:8100';
     this.bridgeToken = process.env.BRIDGE_TOKEN;
   }
 
@@ -344,7 +344,7 @@ services:
       - "3001:3001"
     environment:
       - NODE_ENV=development
-      - ADVISOR_API_URL=http://host.docker.internal:8000
+      - ADVISOR_API_URL=http://host.docker.internal:8100
       - BRIDGE_TOKEN=${BRIDGE_TOKEN}
       - DISCORD_TOKEN=${DISCORD_TOKEN}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}

--- a/webui_openapi_spec.yaml
+++ b/webui_openapi_spec.yaml
@@ -26,7 +26,7 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: http://localhost:8000/api/v1
+  - url: http://localhost:8100/api/v1
     description: Development server
   - url: https://chatty.yourdomain.com/api/v1
     description: Production server


### PR DESCRIPTION
## Summary
- document web service default port as 8100 instead of 8000
- align bridge tool, OpenAPI spec, and web UI docs to use port 8100

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bf25d023c832ca990b71c2d84fd52