### PR TITLE
feat: add ASCII utilities and ascii-only build support

### DIFF
--- a/app/src/lib/ascii.js
+++ b/app/src/lib/ascii.js
@@ -1,3 +1,16 @@
+const NON_ASCII = /[^\x00-\x7F]/g;
+
 export function encodeASCII(s) {
-  return s.replace(/[^\x00-\x7F]/g, '?');
+  return s.replace(NON_ASCII, '?');
+}
+
+export function isASCII(s) {
+  NON_ASCII.lastIndex = 0;
+  return !NON_ASCII.test(s);
+}
+
+export function assertASCII(s) {
+  if (!isASCII(s)) {
+    throw new Error('Non-ASCII input');
+  }
 }

--- a/app/src/lib/ascii.ts
+++ b/app/src/lib/ascii.ts
@@ -1,3 +1,16 @@
+const NON_ASCII = /[^\x00-\x7F]/g;
+
 export function encodeASCII(s: string): string {
-  return s.replace(/[^\x00-\x7F]/g, '?');
+  return s.replace(NON_ASCII, '?');
+}
+
+export function isASCII(s: string): boolean {
+  NON_ASCII.lastIndex = 0;
+  return !NON_ASCII.test(s);
+}
+
+export function assertASCII(s: string): void {
+  if (!isASCII(s)) {
+    throw new Error('Non-ASCII input');
+  }
 }

--- a/server/services/builder.ts
+++ b/server/services/builder.ts
@@ -1,3 +1,11 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { encodeASCII } from '../../app/src/lib/ascii.js';
+
 export async function build(entry: string, asciiOnly?: boolean) {
+  let contents = await readFile(entry, 'utf8');
+  if (asciiOnly) {
+    contents = encodeASCII(contents);
+  }
+  await writeFile('/tmp/bundle.js', contents, 'utf8');
   return { bundleUrl: '/bundle.js', version: '0.0.0', sha256: '' };
 }

--- a/tests/unit/ascii.test.js
+++ b/tests/unit/ascii.test.js
@@ -1,8 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { encodeASCII } from '../../app/src/lib/ascii.js';
+import { encodeASCII, isASCII } from '../../app/src/lib/ascii.js';
 
 test('encodeASCII replaces non-ascii', () => {
   assert.strictEqual(encodeASCII('hello'), 'hello');
   assert.strictEqual(encodeASCII('hi✓'), 'hi?');
+});
+
+test('isASCII guards strings', () => {
+  assert.ok(isASCII('plain'));
+  assert.ok(!isASCII('✓'));
 });


### PR DESCRIPTION
## Summary
- add ASCII helpers with guards for validation and encoding
- strip non-ASCII characters in builder when asciiOnly flag is set
- test ASCII utilities via unit tests

## Testing
- `node --test tests/unit/ascii.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c25ef47f0832cabeba6e0a0a2daa9