### PR TITLE
docs: add configuration schema and adapter guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 Hello and welcome to ChattyCommander! If you're new here or revisiting after some time, this README will guide you through what the app does, its benefits, and how to get started. ChattyCommander is a voice-activated command processing system that uses machine learning models to detect wake words and execute predefined actions, making hands-free computing a reality.
 
 If you're looking to contribute, start with the [New Contributor Guide](docs/NEW_CONTRIBUTOR_GUIDE.md).
+For component diagrams and extension points see
+[Architecture Overview](docs/ARCHITECTURE_OVERVIEW.md),
+[Configuration Schema](docs/CONFIG_SCHEMA.md), and
+[Adapter and Plugin System](docs/ADAPTERS.md).
 
 ## What It Does
 
@@ -20,39 +24,42 @@ ChattyCommander listens continuously for voice commands using ONNX-based models.
 ## Core Concepts
 
 ### Modes (States)
+
 ChattyCommander operates in distinct "modes" or "states," each designed to activate a specific set of voice models and functionalities. This allows the application to respond differently based on the context you've set. The primary states are:
 
--   **Idle**: The default state. In this mode, ChattyCommander primarily listens for wake words that transition it to other states (e.g., "hey chat tee", "hey khum puter").
--   **Computer**: Once in this state, ChattyCommander activates models specifically designed for system-level commands, allowing you to control your computer through voice.
--   **Chatty**: In this mode, the application is configured to interact with chatbot models, enabling conversational commands and responses.
+- **Idle**: The default state. In this mode, ChattyCommander primarily listens for wake words that transition it to other states (e.g., "hey chat tee", "hey khum puter").
+- **Computer**: Once in this state, ChattyCommander activates models specifically designed for system-level commands, allowing you to control your computer through voice.
+- **Chatty**: In this mode, the application is configured to interact with chatbot models, enabling conversational commands and responses.
 
 Transitions between these states are triggered by specific wake words defined in your configuration, ensuring that only relevant models are active at any given time.
 
 ### Actions and Keybindings
+
 Actions are the core functionalities ChattyCommander performs in response to recognized commands. These can include:
 
--   **Keypresses**: Emulating keyboard shortcuts (e.g., `ctrl+shift+;` for `okay_stop`). These are handled by the `pyautogui` library.
--   **URL Calls**: Sending HTTP requests to specified URLs, often used for integrating with smart home systems like Home Assistant.
--   **System Commands**: Executing shell commands directly on your operating system.
+- **Keypresses**: Emulating keyboard shortcuts (e.g., `ctrl+shift+;` for `okay_stop`). These are handled by the `pyautogui` library.
+- **URL Calls**: Sending HTTP requests to specified URLs, often used for integrating with smart home systems like Home Assistant.
+- **System Commands**: Executing shell commands directly on your operating system.
 
 Each recognized voice command is mapped to a specific action within the `config.py` file, allowing for flexible and customizable responses.
 
 ### Voice Files (ONNX Models)
+
 ChattyCommander utilizes ONNX (Open Neural Network Exchange) models for efficient and accurate voice command recognition. These models are pre-trained neural networks that convert spoken words into actionable commands.
 
--   **Model Placement**: ONNX models are organized into specific directories (`models-idle`, `models-computer`, `models-chatty`) corresponding to the application's states.
--   **Efficiency**: ONNX models are chosen for their optimized performance, enabling real-time voice processing with minimal latency.
--   **Customization**: Users can train and integrate their own ONNX models to extend ChattyCommander's vocabulary and command recognition capabilities.
+- **Model Placement**: ONNX models are organized into specific directories (`models-idle`, `models-computer`, `models-chatty`) corresponding to the application's states.
+- **Efficiency**: ONNX models are chosen for their optimized performance, enabling real-time voice processing with minimal latency.
+- **Customization**: Users can train and integrate their own ONNX models to extend ChattyCommander's vocabulary and command recognition capabilities.
 
 ## Installation
 
 Quickstart
