### PR TITLE
Expose CommandExecutor in app package

### DIFF
--- a/src/chatty_commander/app/__init__.py
+++ b/src/chatty_commander/app/__init__.py
@@ -1,0 +1,3 @@
+from .command_executor import CommandExecutor
+
+__all__ = ["CommandExecutor"]


### PR DESCRIPTION
## Summary
- re-add __init__ for app package to expose CommandExecutor

## Testing
- `PYTHONPATH=src python - <<'PY'
from chatty_commander.app import CommandExecutor
print(CommandExecutor)
PY`
- `pre-commit run --files src/chatty_commander/app/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_689c06e2c148832cace78b6beb186cf8