### PR TITLE
Reduce duplicate shell completion log messages

### DIFF
--- a/src/chatty_commander/app/command_executor.py
+++ b/src/chatty_commander/app/command_executor.py
@@ -273,9 +273,7 @@ class CommandExecutor:
                 logging.warning(f"shell ok: {out[:500]}")
                 # Elevate one completion message to WARNING so caplog captures it
                 logging.warning(f"Completed execution of command: {command_name}")
-                # Keep remaining at INFO for compatibility
-                logging.info(f"Completed execution of command: {command_name}")
-                logging.info(f"Completed execution of command: {command_name}")
+                # Keep one INFO log for compatibility
                 logging.info(f"Completed execution of command: {command_name}")
         except subprocess.TimeoutExpired:
             msg = "shell command timed out"


### PR DESCRIPTION
## Summary
- consolidate repeated shell completion info logs into a single entry in `_execute_shell`

## Testing
- `pytest tests/test_command_executor_shell_and_keybinding.py`

------
https://chatgpt.com/codex/tasks/task_e_689bf6f0c5b8832c81a4d48449629c20