### PR TITLE
refactor: simplify main shim

### DIFF
--- a/src/chatty_commander/main_shim.py
+++ b/src/chatty_commander/main_shim.py
@@ -1,15 +1,14 @@
-"""Package shim to expose root-level main module under chatty_commander.main.
+"""Compatibility shim re-exporting :mod:`chatty_commander.main`.
 
-This allows tests to import chatty_commander.main even when running from repo root.
+Historically this module loaded a top-level ``main`` using ``importlib`` so
+tests could import ``chatty_commander.main`` from the repository root. Now that
+``main`` lives inside the package, we simply import it directly and expose the
+relevant functions for any lingering imports of :mod:`chatty_commander.main_shim`.
 """
 
 from __future__ import annotations
 
-import importlib
-
-_root_main = importlib.import_module("main")
+from chatty_commander import main as _root_main
 
 create_parser = _root_main.create_parser
 run_orchestrator_mode = _root_main.run_orchestrator_mode
-
-


### PR DESCRIPTION
## Summary
- refactor `main_shim` to import `chatty_commander.main` directly and clean up the shim's purpose

## Testing
- `pre-commit run --files src/chatty_commander/main_shim.py`
- `pytest` *(fails: 18 errors during collection)*
- `pytest tests/test_main_orchestrator_run.py`


------
https://chatgpt.com/codex/tasks/task_e_689c0fbb51fc832c8471f5d23cd93060