### PR TITLE
Add configurable state transition mapping

### DIFF
--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -42,6 +42,30 @@ class Config:
             },
         )
 
+        # State transitions (current_state -> command -> new_state)
+        self.state_transitions = self.config_data.get(
+            "state_transitions",
+            {
+                "idle": {
+                    "hey_chat_tee": "chatty",
+                    "hey_khum_puter": "computer",
+                    "toggle_mode": "computer",
+                },
+                "chatty": {
+                    "hey_khum_puter": "computer",
+                    "okay_stop": "idle",
+                    "thanks_chat_tee": "idle",
+                    "toggle_mode": "idle",
+                },
+                "computer": {
+                    "hey_chat_tee": "chatty",
+                    "okay_stop": "idle",
+                    "that_ill_do": "idle",
+                    "toggle_mode": "chatty",
+                },
+            },
+        )
+
         # Audio settings
         audio_settings = self.config_data.get("audio_settings", {})
         self.mic_chunk_size = audio_settings.get("mic_chunk_size", 1024)

--- a/src/chatty_commander/app/state_manager.py
+++ b/src/chatty_commander/app/state_manager.py
@@ -29,16 +29,8 @@ class StateManager:
         Returns the new state if a transition occurred, otherwise None.
         """
         new_state: str | None = None
-        if command == 'hey_chat_tee':
-            new_state = 'chatty'
-        elif command == 'hey_khum_puter':
-            new_state = 'computer'
-        elif command in ['okay_stop', 'thanks_chat_tee', 'that_ill_do']:
-            new_state = 'idle'
-        elif command == 'toggle_mode':
-            states = ['idle', 'computer', 'chatty']
-            current_index = states.index(self.current_state)
-            new_state = states[(current_index + 1) % len(states)]
+        state_transitions = self.config.state_transitions.get(self.current_state, {})
+        new_state = state_transitions.get(command)
 
         if new_state and new_state != self.current_state:
             self.change_state(new_state)

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -36,3 +36,10 @@ class TestStateManager:
         sm = StateManager()
         sm.active_models = ["model1", "model2"]
         assert sm.get_active_models() == ["model1", "model2"]
+
+    def test_update_state_with_custom_mapping(self):
+        sm = StateManager()
+        sm.config.state_transitions = {"idle": {"go": "chatty"}, "chatty": {}}
+        assert sm.update_state("go") == "chatty"
+        assert sm.current_state == "chatty"
+        assert sm.update_state("go") is None


### PR DESCRIPTION
## Summary
- add `state_transitions` mapping to configuration for command-driven state changes
- refactor `StateManager.update_state` to use configurable transitions
- test configurable transition table and update existing state tests

## Testing
- `uv run ruff check src/chatty_commander/app/config.py src/chatty_commander/app/state_manager.py tests/test_state_manager.py tests/test_states.py`
- `uv run pytest tests/test_state_manager.py tests/test_states.py`


------
https://chatgpt.com/codex/tasks/task_e_689bf69fc4f8832ca8d6f331691303ab