### PR TITLE
Add queued avatar audio playback with interrupt support

### DIFF
--- a/src/chatty_commander/web/routes/avatar_ws.py
+++ b/src/chatty_commander/web/routes/avatar_ws.py
@@ -119,6 +119,132 @@ class AvatarWSConnectionManager:
 manager = AvatarWSConnectionManager()
 
 
+class AvatarAudioQueue:
+    """Queue managing sequential avatar speech playback.
+
+    Messages with optional audio are enqueued. Only one message is played at a
+    time; additional messages wait in the queue.  The queue broadcasts start/end
+    events through ``AvatarWSConnectionManager`` so connected avatar clients can
+    update their state.
+
+    An interrupt API is provided to clear pending messages and immediately play
+    a high priority one (useful for alerts).
+    """
+
+    def __init__(self, ws_manager: AvatarWSConnectionManager) -> None:
+        self.manager = ws_manager
+        self.queue: asyncio.Queue[tuple[str, str, bytes | None]] = asyncio.Queue()
+        self._processor_task: asyncio.Task | None = None
+        self._current_play_task: asyncio.Task | None = None
+
+    @property
+    def is_speaking(self) -> bool:
+        """Return ``True`` if audio is currently being played."""
+
+        return self._current_play_task is not None and not self._current_play_task.done()
+
+    async def _play_audio(self, audio: bytes | None) -> None:
+        """Placeholder for audio playback.
+
+        In production this would stream audio to an output device. For testing
+        we simply sleep for a duration based on the audio length if provided.
+        """
+
+        if audio:
+            # Rough heuristic: 1000 bytes ~= 1 second
+            await asyncio.sleep(max(len(audio) / 1000.0, 0))
+        else:
+            await asyncio.sleep(0)
+
+    async def _process(self) -> None:
+        while not self.queue.empty():
+            agent_id, message, audio = await self.queue.get()
+            start = {
+                "type": "avatar_audio_start",
+                "data": {"agent_id": agent_id, "message": message},
+            }
+            self.manager.broadcast_state_change(start)
+            try:
+                self._current_play_task = asyncio.create_task(self._play_audio(audio))
+                await self._current_play_task
+            except asyncio.CancelledError:
+                end = {
+                    "type": "avatar_audio_end",
+                    "data": {"agent_id": agent_id, "interrupted": True},
+                }
+                self.manager.broadcast_state_change(end)
+            else:
+                end = {
+                    "type": "avatar_audio_end",
+                    "data": {"agent_id": agent_id},
+                }
+                self.manager.broadcast_state_change(end)
+            finally:
+                self._current_play_task = None
+                self.queue.task_done()
+
+        self._processor_task = None
+
+    def _ensure_processor(self) -> None:
+        if self._processor_task is None or self._processor_task.done():
+            try:
+                loop = asyncio.get_running_loop()
+                self._processor_task = loop.create_task(self._process())
+            except RuntimeError:
+                asyncio.run(self._process())
+
+    async def enqueue(self, agent_id: str, message: str, audio: bytes | None = None) -> None:
+        """Add a message to the queue for playback."""
+
+        await self.queue.put((agent_id, message, audio))
+        self._ensure_processor()
+
+    async def interrupt(
+        self, agent_id: str, message: str, audio: bytes | None = None
+    ) -> None:
+        """Interrupt current playback and play a priority message immediately."""
+
+        # Clear any pending messages
+        while not self.queue.empty():
+            try:
+                self.queue.get_nowait()
+                self.queue.task_done()
+            except asyncio.QueueEmpty:
+                break
+
+        # Cancel currently playing audio
+        if self._current_play_task and not self._current_play_task.done():
+            self._current_play_task.cancel()
+            try:
+                await self._current_play_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+
+        # Queue the priority message and ensure processor running
+        await self.queue.put((agent_id, message, audio))
+        self._ensure_processor()
+
+
+# Global audio queue instance
+audio_queue = AvatarAudioQueue(manager)
+
+
+async def queue_avatar_message(agent_id: str, message: str, audio: bytes | None = None) -> None:
+    """Public helper to queue avatar speech."""
+
+    await audio_queue.enqueue(agent_id, message, audio)
+
+
+async def interrupt_avatar_queue(
+    agent_id: str, message: str, audio: bytes | None = None
+) -> None:
+    """Public helper to interrupt current avatar speech with a priority message."""
+
+    await audio_queue.interrupt(agent_id, message, audio)
+
+
 @router.websocket("/avatar/ws")
 async def avatar_ws_endpoint(websocket: WebSocket):
     await manager.connect(websocket)

--- a/tests/test_avatar_audio_queue.py
+++ b/tests/test_avatar_audio_queue.py
@@ -1,0 +1,52 @@
+import asyncio
+
+from src.chatty_commander.web.routes.avatar_ws import AvatarAudioQueue
+
+
+class StubManager:
+    def __init__(self):
+        self.events = []
+
+    def broadcast_state_change(self, message):
+        self.events.append(message)
+
+
+def test_queue_processes_sequentially():
+    mgr = StubManager()
+    queue = AvatarAudioQueue(mgr)
+
+    async def run():
+        await queue.enqueue('a', 'first', b'aa')
+        await queue.enqueue('a', 'second', b'bb')
+        await queue.queue.join()
+
+    asyncio.run(run())
+    starts = [e['data']['message'] for e in mgr.events if e['type'] == 'avatar_audio_start']
+    assert starts == ['first', 'second']
+
+
+def test_interrupt_replaces_current_playback():
+    mgr = StubManager()
+    queue = AvatarAudioQueue(mgr)
+
+    async def fake_play(audio):
+        await asyncio.sleep(0.05)
+
+    queue._play_audio = fake_play  # type: ignore[attr-defined]
+
+    async def run():
+        await queue.enqueue('a', 'first', b'aa')
+        await asyncio.sleep(0.01)
+        await queue.interrupt('a', 'priority', b'bb')
+        await queue.queue.join()
+
+    asyncio.run(run())
+    starts = [e['data']['message'] for e in mgr.events if e['type'] == 'avatar_audio_start']
+    assert starts[0] == 'first'
+    assert starts[1] == 'priority'
+    # Ensure an interrupted flag was broadcast
+    assert any(
+        e['data'].get('interrupted')
+        for e in mgr.events
+        if e['type'] == 'avatar_audio_end' and e['data']['agent_id'] == 'a'
+    )


### PR DESCRIPTION
## Summary
- add `AvatarAudioQueue` using `asyncio.Queue` to serialize avatar speech and audio playback
- broadcast playback start/end events through `AvatarWSConnectionManager`
- expose helpers to enqueue messages and interrupt playback
- add tests for sequential processing and interrupt behavior

## Testing
- `uv run pytest tests/test_avatar_audio_queue.py tests/test_avatar_ws.py tests/test_avatar_ws_theme.py tests/test_avatar_ws_no_clients.py tests/test_thinking_state_broadcast_async.py -q`
- `uv run pytest tests/test_avatar_api.py tests/test_avatar_api_list_success.py tests/test_avatar_api_errors.py tests/test_avatar_api_errors_minimal.py tests/test_avatar_selector.py tests/test_avatar_selector_basic.py tests/test_avatar_settings.py tests/test_thinking_state.py tests/test_avatar_gui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c25b712d8832ca36f2efdbde38692