### PR TITLE
feat(config): allow env overrides for general settings

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -61,6 +61,19 @@ class GeneralSettings:
     check_for_updates: bool = True
 ```
 
+### Environment variable overrides
+
+These fields may be overridden with environment variables. Boolean values
+accept `1`, `true` or `yes` (case-insensitive) to enable them.
+
+| Variable                       | Description                    |
+| ------------------------------ | ------------------------------ |
+| `CHATCOMM_DEBUG`               | Enable debug mode              |
+| `CHATCOMM_DEFAULT_STATE`       | Default state when starting    |
+| `CHATCOMM_INFERENCE_FRAMEWORK` | Override inference framework   |
+| `CHATCOMM_START_ON_BOOT`       | Launch ChattyCommander on boot |
+| `CHATCOMM_CHECK_FOR_UPDATES`   | Check for application updates  |
+
 ## Adding a custom command
 
 1. Define a keybinding:

--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -27,25 +27,28 @@ class Config:
         self.wakeword_state_map = self.config_data.get("wakeword_state_map", {})
         self.state_transitions = self.config_data.get("state_transitions", {})
         self.commands = self.config_data.get("commands", {})
-        
+
         # Create general_settings object for backward compatibility
         class GeneralSettings:
             def __init__(self, config):
                 self._config = config
-            
+
             @property
             def default_state(self):
                 return self._config.default_state
-            
+
             @default_state.setter
             def default_state(self, value):
                 self._config.default_state = value
                 self._config.config_data["default_state"] = value
-        
+
         self.general_settings = GeneralSettings(self)
 
         # Apply environment variable overrides
         self._apply_env_overrides()
+
+        # Load general settings with possible environment overrides
+        self._load_general_settings()
 
     def _apply_env_overrides(self):
         """Apply environment variable overrides to API endpoints."""
@@ -136,13 +139,7 @@ class Config:
         self.audio_format = audio_settings.get("audio_format", "int16")
 
         # General settings
-        general_settings = self.config_data.get("general_settings", {})
-        self.debug_mode = general_settings.get("debug_mode", True)
-        self.default_state = general_settings.get("default_state", "idle")
-        self.inference_framework = general_settings.get("inference_framework", "onnx")
-        self.start_on_boot = general_settings.get("start_on_boot", False)
-        # Ensure we're using ONNX runtime for ONNX models
-        self.check_for_updates = general_settings.get("check_for_updates", True)
+        self._load_general_settings()
 
         # Keybindings
         self.keybindings = self.config_data.get("keybindings", {})
@@ -273,6 +270,32 @@ class Config:
                 model_actions[command_name] = {"message": command_config.get("message", "")}
 
         return model_actions
+
+    def _load_general_settings(self) -> None:
+        """Load general settings, applying environment variable overrides."""
+        general_settings = self.config_data.get("general_settings", {})
+
+        def _env_bool(name: str, default: bool) -> bool:
+            val = os.getenv(name)
+            if val is None:
+                return default
+            return val.strip().lower() in {"1", "true", "yes"}
+
+        self.debug_mode = _env_bool("CHATCOMM_DEBUG", general_settings.get("debug_mode", True))
+        self.default_state = os.getenv(
+            "CHATCOMM_DEFAULT_STATE", general_settings.get("default_state", "idle")
+        )
+        self.inference_framework = os.getenv(
+            "CHATCOMM_INFERENCE_FRAMEWORK",
+            general_settings.get("inference_framework", "onnx"),
+        )
+        self.start_on_boot = _env_bool(
+            "CHATCOMM_START_ON_BOOT", general_settings.get("start_on_boot", False)
+        )
+        self.check_for_updates = _env_bool(
+            "CHATCOMM_CHECK_FOR_UPDATES",
+            general_settings.get("check_for_updates", True),
+        )
 
     def validate(self):
         import logging

--- a/tests/test_config_env_overrides.py
+++ b/tests/test_config_env_overrides.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from chatty_commander.app.config import Config
@@ -13,3 +14,34 @@ def test_config_env_endpoint_overrides(monkeypatch, tmp_path):
     c = Config(config_file=str(cfg_path))
     assert c.api_endpoints["chatbot_endpoint"] == "http://override.local/"
     assert c.api_endpoints["home_assistant"] == "http://ha.local/api"
+
+
+def test_config_general_settings_env_overrides(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "general_settings": {
+                    "debug_mode": False,
+                    "default_state": "idle",
+                    "inference_framework": "onnx",
+                    "start_on_boot": False,
+                    "check_for_updates": True,
+                }
+            }
+        )
+    )
+
+    monkeypatch.setenv("CHATCOMM_DEBUG", "TrUe")
+    monkeypatch.setenv("CHATCOMM_DEFAULT_STATE", "computer")
+    monkeypatch.setenv("CHATCOMM_INFERENCE_FRAMEWORK", "pytorch")
+    monkeypatch.setenv("CHATCOMM_START_ON_BOOT", "YeS")
+    monkeypatch.setenv("CHATCOMM_CHECK_FOR_UPDATES", "0")
+
+    c = Config(config_file=str(cfg_path))
+
+    assert c.debug_mode is True
+    assert c.default_state == "computer"
+    assert c.inference_framework == "pytorch"
+    assert c.start_on_boot is True
+    assert c.check_for_updates is False


### PR DESCRIPTION
## Summary
- allow CHATCOMM_* env vars to override general settings like debug mode, default state, inference framework, auto start, and update checks
- document new environment variables and boolean parsing
- test that general settings respect these overrides

## Testing
- `PYENV_VERSION=3.11.12 pre-commit run --files src/chatty_commander/app/config.py docs/CONFIG_SCHEMA.md tests/test_config_env_overrides.py`
- `PYENV_VERSION=3.11.12 PYTHONPATH=src python -m pytest tests/test_config_env_overrides.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2092f238832c84f4e3fc9a44f7f2