+
 - Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh
 - Create and sync env: uv python install 3.11 && uv sync
 - Run tests: uv run pytest -q
 - Run CLI: uv run chatty-commander --help
 - Run web server: uv run python main.py --web --no-auth
-
 
 1. **Prerequisites**: Ensure you have Python 3.11+ and `uv` installed for dependency management.
 2. **Clone the Repository**: `git clone https://github.com/your-repo/chatty-commander.git`
@@ -75,6 +82,7 @@ Quickstart
 ### Web UI with Authentication
 
 Start the web server with authentication enabled (default):
+
 ```bash
 uv run python main.py --web --port 8100
 ```
@@ -82,17 +90,20 @@ uv run python main.py --web --port 8100
 ### Development Mode (No Authentication)
 
 ⚠️ **Security Warning**: Only use `--no-auth` for local development. This mode:
+
 - Disables all authentication mechanisms
 - Allows unrestricted API access
 - Exposes OpenAPI documentation at `/docs`
 - Should **NEVER** be used in production or on public networks
 
 For local development only:
+
 ```bash
 uv run python main.py --web --no-auth --port 8100
 ```
 
 This enables:
+
 - Swagger UI at `http://localhost:8100/docs`
 - Unrestricted CORS from `http://localhost:3000` (for frontend development)
 - Direct API access without authentication tokens
@@ -177,6 +188,7 @@ The application uses a JSON-based configuration system with automatic default ge
 ### Default Configuration
 
 When no configuration is detected, the system automatically generates:
+
 - A comprehensive `config.json` with sample commands and settings
 - A `wakewords/` directory containing placeholder ONNX files
 - Model directories (`models-idle`, `models-computer`, `models-chatty`) with symlinks to wakeword files
@@ -191,20 +203,27 @@ When no configuration is detected, the system automatically generates:
 ChattyCommander can be configured dynamically using the CLI tool via the `chatty` command. This allows you to update `config.json` interactively or non-interactively.
 
 ### Interactive Mode
+
 Run:
+
 ```bash
 uv run chatty config
 ```
+
 Follow the prompts to set model-action mappings, state-model associations, and other settings.
 
 ### Non-Interactive Mode
+
 Update specific settings directly:
+
 ```bash
 uv run chatty config --model-action "okay_stop" "ctrl+shift+;"
 ```
+
 Use `uv run chatty config --help` for more options.
 
 Alternatively, edit `config.py` manually for static changes.
+
 - Model paths and state associations.
 - Actions for commands (e.g., keypresses or URLs).
 - Audio settings like sample rate.
