### PR TITLE
Add tests for config schema, state transitions, orchestrator lifecycle, model hot reload, and web auth

### DIFF
--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,5 +1,6 @@
 import pytest
 
+from src.chatty_commander.config import Config
 from src.chatty_commander.state_manager import StateManager
 
 
@@ -36,3 +37,21 @@ class TestStateManager:
         sm = StateManager()
         sm.active_models = ["model1", "model2"]
         assert sm.get_active_models() == ["model1", "model2"]
+
+    def test_initial_state_respects_config(self, monkeypatch):
+        cfg = Config()
+        cfg.default_state = "computer"
+        cfg.state_models["computer"] = ["comp_model"]
+        monkeypatch.setattr("chatty_commander.app.state_manager.Config", lambda: cfg)
+        sm = StateManager()
+        assert sm.current_state == "computer"
+        assert sm.get_active_models() == ["comp_model"]
+
+    def test_dynamic_state_from_config(self, monkeypatch):
+        cfg = Config()
+        cfg.state_models["gaming"] = ["shoot"]
+        monkeypatch.setattr("chatty_commander.app.state_manager.Config", lambda: cfg)
+        sm = StateManager()
+        sm.change_state("gaming")
+        assert sm.current_state == "gaming"
+        assert sm.get_active_models() == ["shoot"]


### PR DESCRIPTION
## Summary
- validate configuration against OpenAPI schema
- test StateManager's config-driven defaults and dynamic states
- ensure ModeOrchestrator discovers adapters conditionally and manages lifecycle
- cover ModelManager hot-reload during async operation
- test authenticated bridge route requiring token

## Testing
- `uv run pytest tests/test_config.py tests/test_state_manager.py tests/test_orchestrator.py tests/test_model_manager.py tests/test_web_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf6a74a88832cb89243a18fc35eab