### PR TITLE
Respect web server env overrides

### DIFF
--- a/src/chatty_commander/main.py
+++ b/src/chatty_commander/main.py
@@ -90,6 +90,8 @@ def run_web_mode(
     config, model_manager, state_manager, command_executor, logger, no_auth=False, port=8100
 ):
     """Run the web UI mode with FastAPI server and graceful shutdown."""
+    import os
+
     try:
         from chatty_commander.web.web_mode import create_web_server
     except ImportError:
@@ -137,9 +139,18 @@ def run_web_mode(
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
+    host = os.getenv("CHATCOMM_HOST", "0.0.0.0")
+    env_port = os.getenv("CHATCOMM_PORT")
+    if env_port:
+        try:
+            port = int(env_port)
+        except ValueError:
+            logger.warning("Invalid CHATCOMM_PORT '%s'; using %s", env_port, port)
+    log_level = os.getenv("CHATCOMM_LOG_LEVEL", "info")
+
     # Start the server
     try:
-        web_server.run(host="0.0.0.0", port=port, log_level="info")
+        web_server.run(host=host, port=port, log_level=log_level)
     finally:
         try:
             if hasattr(model_manager, "shutdown"):

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-web_mode.py
+"""web_mode.py.
 
 FastAPI web server implementation for ChattyCommander.
 Provides REST API endpoints and WebSocket support for web interface.
@@ -9,6 +8,7 @@ Provides REST API endpoints and WebSocket support for web interface.
 import asyncio
 import json
 import logging
+import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -455,7 +455,7 @@ class WebModeServer:
 
         @app.websocket("/ws")
         async def websocket_endpoint(websocket: WebSocket):
-            """WebSocket endpoint for real-time updates."""
+            """Websocket endpoint for real-time updates."""
             await websocket.accept()
             self.active_connections.add(websocket)
 
@@ -621,7 +621,21 @@ class WebModeServer:
             pass
 
     def run(self, host: str = "0.0.0.0", port: int = 8100, log_level: str = "info") -> None:
-        """Run the web server."""
+        """Run the web server, honoring environment overrides."""
+        env_host = os.getenv("CHATCOMM_HOST")
+        env_port = os.getenv("CHATCOMM_PORT")
+        env_log_level = os.getenv("CHATCOMM_LOG_LEVEL")
+
+        if env_host:
+            host = env_host
+        if env_port:
+            try:
+                port = int(env_port)
+            except ValueError:
+                logger.warning("Invalid CHATCOMM_PORT '%s'; falling back to %s", env_port, port)
+        if env_log_level:
+            log_level = env_log_level
+
         logger.info(f"🚀 Starting ChattyCommander web server on {host}:{port}")
         logger.info(f"📖 API documentation: http://{host}:{port}/docs")
         logger.info(f"🔧 Authentication: {'Disabled' if self.no_auth else 'Enabled'}")
@@ -668,7 +682,11 @@ if __name__ == "__main__":
         no_auth=True,
     )
 
-    server.run()
+    env_host = os.getenv("CHATCOMM_HOST", "0.0.0.0")
+    env_port = int(os.getenv("CHATCOMM_PORT", "8100"))
+    env_log_level = os.getenv("CHATCOMM_LOG_LEVEL", "info")
+
+    server.run(host=env_host, port=env_port, log_level=env_log_level)
 
 
 # Minimal, stateless FastAPI app factory for tests

--- a/tests/test_web_env_override.py
+++ b/tests/test_web_env_override.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Test that web server respects environment variable overrides."""
+
+import os
+import subprocess
+import sys
+import time
+
+import requests
+
+
+def test_web_server_env_overrides():
+    env = os.environ.copy()
+    env["CHATCOMM_HOST"] = "127.0.0.1"
+    env["CHATCOMM_PORT"] = "8765"
+    env["CHATCOMM_LOG_LEVEL"] = "warning"
+    env["PYTHONPATH"] = os.path.join(os.getcwd(), "src")
+
+    cmd = [sys.executable, "-m", "chatty_commander.main", "--web", "--no-auth"]
+    proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    url = "http://127.0.0.1:8765/api/v1/health"
+    resp = None
+    try:
+        for _ in range(30):
+            try:
+                resp = requests.get(url, timeout=2)
+                if resp.status_code == 200:
+                    break
+            except requests.exceptions.RequestException:
+                time.sleep(1)
+        else:
+            stdout, stderr = proc.communicate(timeout=1)
+            raise AssertionError(f"Server did not start\nSTDOUT: {stdout}\nSTDERR: {stderr}")
+    finally:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+    assert resp is not None and resp.status_code == 200


### PR DESCRIPTION
## Summary
- read CHATCOMM_HOST, CHATCOMM_PORT and CHATCOMM_LOG_LEVEL inside `WebModeServer.run`
- route `__main__` and main entrypoints through env-based host/port/log level
- add integration test starting server with env overrides

## Testing
- `pre-commit run --files src/chatty_commander/web/web_mode.py src/chatty_commander/main.py tests/test_web_env_override.py`
- `uv run pytest tests/test_web_env_override.py`


------
https://chatgpt.com/codex/tasks/task_e_689c1a7c58ec832cb7ccdb75497e9380