### PR TITLE
Expose web server host and port configuration

### DIFF
--- a/src/chatty_commander/main.py
+++ b/src/chatty_commander/main.py
@@ -87,7 +87,14 @@ def run_cli_mode(config, model_manager, state_manager, command_executor, logger)
 
 
 def run_web_mode(
-    config, model_manager, state_manager, command_executor, logger, no_auth=False, port=8100
+    config,
+    model_manager,
+    state_manager,
+    command_executor,
+    logger,
+    host,
+    port,
+    no_auth: bool = False,
 ):
     """Run the web UI mode with FastAPI server and graceful shutdown."""
     import os
@@ -100,7 +107,9 @@ def run_web_mode(
         )
         sys.exit(1)
 
-    logger.info(f"Starting web mode (auth={'disabled' if no_auth else 'enabled'}) on port {port}")
+    logger.info(
+        f"Starting web mode (auth={'disabled' if no_auth else 'enabled'}) on {host}:{port}"
+    )
 
     # Create web server instance
     web_server = create_web_server(
@@ -119,9 +128,9 @@ def run_web_mode(
         web_server._on_state_change(old_state, new_state)
 
     # Register callbacks
-    if hasattr(model_manager, 'add_command_callback'):
+    if hasattr(model_manager, "add_command_callback"):
         model_manager.add_command_callback(on_command_detected)
-    if hasattr(state_manager, 'add_state_change_callback'):
+    if hasattr(state_manager, "add_state_change_callback"):
         state_manager.add_state_change_callback(on_state_change)
 
     stop_event = threading.Event()
@@ -139,13 +148,6 @@ def run_web_mode(
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
-    host = os.getenv("CHATCOMM_HOST", "0.0.0.0")
-    env_port = os.getenv("CHATCOMM_PORT")
-    if env_port:
-        try:
-            port = int(env_port)
-        except ValueError:
-            logger.warning("Invalid CHATCOMM_PORT '%s'; using %s", env_port, port)
     log_level = os.getenv("CHATCOMM_LOG_LEVEL", "info")
 
     # Start the server
@@ -314,10 +316,16 @@ For detailed documentation and source code, visit: https://github.com/your-repo/
     )
 
     parser.add_argument(
+        "--host",
+        type=str,
+        default=None,
+        help="Specify the host interface for the web server (default from config).",
+    )
+    parser.add_argument(
         "--port",
         type=int,
-        default=8100,
-        help="Specify the port for the web server (default: 8100). Only used in web mode.",
+        default=None,
+        help="Specify the port for the web server (default from config). Only used in web mode.",
     )
 
     parser.add_argument(
@@ -454,7 +462,7 @@ def main():
     # If help was requested, argparse would have exited above with code 0.
     # Continue with validation for actual runs only.
     # Argument validation (only enforce when options are provided)
-    if getattr(args, "web", False) and getattr(args, "port", 8100) < 1024:
+    if getattr(args, "web", False) and args.port is not None and args.port < 1024:
         parser.error("Port must be 1024 or higher for non-root users")
     if getattr(args, "no_auth", False) and not getattr(args, "web", False):
         parser.error("--no-auth only applicable in web mode")
@@ -485,6 +493,23 @@ def main():
             config.advisors["enabled"] = True
         except Exception:
             pass
+
+    # Derive web server settings with CLI overrides
+    web_cfg = getattr(config, "web_server", {}) or {}
+    host = web_cfg.get("host", "0.0.0.0")
+    port = int(web_cfg.get("port", 8100))
+    auth_enabled = bool(web_cfg.get("auth_enabled", True))
+
+    if args.host is not None:
+        host = args.host
+    if args.port is not None:
+        port = args.port
+    if getattr(args, "no_auth", False):
+        auth_enabled = False
+
+    web_cfg.update({"host": host, "port": port, "auth_enabled": auth_enabled})
+    config.web_server = web_cfg
+
     model_manager = ModelManager(config)
     state_manager = StateManager()
     command_executor = CommandExecutor(config, model_manager, state_manager)
@@ -497,8 +522,16 @@ def main():
         config_cli.run_wizard()
         return 0
     elif getattr(args, "web", False):
+        no_auth = not auth_enabled
         run_web_mode(
-            config, model_manager, state_manager, command_executor, logger, args.no_auth, args.port
+            config,
+            model_manager,
+            state_manager,
+            command_executor,
+            logger,
+            host=host,
+            port=port,
+            no_auth=no_auth,
         )
         return 0
     elif args.gui:

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -620,11 +620,22 @@ class WebModeServer:
             # No event loop running, skip broadcast
             pass
 
-    def run(self, host: str = "0.0.0.0", port: int = 8100, log_level: str = "info") -> None:
-        """Run the web server, honoring environment overrides."""
+    def run(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        log_level: str = "info",
+    ) -> None:
+        """Run the web server, honoring environment and config defaults."""
         env_host = os.getenv("CHATCOMM_HOST")
         env_port = os.getenv("CHATCOMM_PORT")
         env_log_level = os.getenv("CHATCOMM_LOG_LEVEL")
+
+        cfg = getattr(self.config_manager, "web_server", {}) or {}
+        if host is None:
+            host = cfg.get("host", "0.0.0.0")
+        if port is None:
+            port = int(cfg.get("port", 8100))
 
         if env_host:
             host = env_host
@@ -636,9 +647,13 @@ class WebModeServer:
         if env_log_level:
             log_level = env_log_level
 
-        logger.info(f"🚀 Starting ChattyCommander web server on {host}:{port}")
+        logger.info(
+            "🚀 Starting ChattyCommander web server on %s:%s (auth %s)",
+            host,
+            port,
+            "disabled" if self.no_auth else "enabled",
+        )
         logger.info(f"📖 API documentation: http://{host}:{port}/docs")
-        logger.info(f"🔧 Authentication: {'Disabled' if self.no_auth else 'Enabled'}")
 
         uvicorn.run(self.app, host=host, port=port, log_level=log_level, access_log=True)
 


### PR DESCRIPTION
## Summary
- derive host, port, and auth-enabled from `config.web_server`
- allow CLI to override `config.web_server` and pass host/port to `run_web_mode`
- allow `WebModeServer.run` to accept optional host/port and use config defaults

## Testing
- `uv run pytest -q` *(fails: many tests failed due to environment issues)*


------
https://chatgpt.com/codex/tasks/task_e_689c20eee1b8832cac22b656a887e29c