### PR TITLE
style: address linter warnings

### DIFF
--- a/src/chatty_commander/advisors/service.py
+++ b/src/chatty_commander/advisors/service.py
@@ -1,15 +1,13 @@
-"""
-Advisor service for handling AI advisor interactions.
-"""
+"""Advisor service for handling AI advisor interactions."""
 
 from dataclasses import dataclass
 from typing import Any
 
+from ..avatars.thinking_state import get_thinking_manager
 from .context import ContextManager, PlatformType
 from .memory import MemoryStore
 from .prompting import Persona, build_provider_prompt
 from .providers import build_provider_safe
-from ..avatars.thinking_state import get_thinking_manager, ThinkingState
 
 
 @dataclass
@@ -60,14 +58,13 @@ class AdvisorsService:
         self.enabled = base_cfg.get('enabled', False)
 
     def handle_message(self, message: AdvisorMessage) -> AdvisorReply:
-        """
-        Process an incoming message and return advisor response.
+        """Process an incoming message and return an advisor response.
 
         Args:
-            message: The incoming message to process
+            message: The incoming message to process.
 
         Returns:
-            AdvisorReply with response and metadata
+            AdvisorReply with response and metadata.
         """
         if not self.enabled:
             raise RuntimeError("Advisors are not enabled")

--- a/src/chatty_commander/app/state_manager.py
+++ b/src/chatty_commander/app/state_manager.py
@@ -1,10 +1,8 @@
-"""
-state_manager.py
+"""Manage application state transitions.
 
-Manages the state transitions and active model sets for the ChattyCommander application.
-This module helps in toggling between different operational states based on detected commands
-and manages the corresponding model activations. Enhanced to support dynamic state updates
-and more complex state dependencies.
+This module toggles between different operational states based on detected
+commands and manages the corresponding model activations. It supports dynamic
+state updates and complex state dependencies.
 """
 
 import logging
@@ -24,9 +22,9 @@ class StateManager:
         self.logger.info(f"StateManager initialized with state: {self.current_state}")
 
     def update_state(self, command: str) -> str | None:
-        """
-        Updates the state based on the detected command.
-        Returns the new state if a transition occurred, otherwise None.
+        """Update state based on a command.
+
+        Returns the new state if a transition occurred, otherwise ``None``.
         """
         new_state: str | None = None
         state_transitions = self.config.state_transitions.get(self.current_state, {})

--- a/src/chatty_commander/config_cli.py
+++ b/src/chatty_commander/config_cli.py
@@ -14,7 +14,6 @@ import sys
 
 from chatty_commander.app.config import Config
 
-
 XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 APP_CONFIG_DIR = os.path.join(XDG_CONFIG_HOME, "chatty-commander")
 DEFAULT_CONFIG_PATH = os.path.join(APP_CONFIG_DIR, "config.json")

--- a/src/chatty_commander/gui.py
+++ b/src/chatty_commander/gui.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""
-ChattyCommander Desktop GUI
+"""ChattyCommander desktop GUI.
 
-A desktop application for configuring and managing ChattyCommander.
-Provides a user-friendly interface for setting up commands, states, and models.
+A desktop application for configuring and managing ChattyCommander. Provides a
+user-friendly interface for setting up commands, states, and models.
 """
 
 import json
@@ -870,7 +869,9 @@ class CommandDialog:
         self.dialog.grab_set()
 
         # Center the dialog
-        self.dialog.geometry("+%d+%d" % (parent.winfo_rootx() + 50, parent.winfo_rooty() + 50))
+        self.dialog.geometry(
+            f"+{parent.winfo_rootx() + 50}+{parent.winfo_rooty() + 50}"
+        )
 
         # Name field
         ttk.Label(self.dialog, text="Command Name:").pack(pady=5)
@@ -924,7 +925,9 @@ class StateModelsDialog:
         self.dialog.grab_set()
 
         # Center the dialog
-        self.dialog.geometry("+%d+%d" % (parent.winfo_rootx() + 50, parent.winfo_rooty() + 50))
+        self.dialog.geometry(
+            f"+{parent.winfo_rootx() + 50}+{parent.winfo_rooty() + 50}"
+        )
 
         # Create interface for each state
         self.model_vars = {}

--- a/src/chatty_commander/main.py
+++ b/src/chatty_commander/main.py
@@ -1,16 +1,7 @@
-"""
-main.py
+"""Entry point for the ChattyCommander application.
 
-This module serves as the entry point for the ChattyCommander application. It coordinates the
-loading of machine learning models, manages state transitions based on voice commands, and
-handles the execution of commands.
-
-Usage:
-    Run the script from the command line to start the voice-activated command processing system.
-    Ensure that all dependencies are installed and models are correctly placed in their respective directories.
-
-Example:
-    python main.py
+This module coordinates model loading, manages state transitions based on
+voice commands, and handles the execution of commands.
 """
 
 import argparse
