### PR TITLE
docs: update avatar path comment

### DIFF
--- a/src/chatty_commander/avatars/avatar_gui.py
+++ b/src/chatty_commander/avatars/avatar_gui.py
@@ -32,10 +32,10 @@ except Exception:  # pragma: no cover
 
 
 def _avatar_index_path() -> Path:
-    # File location: src/chatty_commander/gui/avatar_gui.py
+    # File location: src/chatty_commander/avatars/avatar_gui.py
     # We want:      src/chatty_commander/webui/avatar/index.html
     here = Path(__file__).resolve()
-    root = here.parent.parent  # up from gui/ to chatty_commander/
+    root = here.parent.parent  # up from avatars/ to chatty_commander/
     return root / "webui" / "avatar" / "index.html"
 
 


### PR DESCRIPTION
## Summary
- fix comment in `_avatar_index_path` to reference current avatar GUI file path

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689bf6f1e7b8832ca08a5dca7318016d