### PR TITLE
chore: drop command executor shims

### DIFF
--- a/src/chatty_commander/app/command_executor.py
+++ b/src/chatty_commander/app/command_executor.py
@@ -32,20 +32,7 @@ try:
 except (ImportError, OSError, KeyError):
     pyautogui = None  # type: ignore[assignment]
 
-# Bridge to root-level shim so tests can patch command_executor.pyautogui/requests
-try:  # pragma: no cover
-    from command_executor import pyautogui as _shim_pg  # type: ignore
-except Exception:
-    _shim_pg = None  # type: ignore
-if _shim_pg is not None:
-    pyautogui = _shim_pg  # type: ignore
-
-try:  # pragma: no cover
-    from command_executor import requests as _shim_requests  # type: ignore
-except Exception:
-    _shim_requests = None  # type: ignore
-if _shim_requests is not None:
-    requests = _shim_requests  # type: ignore
+# Tests patch via the canonical import path; no root-level shims needed.
 
 
 class CommandExecutor:
@@ -122,16 +109,11 @@ class CommandExecutor:
         elif 'shell' in command_action:
             try:
                 cmd = command_action.get('shell', '')
-                result = subprocess.run(
-                    cmd,
-                    shell=True,
-                    text=True,
-                    capture_output=True
-                )
+                result = subprocess.run(cmd, shell=True, text=True, capture_output=True)
                 if result.returncode == 0:
                     # Ensure tests can detect success in caplog
-                    logger.warning("shell ok")
-                    logger.info(f"Completed execution of command: {command_name}")
+                    logging.warning("shell ok")
+                    logging.getLogger().info(f"Completed execution of command: {command_name}")
                     success = True
                 else:
                     logger.error(f"shell exit {result.returncode}")
@@ -178,10 +160,12 @@ class CommandExecutor:
         """
         Executes a keybinding action using pyautogui to simulate keyboard shortcuts.
 
-        Tests patch 'command_executor.pyautogui' (root-level shim). We must fetch the
-        patched object via _get_pyautogui() instead of relying on a static import.
+        Tests patch this module's ``pyautogui`` via the canonical import path.
+        We fetch the possibly patched object through ``_get_pyautogui()`` instead
+        of relying on a static import.
         """
-        # Special-case early return when pyautogui is explicitly None (tests patch command_executor.pyautogui)
+        # Special-case early return when pyautogui is explicitly None (tests patch
+        # chatty_commander.app.command_executor.pyautogui)
         if _get_pyautogui() is None:
             # Emit exactly the messages tests assert, using root-level logging functions so patch('logging.critical') catches them
             logging.error("pyautogui is not installed")
@@ -294,38 +278,36 @@ class CommandExecutor:
 
 
 def _get_pyautogui():
-    # Prefer root-level shim attribute so tests can patch command_executor.pyautogui
-    try:
-        import importlib
-        _shim_ce = importlib.import_module("command_executor")
-        pg = getattr(_shim_ce, "pyautogui", None)
-        if pg is not None:
-            return pg
-    except Exception:
-        pass
-    # Fall back to local module variable first (may have been overridden by earlier bridge)
+    """Return pyautogui or ``None`` if unavailable.
+
+    Tests may patch ``chatty_commander.app.command_executor.pyautogui``; this
+    helper returns whatever object is currently assigned.
+    """
     try:
         return pyautogui  # type: ignore[name-defined]
     except Exception:
         pass
-    # Finally, try importing real library
     try:
         import pyautogui as _real_pg  # type: ignore
+
         return _real_pg
     except Exception:
         return None
 
+
 def _get_requests():
+    """Return the requests module or ``None`` if unavailable.
+
+    Tests may patch ``chatty_commander.app.command_executor.requests``; this
+    helper retrieves the patched module when present.
+    """
     try:
-        import importlib
-        _shim_ce = importlib.import_module("command_executor")
-        rq = getattr(_shim_ce, "requests", None)
-        if rq is not None:
-            return rq
+        return requests  # type: ignore[name-defined]
     except Exception:
         pass
     try:
         import requests as _real_requests  # type: ignore
+
         return _real_requests
     except Exception:
         return None


### PR DESCRIPTION
## Summary
- remove root-level shim usage from command executor
- adjust shell logging to use root logger warning
- simplify `_get_pyautogui`/`_get_requests` helpers for canonical import patching

## Testing
- `pre-commit run --files src/chatty_commander/app/command_executor.py`


------
https://chatgpt.com/codex/tasks/task_e_689c0543e344832cb9784a8b58f83f22