@@ -28,18 +19,20 @@ _root_src = _os.path.abspath(_os.path.join(_pkg_dir, ".."))
 if _root_src not in _sys.path:
     _sys.path.insert(0, _root_src)
 
-from chatty_commander.app.command_executor import CommandExecutor  # type: ignore
-from chatty_commander.app.model_manager import ModelManager  # type: ignore
-from chatty_commander.app.orchestrator import (  # type: ignore
+from chatty_commander.app.command_executor import (  # noqa: E402, type: ignore
+    CommandExecutor,
+)
+from chatty_commander.app.config import Config  # noqa: E402, type: ignore
+from chatty_commander.app.default_config import (  # noqa: E402, type: ignore
+    generate_default_config_if_needed,
+)
+from chatty_commander.app.model_manager import ModelManager  # noqa: E402, type: ignore
+from chatty_commander.app.orchestrator import (  # noqa: E402, type: ignore
     ModeOrchestrator,
     OrchestratorFlags,
 )
-from chatty_commander.app.state_manager import StateManager  # type: ignore
-from chatty_commander.app.config import Config  # type: ignore
-from chatty_commander.app.default_config import (  # type: ignore
-    generate_default_config_if_needed,
-)
-from chatty_commander.utils.logger import setup_logger  # type: ignore
+from chatty_commander.app.state_manager import StateManager  # noqa: E402, type: ignore
+from chatty_commander.utils.logger import setup_logger  # noqa: E402, type: ignore
 
 
 def run_cli_mode(config, model_manager, state_manager, command_executor, logger):

--- a/src/chatty_commander/web/server.py
+++ b/src/chatty_commander/web/server.py
@@ -89,8 +89,8 @@ def create_app(
         logger.warning("Failed to include websocket routes; falling back to legacy-only: %s", e)
 
     # Avatar routes
-    from .routes.avatar_ws import router as avatar_ws_router
     from .routes.avatar_api import router as avatar_api_router
+    from .routes.avatar_ws import router as avatar_ws_router
     # Lifecycle hooks (no-op by default to preserve behavior)
     try:
         register_lifecycle(
@@ -118,7 +118,7 @@ def create_app(
                 avatar = gui.get("avatar", {}) if isinstance(gui, dict) else {}
                 mapping = avatar.get("persona_theme_map", {}) if isinstance(avatar, dict) else {}
                 return mapping.get(persona_id, mapping.get("default", "default"))
-            setattr(_avatar_ws_mod.manager, "theme_resolver", _resolve_theme)
+            _avatar_ws_mod.manager.theme_resolver = _resolve_theme
             logger.debug("server.create_app: set WS theme_resolver from config")
         except Exception as e:
             logger.debug("server.create_app: theme_resolver not set: %s", e)
@@ -128,8 +128,8 @@ def create_app(
 
     # Avatar settings routes
     try:
-        from .routes.avatar_settings import include_avatar_settings_routes
         from .routes.avatar_selector import router as avatar_selector_router
+        from .routes.avatar_settings import include_avatar_settings_routes
         settings_router = include_avatar_settings_routes(get_config_manager=lambda: legacy.config_manager)
         app.include_router(settings_router)
         app.include_router(avatar_selector_router)

--- a/tests/test_avatar_api.py
+++ b/tests/test_avatar_api.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
-from fastapi.testclient import TestClient
-
-from fastapi import FastAPI
 from chatty_commander.web.routes.avatar_api import router as avatar_router
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 def test_list_animations_endpoint(tmp_path: Path):

--- a/tests/test_avatar_selector.py
+++ b/tests/test_avatar_selector.py
@@ -1,7 +1,6 @@
+from chatty_commander.web.routes.avatar_selector import router as selector_router
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from chatty_commander.web.routes.avatar_selector import router as selector_router
 
 
 def test_animation_selector_basic():

--- a/tests/test_avatar_settings.py
+++ b/tests/test_avatar_settings.py
@@ -1,7 +1,6 @@
+from chatty_commander.web.routes.avatar_settings import include_avatar_settings_routes
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from chatty_commander.web.routes.avatar_settings import include_avatar_settings_routes
 
 
 class StubCfg:

--- a/tests/test_avatar_ws.py
+++ b/tests/test_avatar_ws.py
@@ -1,10 +1,10 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 import json
 import time
 
-from chatty_commander.web.routes.avatar_ws import router as avatar_ws_router
 from chatty_commander.avatars.thinking_state import get_thinking_manager, reset_thinking_manager
+from chatty_commander.web.routes.avatar_ws import router as avatar_ws_router
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 def test_avatar_ws_broadcasts_state_changes():

--- a/tests/test_avatar_ws_theme.py
+++ b/tests/test_avatar_ws_theme.py
@@ -1,9 +1,10 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 import json
 
-from chatty_commander.web.routes.avatar_ws import router as avatar_ws_router, manager
 from chatty_commander.avatars.thinking_state import get_thinking_manager, reset_thinking_manager
+from chatty_commander.web.routes.avatar_ws import manager
+from chatty_commander.web.routes.avatar_ws import router as avatar_ws_router
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 def test_avatar_ws_includes_theme_in_snapshot():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,6 +7,7 @@ from chatty_commander.app.config import Config
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 
+
 @pytest.fixture
 def config():
     """Setup the CommandExecutor with a mock configuration for testing."""

--- a/tests/test_config_permutations.py
+++ b/tests/test_config_permutations.py
@@ -1,7 +1,6 @@
 from itertools import product
 
 import pytest
-
 from chatty_commander.app.config import Config
 
 

--- a/tests/test_integration_voice.py
+++ b/tests/test_integration_voice.py
@@ -1,10 +1,9 @@
 from unittest.mock import patch
 
 import pytest
+from chatty_commander.app.config import Config
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
-
-from chatty_commander.app.config import Config
 
 
 @pytest.fixture

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,8 +8,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.config import Config
+from chatty_commander.app.model_manager import ModelManager
 
 
 class TestModelLoading(unittest.TestCase):

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -6,9 +6,8 @@ import logging
 import unittest
 from unittest.mock import MagicMock
 
-from chatty_commander.app.state_manager import StateManager
-
 from chatty_commander.app.config import Config
+from chatty_commander.app.state_manager import StateManager
 
 
 class TestStateManager(unittest.TestCase):

--- a/tests/test_thinking_state.py
+++ b/tests/test_thinking_state.py
@@ -1,7 +1,7 @@
 from chatty_commander.avatars.thinking_state import (
+    ThinkingState,
     get_thinking_manager,
     reset_thinking_manager,
-    ThinkingState,
 )
 
 

--- a/tests/test_web_mode.py
+++ b/tests/test_web_mode.py
@@ -9,15 +9,13 @@ Tests FastAPI endpoints, WebSocket connections, and frontend integration.
 import asyncio
 import json
 import logging
-
-import requests
-import websockets
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
-
+import requests
+import websockets
 from config import Config
+from fastapi.testclient import TestClient
 from web_mode import WebModeServer
 
 # Configure logging


### PR DESCRIPTION
## Summary
- clean up config dataclass imports and typing
- document advisor service and state manager modules
- improve CLI entrypoint and GUI dialog formatting

## Testing
- `uv run ruff check .`
- `uv run black --check .` *(fails: would reformat multiple files)*
- `uv run pydocstyle src` *(fails: numerous docstring style violations in untouched modules)*
- `uv run doc8 README.md docs`


------
https://chatgpt.com/codex/tasks/task_e_689c155b7a74832cbb4803f9b578aa87