### PR TITLE
feat: make test app configurable origins

### DIFF
--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -692,7 +692,45 @@ if __name__ == "__main__":
 # Minimal, stateless FastAPI app factory for tests
 
 
-def create_app(no_auth: bool = True) -> FastAPI:
+def create_app(no_auth: bool = True, config: Config | None = None) -> FastAPI:
+    """Create a minimal FastAPI app used in unit tests.
+
+    Parameters
+    ----------
+    no_auth:
+        When ``True`` the server behaves in development/no-auth mode and CORS
+        is fully permissive. When ``False`` the app applies the same CORS
+        restrictions as production.
+    config:
+        Optional :class:`~chatty_commander.app.config.Config` instance.  If
+        supplied and ``no_auth`` is ``False`` the ``web.allowed_origins`` value
+        from the config is used for CORS.  When not provided, the comma-separated
+        ``CHATCOMM_ALLOWED_ORIGINS`` environment variable is consulted.  This
+        mirrors the behaviour of the production server and allows tests to
+        supply custom origins without modifying global state.
+    """
+
+    if no_auth:
+        allowed_origins = ["*"]
+    else:
+        origins: list[str] | None = None
+        # Prefer config-provided origins when available
+        if config is not None:
+            web_cfg = getattr(config, "config", {}).get("web", {})  # type: ignore[arg-type]
+            cfg_origins = web_cfg.get("allowed_origins") if isinstance(web_cfg, dict) else None
+            if isinstance(cfg_origins, str):
+                origins = [cfg_origins]
+            elif isinstance(cfg_origins, (list, tuple)):
+                origins = [str(o) for o in cfg_origins]
+        # Fall back to environment variable
+        if origins is None:
+            env_origins = os.environ.get("CHATCOMM_ALLOWED_ORIGINS")
+            if env_origins:
+                origins = [o.strip() for o in env_origins.split(",") if o.strip()]
+        if not origins:
+            origins = ["http://localhost:3000"]
+        allowed_origins = origins
+
     app = FastAPI(
         title="ChattyCommander API",
         version="0.2.0",
@@ -701,7 +739,7 @@ def create_app(no_auth: bool = True) -> FastAPI:
     )
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"] if no_auth else ["http://localhost:3000"],
+        allow_origins=allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -744,7 +782,7 @@ def create_app(no_auth: bool = True) -> FastAPI:
         def save_config(self, *_args, **_kwargs) -> None:  # matches both signatures
             return None
 
-    cfg_mgr = _MiniConfig()
+    cfg_mgr = config if config is not None else _MiniConfig()
 
     last_cmd: dict[str, str | None] = {"value": None}
 

--- a/tests/test_cors_no_auth.py
+++ b/tests/test_cors_no_auth.py
@@ -1,3 +1,4 @@
+from chatty_commander.app.config import Config
 from chatty_commander.web.web_mode import create_app
 from fastapi.testclient import TestClient
 
@@ -29,12 +30,15 @@ def test_cors_header_present_on_simple_get_when_no_auth():
     assert resp.headers.get("access-control-allow-origin") in {"*", "http://example.com"}
 
 
-def test_cors_respects_configured_origins(monkeypatch):
-    monkeypatch.setenv(
-        "CHATCOMM_ALLOWED_ORIGINS",
-        "http://foo.example,http://bar.example",
-    )
-    app = create_app(no_auth=False)
+def test_cors_respects_configured_origins():
+    """Custom origins can be supplied via Config for test parity with production."""
+
+    cfg = Config()
+    cfg.config.setdefault("web", {})["allowed_origins"] = [
+        "http://foo.example",
+        "http://bar.example",
+    ]
+    app = create_app(no_auth=False, config=cfg)
     client = TestClient(app)
 
     headers = {


### PR DESCRIPTION
## Summary
- allow test create_app to accept Config or CHATCOMM_ALLOWED_ORIGINS env var for CORS
- exercise custom origins in CORS test via Config

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_cors_no_auth.py -q`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: many assertions and missing dependencies across suite)*

------
https://chatgpt.com/codex/tasks/task_e_689c20953484832c85cef1106fb8fa03