### PR TITLE
test: assert set_mode not invoked on invalid mode

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,9 +58,10 @@ def test_cli_set_listen_for(monkeypatch):
 
 def test_cli_set_mode(monkeypatch, capsys):
     monkeypatch.setattr(sys, 'argv', ['cli.py', 'config', '--set-mode', 'mode1', 'option1'])
-    with patch('cli.ConfigCLI.set_mode'):
+    with patch('cli.ConfigCLI.set_mode') as mock_set:
         with pytest.raises(SystemExit):
             cli_main()
+        mock_set.assert_not_called()
     captured = capsys.readouterr()
     assert "Invalid mode" in captured.err
 


### PR DESCRIPTION
## Summary
- verify ConfigCLI.set_mode isn't called when CLI receives an invalid mode

## Testing
- `pytest tests/test_cli.py::test_cli_set_mode -q`
- `pytest tests/test_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf6f2b3e0832c8ba3f35bacc64e35