### PR TITLE
feat: scaffold chatty commander app

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chatty Commander</title>
+  </head>
+  <body class="bg-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "chatty-commander-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.0",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/app/src/app-shell/Grid.tsx
+++ b/app/src/app-shell/Grid.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode[];
+}
+
+export default function GridLayout({ children }: Props) {
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      <div className="w-90 border-r border-gray-700 overflow-y-auto" aria-label="Chat">
+        {children[0]}
+      </div>
+      <div className="flex-1 flex flex-col" aria-label="Canvas">
+        {children[1]}
+      </div>
+      <div className="w-130 border-l border-gray-700 overflow-y-auto" aria-label="Review">
+        {children[2]}
+      </div>
+    </div>
+  );
+}

--- a/app/src/app-shell/TopBar.tsx
+++ b/app/src/app-shell/TopBar.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function TopBar() {
+  return (
+    <header className="flex items-center px-4 py-2 border-b border-gray-700">
+      <h1 className="flex-1 text-lg font-semibold">Chatty Commander</h1>
+      <div className="space-x-2">
+        <button aria-label="Run" className="px-2 py-1 bg-gray-800 rounded">▶</button>
+        <button aria-label="Stop" className="px-2 py-1 bg-gray-800 rounded">■</button>
+      </div>
+    </header>
+  );
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TopBar from './app-shell/TopBar';
+import GridLayout from './app-shell/Grid';
+import ChatPane from './panes/ChatPane';
+import CanvasPane from './panes/CanvasPane';
+import SidecarPane from './panes/SidecarPane';
+import './styles/index.css';
+
+function App() {
+  return (
+    <div className="h-screen flex flex-col bg-gray-900 text-gray-100">
+      <TopBar />
+      <GridLayout>
+        <ChatPane />
+        <CanvasPane />
+        <SidecarPane />
+      </GridLayout>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,0 +1,18 @@
+import React, { useRef } from 'react';
+
+export default function CanvasPane() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  return (
+    <section className="flex-1 flex flex-col">
+      <iframe
+        ref={iframeRef}
+        title="canvas"
+        sandbox="allow-scripts allow-downloads"
+        className="flex-1 bg-white"
+      />
+      <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
+        Console output...
+      </div>
+    </section>
+  );
+}

--- a/app/src/panes/ChatPane.tsx
+++ b/app/src/panes/ChatPane.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ChatPane() {
+  return (
+    <section className="h-full flex flex-col">
+      <div className="flex-1 overflow-auto p-2">Chat messages will appear here.</div>
+      <textarea className="p-2 bg-gray-800" placeholder="Type a message" />
+    </section>
+  );
+}

--- a/app/src/panes/SidecarPane.tsx
+++ b/app/src/panes/SidecarPane.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function SidecarPane() {
+  return (
+    <section className="h-full p-2">
+      <h2 className="font-semibold mb-2">Sidecar</h2>
+      <div>Open files and notes will appear here.</div>
+    </section>
+  );
+}

--- a/app/src/stores/canvas.ts
+++ b/app/src/stores/canvas.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface CanvasStore {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  asciiOnly: boolean;
+  logs: string[];
+  setStatus: (s: CanvasStore['status']) => void;
+  setAscii: (flag: boolean) => void;
+  addLog: (line: string) => void;
+  clearLogs: () => void;
+}
+
+export const useCanvasStore = create<CanvasStore>(set => ({
+  status: 'idle',
+  asciiOnly: false,
+  logs: [],
+  setStatus: status => set({ status }),
+  setAscii: asciiOnly => set({ asciiOnly }),
+  addLog: line => set(s => ({ logs: [...s.logs, line].slice(-2000) })),
+  clearLogs: () => set({ logs: [] }),
+}));

--- a/app/src/stores/chat.ts
+++ b/app/src/stores/chat.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+export type Role = 'user' | 'assistant' | 'system' | 'tool';
+
+export interface ChatMessage {
+  id: string;
+  role: Role;
+  createdAt: string;
+  content: any[];
+  contextRef?: { pane: 'sidecar' | 'canvas'; refId?: string };
+  meta?: Record<string, any>;
+}
+
+interface ChatStore {
+  messages: ChatMessage[];
+  push: (m: ChatMessage) => void;
+}
+
+export const useChatStore = create<ChatStore>(set => ({
+  messages: [],
+  push: m => set(s => ({ messages: [...s.messages, m] })),
+}));

--- a/app/src/stores/session.ts
+++ b/app/src/stores/session.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
+
+interface SessionStore {
+  id: string;
+  user?: { id?: string; name?: string };
+  flags: { ws?: boolean };
+}
+
+export const useSessionStore = create<SessionStore>(() => ({
+  id: uuidv4(),
+  user: undefined,
+  flags: {},
+}));

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface SettingsStore {
+  theme: 'dark';
+  reducedMotion: boolean;
+  telemetryOptIn: boolean;
+}
+
+export const useSettingsStore = create<SettingsStore>(() => ({
+  theme: 'dark',
+  reducedMotion: false,
+  telemetryOptIn: false,
+}));

--- a/app/src/stores/sidecar.ts
+++ b/app/src/stores/sidecar.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+interface SidecarItem {
+  refId: string;
+  title: string;
+  kind: 'code' | 'tests' | 'diff' | 'notes';
+  contentUrl?: string;
+  snippet?: string;
+}
+
+interface SidecarStore {
+  open: boolean;
+  current?: SidecarItem;
+  set: (item: SidecarItem) => void;
+  close: () => void;
+}
+
+export const useSidecarStore = create<SidecarStore>(set => ({
+  open: false,
+  current: undefined,
+  set: item => set({ open: true, current: item }),
+  close: () => set({ open: false, current: undefined }),
+}));

--- a/app/src/styles/index.css
+++ b/app/src/styles/index.css
@@ -1,0 +1,5 @@
+/* Placeholder for Tailwind directives */
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "ESNext"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "chatty-commander-monorepo",
+  "private": true,
+  "scripts": {
+    "dev:all": "pnpm --filter app dev & pnpm --filter server dev",
+    "build:all": "pnpm --filter app build && pnpm --filter server build",
+    "test": "pnpm --filter ./tests test"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - 'app'
+  - 'server'
+  - 'workers'
+  - 'tests'

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import cors from 'cors';
+import chat from './routes/chat.js';
+import canvas from './routes/canvas.js';
+import consoleRoute from './routes/console.js';
+import sidecar from './routes/sidecar.js';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/chat', chat);
+app.use('/api/canvas', canvas);
+app.use('/api/console', consoleRoute);
+app.use('/api/sidecar', sidecar);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`server on ${port}`));

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function auth(req: Request, res: Response, next: NextFunction) {
+  // placeholder auth
+  next();
+}

--- a/server/middleware/cors.ts
+++ b/server/middleware/cors.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function corsHeaders(req: Request, res: Response, next: NextFunction) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  next();
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "chatty-commander-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev index.ts",
+    "build": "tsc",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node-dev": "^2.0.0"
+  }
+}

