### PR TITLE
refactor: use f-strings for dialog geometry

### DIFF
--- a/src/chatty_commander/gui.py
+++ b/src/chatty_commander/gui.py
@@ -870,7 +870,7 @@ class CommandDialog:
         self.dialog.grab_set()
 
         # Center the dialog
-        self.dialog.geometry("+%d+%d" % (parent.winfo_rootx() + 50, parent.winfo_rooty() + 50))
+        self.dialog.geometry(f"+{parent.winfo_rootx() + 50}+{parent.winfo_rooty() + 50}")
 
         # Name field
         ttk.Label(self.dialog, text="Command Name:").pack(pady=5)
@@ -924,7 +924,7 @@ class StateModelsDialog:
         self.dialog.grab_set()
 
         # Center the dialog
-        self.dialog.geometry("+%d+%d" % (parent.winfo_rootx() + 50, parent.winfo_rooty() + 50))
+        self.dialog.geometry(f"+{parent.winfo_rootx() + 50}+{parent.winfo_rooty() + 50}")
 
         # Create interface for each state
         self.model_vars = {}
@@ -978,9 +978,7 @@ def main():
             "Error: GUI cannot be started because no display is available. Running in headless environment."
         )
         return
-    ChattyCommanderGUI(
-        root
-    )
+    ChattyCommanderGUI(root)
     root.mainloop()
 
 


### PR DESCRIPTION
## Summary
- replace percent-formatting with f-strings when centering dialogs

## Testing
- `uv run --frozen ruff format src/chatty_commander/gui.py`
- `uv run --frozen ruff check --no-fix .` *(fails: Found 100 errors)*
- `uv run --frozen pytest` *(fails: ImportError, SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_689c05282970832c950d1fd2187becc1