### PR TITLE
Consolidate model loading with diagnostic retries

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -13,7 +13,7 @@ All modes are unified by the `ModeOrchestrator` which selects and starts adapter
 
 - **Config**: Single source of truth for model paths, state models, commands, and advisor settings.
 - **StateManager**: Consistent state transitions across modes (idle/computer/chatty).
-- **ModelManager**: Loads and swaps active models per state.
+- **ModelManager**: Loads and swaps active models per state. Model loading uses a retry loop with detailed diagnostics and reports failures via `utils.logger.report_error` after repeated errors.
 - **CommandExecutor**: Executes keypress/URL/system actions; used by all modes.
 - **Web API**: Exposes status, config, state, command, advisors, and memory endpoints.
 - **Advisors**: `AdvisorsService` with context memory and tools (e.g., browser analyst); accessible via Web API and bridge.

--- a/src/chatty_commander/app/model_manager.py
+++ b/src/chatty_commander/app/model_manager.py
@@ -109,6 +109,34 @@ class ModelManager:
             return self.models['chat']
         return {}
 
+    def _load_model_with_retry(self, model_path: str) -> Model | None:
+        import traceback
+        from datetime import datetime
+
+        max_retries = 3
+        retries = 0
+        while True:
+            try:
+                ModelClass = _get_patchable_model_class()
+                return ModelClass(model_path)  # type: ignore[call-arg]
+            except Exception as e:  # pragma: no cover - diagnostics handled below
+                retries += 1
+                diagnostics = {
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                    "model_path": model_path,
+                    "exception": traceback.format_exc(),
+                    "retry": retries,
+                }
+                logging.error("Model loading failure: %s", diagnostics)
+                if retries > max_retries:
+                    try:
+                        from utils.logger import report_error
+
+                        report_error(e)
+                    except Exception as report_exc:
+                        logging.error("Error reporting failed: %s", report_exc)
+                    return None
+
     def load_model_set(self, path: str) -> dict[str, Model]:
         """
         Load all .onnx models from the given path.
@@ -139,16 +167,11 @@ class ModelManager:
                 logging.warning(f"Model file '{model_path}' does not exist. Skipping.")
                 continue
 
-            try:
-                # Use patchable class so tests replacing model_manager.Model with MagicMock are respected
-                ModelClass = _get_patchable_model_class()
-                instance = ModelClass(model_path)  # type: ignore[call-arg]
-                model_set[model_name] = instance  # only add on success
-                logging.info(f"Successfully loaded model '{model_name}' from '{model_path}'.")
-            except Exception as e:
-                logging.error(f"Failed to load model '{model_name}' from '{model_path}'. Error details: {e}. Continuing with other models.")
-                # do not add on failure
+            instance = self._load_model_with_retry(model_path)
+            if instance is None:
                 continue
+            model_set[model_name] = instance
+            logging.info(f"Successfully loaded model '{model_name}' from '{model_path}'.")
 
         return model_set
 
@@ -188,36 +211,3 @@ if __name__ == "__main__":
     config = Config()
     model_manager = ModelManager(config)
     print(model_manager)
-
-
-def load_model(model_path):
-    import logging
-    import traceback
-    from datetime import datetime
-
-    import onnx
-
-    max_retries = 3
-    retries = 0
-
-    while True:
-        try:
-            model = onnx.load(model_path)
-            return model
-        except Exception as e:
-            retries += 1
-            diagnostics = {
-                "timestamp": datetime.utcnow().isoformat() + "Z",
-                "model_path": model_path,
-                "exception": traceback.format_exc(),
-                "retry": retries,
-            }
-            logging.error("Model loading failure: %s", diagnostics)
-            if retries > max_retries:
-                try:
-                    from utils.logger import report_error
-
-                    report_error(e)
-                except Exception as report_exc:
-                    logging.error("Error reporting failed: %s", report_exc)
-                raise Exception("Max retries exceeded") from e

--- a/tests/test_model_loading_logging.py
+++ b/tests/test_model_loading_logging.py
@@ -1,29 +1,29 @@
 import logging
-
 import pytest
 
-from src.chatty_commander.model_manager import load_model
+from src.chatty_commander.model_manager import ModelManager
 
 
-# Dummy exception to simulate model load failure.
 class DummyError(Exception):
     pass
 
 
-# A fake onnx.load function that always fails.
-def fake_onnx_load_failure(model_path):
-    raise DummyError("Failed to load model")
+class FailingModel:
+    def __init__(self, path):  # pragma: no cover - simulated failure
+        raise DummyError("Failed to load model")
 
 
-# Test to simulate repeated failures and inspect logging diagnostics.
-def test_model_loading_logging_retry(monkeypatch, caplog):
-    try:
-        import onnx
-    except ImportError:
-        pytest.skip("onnx not available")
-
-    # Patch onnx.load to always raise an error.
-    monkeypatch.setattr(onnx, "load", fake_onnx_load_failure)
+def test_model_loading_logging_retry(monkeypatch, caplog, tmp_path):
+    # Patch model class to always fail.
+    monkeypatch.setattr(
+        "chatty_commander.app.model_manager._get_patchable_model_class",
+        lambda: FailingModel,
+    )
+    monkeypatch.setattr(
+        "src.chatty_commander.app.model_manager._get_patchable_model_class",
+        lambda: FailingModel,
+        raising=False,
+    )
 
     # Patch the centralized error-reporting function.
     error_reported = {"called": False}
@@ -33,18 +33,28 @@ def test_model_loading_logging_retry(monkeypatch, caplog):
 
     monkeypatch.setattr("utils.logger.report_error", fake_report_error)
 
+    # Prevent __init__ from preloading models.
+    monkeypatch.setattr(ModelManager, "reload_models", lambda *args, **kwargs: {})
+
+    model_file = tmp_path / "model.onnx"
+    model_file.write_text("dummy")
+
+    class Config:
+        def __init__(self):
+            self.general_models_path = str(tmp_path)
+            self.system_models_path = str(tmp_path)
+            self.chat_models_path = str(tmp_path)
+
+    mm = ModelManager(Config())
+
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(Exception) as exc_info:
-            load_model("path/to/model.onnx")
+        models = mm.load_model_set(str(tmp_path))
 
-        # Confirm that the exception message indicates max retries exceeded.
-        assert "Max retries exceeded" in str(exc_info.value)
+    assert models == {}
 
-    # Verify that detailed diagnostics were logged.
     logs = caplog.text
     assert "Failed to load model" in logs
-    assert "path/to/model.onnx" in logs
+    assert str(model_file) in logs
     assert "retry" in logs
 
-    # Verify that the error reporting function was called.
     assert error_reported["called"]


### PR DESCRIPTION
## Summary
- remove unused `load_model` helper
- add retry and diagnostic logging to `ModelManager.load_model_set`
- document unified loading logic in architecture docs
- update tests for consolidated model loading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bf6da5c70832ca526a130d0b00142