--- a/server/routes/canvas.ts
+++ b/server/routes/canvas.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/build', (req, res) => {
+  res.json({ bundleUrl: '', version: '0.0.0', sha256: '' });
+});
+
+export default router;

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.write('event: done\n');
+  res.write('data: {}\n\n');
+  res.end();
+});
+
+export default router;

--- a/server/routes/console.ts
+++ b/server/routes/console.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.write('event: line\n');
+  res.write('data: {"level":"info","line":"ready"}\n\n');
+});
+
+export default router;

--- a/server/routes/sidecar.ts
+++ b/server/routes/sidecar.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/file', (req, res) => {
+  res.status(404).end();
+});
+
+export default router;

--- a/server/services/builder.ts
+++ b/server/services/builder.ts
@@ -1,0 +1,3 @@
+export async function build(entry: string, asciiOnly?: boolean) {
+  return { bundleUrl: '/bundle.js', version: '0.0.0', sha256: '' };
+}

--- a/server/services/llm.ts
+++ b/server/services/llm.ts
@@ -1,0 +1,3 @@
+export async function chat(messages: any[]) {
+  return { id: '0', delta: 'hello' };
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["./**/*.ts"]
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "chatty-commander-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/unit/ascii.test.js
+++ b/tests/unit/ascii.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { encodeASCII } from '../../app/src/lib/ascii.js';
+
+test('encodeASCII replaces non-ascii', () => {
+  assert.strictEqual(encodeASCII('hello'), 'hello');
+  assert.strictEqual(encodeASCII('hi✓'), 'hi?');
+});

--- a/workers/canvas-builder.ts
+++ b/workers/canvas-builder.ts
@@ -1,0 +1,4 @@
+export async function buildCanvas(entry: string) {
+  // placeholder build
+  return { bundleUrl: '/bundle.js', version: '0.0.0', sha256: '' };
+}

--- a/workers/package.json
+++ b/workers/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "chatty-commander-workers",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/workers/tsconfig.json
+++ b/workers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold React + Vite app with three-pane layout and Zustand stores
- add Express server stubs with SSE endpoints and worker placeholder
- set up monorepo tooling and basic ASCII encoding test

## Testing
- `pnpm -w test`


------
https://chatgpt.com/codex/tasks/task_e_689c1c73afb8832cb0007f8f5ecc0677