### PR TITLE
Add host overrides for web mode with tests

### DIFF
--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -620,11 +620,16 @@ class WebModeServer:
             # No event loop running, skip broadcast
             pass
 
-    def run(self, host: str = "0.0.0.0", port: int = 8100, log_level: str = "info") -> None:
-        """Run the web server, honoring environment overrides."""
+    def run(self, host: str | None = None, port: int | None = None, log_level: str = "info") -> None:
+        """Run the web server, honoring config and environment overrides."""
         env_host = os.getenv("CHATCOMM_HOST")
         env_port = os.getenv("CHATCOMM_PORT")
         env_log_level = os.getenv("CHATCOMM_LOG_LEVEL")
+
+        if host is None and getattr(self.config_manager, "web_server", None):
+            host = self.config_manager.web_server.get("host", "0.0.0.0")
+        if port is None and getattr(self.config_manager, "web_server", None):
+            port = self.config_manager.web_server.get("port", 8100)
 
         if env_host:
             host = env_host
@@ -635,6 +640,11 @@ class WebModeServer:
                 logger.warning("Invalid CHATCOMM_PORT '%s'; falling back to %s", env_port, port)
         if env_log_level:
             log_level = env_log_level
+
+        if host is None:
+            host = "0.0.0.0"
+        if port is None:
+            port = 8100
 
         logger.info(f"🚀 Starting ChattyCommander web server on {host}:{port}")
         logger.info(f"📖 API documentation: http://{host}:{port}/docs")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,6 +51,42 @@ class TestMain(unittest.TestCase):
         # mock_state_manager.update_state.assert_called_with('command')
         # mock_executor.execute_command.assert_called_with('command')
 
+    @patch(
+        'sys.argv',
+        ['main.py', '--web', '--host', '1.2.3.4', '--port', '1234', '--no-auth'],
+    )
+    @patch('chatty_commander.main.run_web_mode')
+    @patch('chatty_commander.main.StateManager')
+    @patch('chatty_commander.main.ModelManager')
+    @patch('chatty_commander.main.CommandExecutor')
+    @patch('chatty_commander.main.Config')
+    @patch('chatty_commander.main.setup_logger')
+    def test_web_mode_cli_overrides(
+        self,
+        mock_setup_logger,
+        mock_Config,
+        mock_CommandExecutor,
+        mock_ModelManager,
+        mock_StateManager,
+        mock_run_web_mode,
+    ):
+        mock_config = MagicMock()
+        mock_config.web_server = {'host': '0.0.0.0', 'port': 8100, 'auth_enabled': True}
+        mock_Config.return_value = mock_config
+
+        result = main.main()
+        self.assertEqual(result, 0)
+
+        mock_run_web_mode.assert_called_once()
+        _args, kwargs = mock_run_web_mode.call_args
+        self.assertEqual(kwargs['host'], '1.2.3.4')
+        self.assertEqual(kwargs['port'], 1234)
+        self.assertTrue(kwargs['no_auth'])
+        self.assertEqual(
+            mock_config.web_server,
+            {'host': '1.2.3.4', 'port': 1234, 'auth_enabled': False},
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Support `--host` CLI flag and propagate host/port/no-auth to web server
- WebModeServer defaults to configuration values when no overrides are supplied
- Add unit tests for CLI host override and WebModeServer config usage

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_main.py::TestMain::test_web_mode_cli_overrides tests/test_web_mode.py::test_run_uses_config_when_no_overrides -q`

------
https://chatgpt.com/codex/tasks/task_e_689c20efeec0832cad91a8836d475dc3