### PR TITLE
fix idle animation hint spelling

### DIFF
--- a/src/chatty_commander/web/routes/avatar_api.py
+++ b/src/chatty_commander/web/routes/avatar_api.py
@@ -30,7 +30,7 @@ _CATEGORY_HINTS = {
     "error": ["error", "fail", "oops"],
     "handoff": ["handoff", "swap", "switch"],
     "processing": ["process", "work", "load", "busy"],
-    "idle": ["idle", "rest", "breath", "calm"],
+    "idle": ["idle", "rest", "breathe", "calm"],
 }
 
 


### PR DESCRIPTION
## Summary
- fix 'breath' to 'breathe' in idle avatar animation hints

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf6ef4584832c861808dbd9d895c9