### PR TITLE
Add API key authentication to web mode and tests

### DIFF
--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -66,6 +66,19 @@ class Config:
         # Command sequences
         self.command_sequences = self.config_data.get("command_sequences", {})
 
+        # Authentication settings
+        auth_cfg = self.config_data.get("auth", {})
+        self.auth = {
+            "enabled": auth_cfg.get("enabled", False),
+            # Environment variable override for API key
+            "api_key": os.environ.get(
+                "CHATCOMM_API_KEY", auth_cfg.get("api_key", "")
+            ),
+            "allowed_origins": auth_cfg.get(
+                "allowed_origins", ["http://localhost:3000"]
+            ),
+        }
+
         # Advisors (OpenAI-Agents advisor) settings
         advisors_cfg = self.config_data.get("advisors", {})
         provider_cfg = advisors_cfg.get("provider", {})

--- a/tests/test_web_advisors_api.py
+++ b/tests/test_web_advisors_api.py
@@ -15,6 +15,7 @@ class DummyConfig(Config):
         self.system_models_path = "models-computer"
         self.chat_models_path = "models-chatty"
         self.config = {"model_actions": {}}
+        self.auth = {"enabled": True, "api_key": "secret", "allowed_origins": ["*"]}
         self.advisors = {
             "enabled": True,
             "providers": {
@@ -30,7 +31,7 @@ class DummyConfig(Config):
             }
         }
 
-def build_server(cfg):
+def build_server(cfg, *, no_auth: bool = True):
     with patch('chatty_commander.advisors.providers.build_provider_safe') as mock_build_provider:
         mock_provider = MagicMock()
         mock_provider.model = "test-model"
@@ -39,7 +40,7 @@ def build_server(cfg):
         sm = StateManager()
         mm = ModelManager(cfg)
         ce = CommandExecutor(cfg, mm, sm)
-        return WebModeServer(cfg, sm, mm, ce, no_auth=True)
+        return WebModeServer(cfg, sm, mm, ce, no_auth=no_auth)
 
 
 def test_advisors_message_endpoint_echo():
@@ -80,5 +81,30 @@ def test_advisors_message_endpoint_summarize():
     assert resp.status_code == 200
     data = resp.json()
     assert data["reply"] is not None
+
+
+def test_advisors_message_authentication():
+    cfg = DummyConfig()
+    server = build_server(cfg, no_auth=False)
+    client = TestClient(server.app)
+
+    payload = {
+        "platform": "discord",
+        "channel": "c1",
+        "user": "u1",
+        "text": "hello advisors",
+    }
+
+    # Missing API key should be unauthorized
+    resp = client.post("/api/v1/advisors/message", json=payload)
+    assert resp.status_code == 401
+
+    # Providing correct key should succeed
+    resp = client.post(
+        "/api/v1/advisors/message",
+        json=payload,
+        headers={"X-API-Key": cfg.auth["api_key"]},
+    )
+    assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Summary
- introduce configurable API key auth and CORS origins via config
- secure FastAPI routes and websocket connections with API key checks
- add tests for authorized/unauthorized access to web and advisors APIs

## Testing
- `pytest tests/test_web_mode.py tests/test_web_advisors_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689bf6a50484832cb664fb41d4e0141b