### PR TITLE
feat: allow audio env overrides

### DIFF
--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -27,21 +27,21 @@ class Config:
         self.wakeword_state_map = self.config_data.get("wakeword_state_map", {})
         self.state_transitions = self.config_data.get("state_transitions", {})
         self.commands = self.config_data.get("commands", {})
-        
+
         # Create general_settings object for backward compatibility
         class GeneralSettings:
             def __init__(self, config):
                 self._config = config
-            
+
             @property
             def default_state(self):
                 return self._config.default_state
-            
+
             @default_state.setter
             def default_state(self, value):
                 self._config.default_state = value
                 self._config.config_data["default_state"] = value
-        
+
         self.general_settings = GeneralSettings(self)
 
         # Apply environment variable overrides
@@ -53,6 +53,20 @@ class Config:
             self.api_endpoints["chatbot_endpoint"] = os.environ["CHATBOT_ENDPOINT"]
         if "HOME_ASSISTANT_ENDPOINT" in os.environ:
             self.api_endpoints["home_assistant"] = os.environ["HOME_ASSISTANT_ENDPOINT"]
+
+    @staticmethod
+    def _get_int_env(var_name: str, fallback: int) -> int:
+        """Return an integer from the environment or the provided fallback."""
+        value = os.environ.get(var_name)
+        if value is not None:
+            try:
+                parsed = int(value)
+                if parsed <= 0:
+                    raise ValueError
+                return parsed
+            except ValueError:
+                logger.warning("Invalid %s=%r; using %s", var_name, value, fallback)
+        return fallback
 
     def save_config(self, config_data: dict | None = None) -> None:
         """Save configuration to file."""
@@ -131,9 +145,15 @@ class Config:
 
         # Audio settings
         audio_settings = self.config_data.get("audio_settings", {})
-        self.mic_chunk_size = audio_settings.get("mic_chunk_size", 1024)
-        self.sample_rate = audio_settings.get("sample_rate", 16000)
-        self.audio_format = audio_settings.get("audio_format", "int16")
+        self.mic_chunk_size = self._get_int_env(
+            "CHATCOMM_MIC_CHUNK_SIZE", audio_settings.get("mic_chunk_size", 1024)
+        )
+        self.sample_rate = self._get_int_env(
+            "CHATCOMM_SAMPLE_RATE", audio_settings.get("sample_rate", 16000)
+        )
+        self.audio_format = os.environ.get(
+            "CHATCOMM_AUDIO_FORMAT", audio_settings.get("audio_format", "int16")
+        )
 
         # General settings
         general_settings = self.config_data.get("general_settings", {})

--- a/tests/test_config_env_overrides.py
+++ b/tests/test_config_env_overrides.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from chatty_commander.app.config import Config
@@ -13,3 +14,43 @@ def test_config_env_endpoint_overrides(monkeypatch, tmp_path):
     c = Config(config_file=str(cfg_path))
     assert c.api_endpoints["chatbot_endpoint"] == "http://override.local/"
     assert c.api_endpoints["home_assistant"] == "http://ha.local/api"
+
+
+def test_config_env_audio_overrides(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "audio_settings": {
+                    "mic_chunk_size": 512,
+                    "sample_rate": 8000,
+                    "audio_format": "int8",
+                }
+            }
+        )
+    )
+
+    monkeypatch.setenv("CHATCOMM_MIC_CHUNK_SIZE", "2048")
+    monkeypatch.setenv("CHATCOMM_SAMPLE_RATE", "44100")
+    monkeypatch.setenv("CHATCOMM_AUDIO_FORMAT", "float32")
+
+    c = Config(config_file=str(cfg_path))
+    c.save_config()
+    assert c.mic_chunk_size == 2048
+    assert c.sample_rate == 44100
+    assert c.audio_format == "float32"
+
+
+def test_config_env_audio_invalid(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        json.dumps({"audio_settings": {"mic_chunk_size": 512, "sample_rate": 8000}})
+    )
+
+    monkeypatch.setenv("CHATCOMM_MIC_CHUNK_SIZE", "not-a-number")
+    monkeypatch.setenv("CHATCOMM_SAMPLE_RATE", "-1")
+
+    c = Config(config_file=str(cfg_path))
+    c.save_config()
+    assert c.mic_chunk_size == 512
+    assert c.sample_rate == 8000


### PR DESCRIPTION
## Summary
- read audio env vars for chunk size, sample rate, and format
- validate numeric env vars before using
- test env override behavior for audio settings

## Testing
- `ruff check src/chatty_commander/app/config.py tests/test_config_env_overrides.py`
- `black src/chatty_commander/app/config.py tests/test_config_env_overrides.py`
- `PYENV_VERSION=3.11.12 PYTHONPATH=src python -m pytest tests/test_config_env_overrides.py`


------
https://chatgpt.com/codex/tasks/task_e_689c20940648832c88aa98591f22c815