### PR TITLE
Add state_manager alias to compatibility layer

### DIFF
--- a/src/chatty_commander/compat.py
+++ b/src/chatty_commander/compat.py
@@ -16,6 +16,7 @@ from types import ModuleType
 ALIASES: dict[str, str] = {
     "config": "chatty_commander.app.config",
     "model_manager": "chatty_commander.app.model_manager",
+    "state_manager": "chatty_commander.app.state_manager",
     "web_mode": "chatty_commander.web.web_mode",
 }
 


### PR DESCRIPTION
## Summary
- add state_manager mapping to compat.ALIASES so legacy imports resolve to chatty_commander.app.state_manager

## Testing
- `python - <<'PY'
import sys
sys.path.append('src')
from chatty_commander import compat
compat.load('state_manager')
print('loaded')
PY`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_689c123f8564832cab1e271b5f49be40