@@ -215,14 +234,17 @@ Alternatively, edit `config.py` manually for static changes.
 {
   "advisors": {
     "enabled": true,
-    "llm_api_mode": "completion", 
+    "llm_api_mode": "completion",
     "model": "gpt-oss20b",
     "provider": { "base_url": "http://localhost:11434", "api_key": "" },
     "bridge": { "token": "secret" },
     "platforms": ["discord", "slack"],
     "personas": { "default": "philosophy_advisor" },
     "features": { "browser_analyst": true, "avatar_talkinghead": false },
-    "memory": { "persistence_enabled": true, "persistence_path": "data/advisors_memory.jsonl" }
+    "memory": {
+      "persistence_enabled": true,
+      "persistence_path": "data/advisors_memory.jsonl"
+    }
   }
 }
 ```
@@ -234,9 +256,6 @@ Alternatively, edit `config.py` manually for static changes.
 - Refer to logs for detailed error messages.
 
 Enjoy using ChattyCommander! If you have questions, feel free to open an issue.
-
-
-
 
 ## Avatar GUI and Settings
 
@@ -250,19 +269,12 @@ Enjoy using ChattyCommander! If you have questions, feel free to open an issue.
 
 Basic help:
 
-
-
 Start interactive REPL:
 
-
-
 Example session (stdin-driven):
-
-
 
 This flow is covered by automated tests: see [tests.test_repl_basic.test_repl_quick_session_executes_and_exits_cleanly():1].
 
 ## Contributing
 
 Contributions are welcome! For larger changes or new features, please start by opening an RFC issue using the provided template and follow the [RFC process](docs/RFC_PROCESS.md).
-

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,0 +1,44 @@
+# Adapter and Plugin System
+
+Adapters encapsulate mode‑specific input sources (text, web, GUI, etc.).
+They all implement the lightweight `InputAdapter` protocol and are
+managed by the `ModeOrchestrator`.
+
+```python
+class InputAdapter(Protocol):
+    name: str
+    def start(self) -> None: ...
+    def stop(self) -> None: ...
+```
+
+The orchestrator selects adapters based on CLI flags and starts each one,
+routing recognised commands to a shared `CommandExecutor`:
+
+```python
+orch = ModeOrchestrator(
+    config=config,
+    command_sink=executor,
+    flags=OrchestratorFlags(enable_text=True)
+)
+orch.start()
+```
+
+## Writing a custom adapter
+
+1. Subclass the protocol and implement `start`/`stop` plus any input loop.
+2. Pass a callback that dispatches recognised commands to the orchestrator.
+
+```python
+class MQTTAdapter:
+    name = "mqtt"
+    def __init__(self, on_command: Callable[[str], None]):
+        self._on_command = on_command
+    def start(self) -> None:
+        client.subscribe("commands/#")
+    def stop(self) -> None:
+        client.disconnect()
+```
+
+Enable it by appending an instance to `ModeOrchestrator.adapters` or by
+extending `select_adapters` in your fork. Adapters are intentionally
+simple so plugins can live in separate packages.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -19,6 +19,26 @@ All modes are unified by the `ModeOrchestrator` which selects and starts adapter
 - **Advisors**: `AdvisorsService` with context memory and tools (e.g., browser analyst); accessible via Web API and bridge.
 - **Bridge**: External Node.js integration for Discord/Slack; shared-secret auth, HTTP/WebSocket contract.
 
+## Module interactions and state transitions
+
+1. **Adapters** feed recognized text into the shared `CommandExecutor`.
+2. `StateManager.update_state()` reacts to wake words and toggles between `idle`, `computer`, and `chatty`.
+3. `ModelManager` activates the model list provided by `StateManager` for the new state.
+4. `CommandExecutor` performs the configured action for the command.
+
+### State transition map
+
+| Command                                       | New state             |
+| --------------------------------------------- | --------------------- |
+| `hey_chat_tee`                                | `chatty`              |
+| `hey_khum_puter`                              | `computer`            |
+| `okay_stop`, `thanks_chat_tee`, `that_ill_do` | `idle`                |
+| `toggle_mode`                                 | cycles through states |
+
+## Adapter architecture
+
+Adapters implement a tiny protocol (`start`/`stop` and a `name`) and are registered by the `ModeOrchestrator`. Custom adapters can live in separate packages and plug in without modifying core logic. This plugin model keeps mode-specific code isolated while sharing a common command sink and configuration.
+
 ## Solution design mitigations
 
 - **Single business logic path**: Commands flow into `CommandExecutor` from all modes to avoid duplication.
@@ -32,8 +52,8 @@ All modes are unified by the `ModeOrchestrator` which selects and starts adapter
 
 ## Data flow (high level)
 
-1) Input (voice/text/web/bridge) → Adapter → `StateManager` (optional) → `CommandExecutor` (actions)
-2) Advisors input (web/bridge) → `AdvisorsService` → tools/LLM → reply + memory → Web/bridge
+1. Input (voice/text/web/bridge) → Adapter → `StateManager` (optional) → `CommandExecutor` (actions)
+2. Advisors input (web/bridge) → `AdvisorsService` → tools/LLM → reply + memory → Web/bridge
 
 ## References
 
@@ -42,4 +62,3 @@ All modes are unified by the `ModeOrchestrator` which selects and starts adapter
 - `src/chatty_commander/advisors/` (service, memory)
 - `src/chatty_commander/app/{config,state_manager,model_manager,command_executor}.py`
 - `README.md`, `WEBUI_PLAN.md`, `WEBUI_IMPLEMENTATION.md`, `TODO.md`
-

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -1,0 +1,84 @@
+# Configuration Schema
+
+ChattyCommander now ships with a **typed configuration** defined in Python using dataclasses.
+The schema is loaded from `config.json` (or environment overrides) and validated on start up.
+Each field below lists its type and purpose.
+
+## Top‑level structure
+
+| Field               | Type                            | Description                                |
+| ------------------- | ------------------------------- | ------------------------------------------ |
+| `keybindings`       | `dict[str, str]`                | Named keyboard shortcuts used by commands. |
+| `commands`          | `dict[str, Command]`            | Mapping of command names to actions.       |
+| `command_sequences` | `dict[str, list[SequenceStep]]` | Ordered multi‑step commands.               |
+| `api_endpoints`     | `dict[str, str]`                | Base URLs used in URL actions.             |
+| `state_models`      | `dict[str, list[str]]`          | Commands/models active for each state.     |
+| `model_paths`       | `ModelPaths`                    | Directory locations for model files.       |
+| `audio_settings`    | `AudioSettings`                 | Recording configuration.                   |
+| `general_settings`  | `GeneralSettings`               | Application flags and defaults.            |
+
+### Command
+
+```python
+@dataclass
+class Command:
+    action: Literal["keypress", "url", "shell", "custom_message"]
+    keys: str | None = None
+    url: str | None = None
+    shell: str | None = None
+    message: str | None = None
+```
+
+### ModelPaths
+
+```python
+@dataclass
+class ModelPaths:
+    idle: str
+    computer: str
+    chatty: str
+```
+
+### AudioSettings
+
+```python
+@dataclass
+class AudioSettings:
+    mic_chunk_size: int = 1024
+    sample_rate: int = 16000
+    audio_format: str = "int16"
+```
+
+### GeneralSettings
+
+```python
+@dataclass
+class GeneralSettings:
+    debug_mode: bool = False
+    default_state: str = "idle"
+    inference_framework: Literal["onnx", "pytorch"] = "onnx"
+    start_on_boot: bool = False
+    check_for_updates: bool = True
+```
+
+## Adding a custom command
+
+1. Define a keybinding:
+   ```json
+   {
+     "keybindings": {
+       "mute": "ctrl+m"
+     }
+   }
+   ```
+2. Reference it in `commands`:
+   ```json
+   {
+     "commands": {
+       "mute_audio": { "action": "keypress", "keys": "mute" }
+     }
+   }
+   ```
+3. Add the command name to a state's `state_models` list so the model is loaded when active.
+
+This typed schema ensures configuration errors are caught early and provides IDE type hints for contributors.

--- a/docs/NEW_CONTRIBUTOR_GUIDE.md
+++ b/docs/NEW_CONTRIBUTOR_GUIDE.md
@@ -9,5 +9,9 @@ Welcome! This brief guide highlights a few places to explore when getting starte
 2. **Inspect `config.json`** in the repository root to learn how wake words, actions, and services are configured.
 3. **Explore `src/chatty_commander/web_mode.py`** to understand how the web interface and server are implemented.
 4. **Review the modules in `src/chatty_commander/advisors/`** to see how advisor behaviors and integrations are structured.
+5. **Read the docs** for architecture, configuration, and adapters:
+   - [Architecture Overview](ARCHITECTURE_OVERVIEW.md)
+   - [Configuration Schema](CONFIG_SCHEMA.md)
+   - [Adapter and Plugin System](ADAPTERS.md)
 
 Happy hacking!


### PR DESCRIPTION
## Summary
- document typed configuration schema and plugin adapters
- expand architecture overview with module interactions and state map
- link new docs from README and contributor guide

## Testing
- `pre-commit run --files README.md docs/NEW_CONTRIBUTOR_GUIDE.md docs/ARCHITECTURE_OVERVIEW.md docs/CONFIG_SCHEMA.md docs/ADAPTERS.md`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf6a918a0832c98954e8bd5490cef