### PR TITLE
Add config wizard entrypoint for CLI and main

### DIFF
--- a/src/chatty_commander/config_cli.py
+++ b/src/chatty_commander/config_cli.py
@@ -121,6 +121,25 @@ class ConfigCLI:
             if continue_input.lower() != "y":
                 break
 
+    # ------------------------------------------------------------------
+    # Public entrypoints
+
+    def run_wizard(self) -> int:
+        """Launch the guided configuration wizard.
+
+        The current implementation simply delegates to :meth:`interactive_mode`
+        which provides a minimal interactive prompt used throughout the test
+        suite.  Returning an integer exit code mirrors the expectations of
+        callers such as :mod:`main` and :mod:`cli` which treat a ``0`` return
+        value as success.
+
+        Returns:
+            int: ``0`` on success.
+        """
+
+        self.interactive_mode()
+        return 0
+
 
 __all__ = ["ConfigCLI"]
 

--- a/tests/test_main_config_wizard.py
+++ b/tests/test_main_config_wizard.py
@@ -1,0 +1,20 @@
+import sys
+from unittest.mock import patch
+
+from src.chatty_commander import main
+
+
+def test_main_config_wizard(monkeypatch):
+    """Ensure that invoking main with --config triggers ConfigCLI.run_wizard."""
+    monkeypatch.setattr(sys, 'argv', ['main.py', '--config'])
+    with patch('config_cli.ConfigCLI.__init__', return_value=None), \
+         patch('config_cli.ConfigCLI.run_wizard') as mock_wizard, \
+         patch('src.chatty_commander.main.Config'), \
+         patch('src.chatty_commander.main.ModelManager'), \
+         patch('src.chatty_commander.main.StateManager'), \
+         patch('src.chatty_commander.main.CommandExecutor'), \
+         patch('src.chatty_commander.main.setup_logger'), \
+         patch('src.chatty_commander.main.generate_default_config_if_needed', return_value=False):
+        result = main.main()
+        assert result == 0
+        mock_wizard.assert_called_once()


### PR DESCRIPTION
## Summary
- implement `ConfigCLI.run_wizard` that launches the interactive configuration flow and returns a success exit code
- add regression test ensuring `main --config` dispatches to the new wizard

## Testing
- `pytest tests/test_cli.py::test_cli_config_wizard tests/test_main_config_wizard.py -q`
- `pytest -q` *(fails: SyntaxError in tests/test_orchestrator.py)*

------
https://chatgpt.com/codex/tasks/task_e_689c0fb8f9bc832c8d1b988c7c48d56a