### PR TITLE
feat: add ASCII pipeline utilities and secure canvas runtime

### DIFF
--- a/app/src/lib/ascii.js
+++ b/app/src/lib/ascii.js
@@ -1,3 +1,18 @@
-export function encodeASCII(s) {
-  return s.replace(/[^\x00-\x7F]/g, '?');
+// Encode a string into ASCII bytes, replacing non-ASCII chars with '?'
+export function encodeASCII(str) {
+  const out = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    out[i] = code < 0x80 ? code : 0x3f; // '?'
+  }
+  return out;
+}
+
+// Decode ASCII bytes into a string, substituting non-ASCII bytes with '?'
+export function decodeASCII(bytes) {
+  let result = '';
+  for (const b of bytes) {
+    result += String.fromCharCode(b < 0x80 ? b : 0x3f);
+  }
+  return result;
 }

--- a/app/src/lib/ascii.ts
+++ b/app/src/lib/ascii.ts
@@ -1,3 +1,18 @@
-export function encodeASCII(s: string): string {
-  return s.replace(/[^\x00-\x7F]/g, '?');
+// Encode a string into ASCII bytes, replacing non-ASCII chars with '?'
+export function encodeASCII(str: string): Uint8Array {
+  const out = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    out[i] = code < 0x80 ? code : 0x3f; // '?'
+  }
+  return out;
+}
+
+// Decode ASCII bytes into a string, substituting non-ASCII bytes with '?'
+export function decodeASCII(bytes: Uint8Array): string {
+  let result = '';
+  for (const b of bytes) {
+    result += String.fromCharCode(b < 0x80 ? b : 0x3f);
+  }
+  return result;
 }

--- a/app/src/lib/iframe-runtime.ts
+++ b/app/src/lib/iframe-runtime.ts
@@ -1,0 +1,7 @@
+export function appendLog(text: string) {
+  const pre = document.getElementById('console') || document.body.appendChild(document.createElement('pre'));
+  pre.id = 'console';
+  const line = document.createElement('div');
+  line.textContent = text;
+  pre.appendChild(line);
+}

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,7 +1,17 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
+import { useCanvasStore } from '../stores/canvas';
 
 export default function CanvasPane() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const consoleRef = useRef<HTMLPreElement>(null);
+  const logs = useCanvasStore(s => s.logs);
+
+  useEffect(() => {
+    if (consoleRef.current) {
+      consoleRef.current.textContent = logs.join('\n');
+    }
+  }, [logs]);
+
   return (
     <section className="flex-1 flex flex-col">
       <iframe
@@ -10,9 +20,11 @@ export default function CanvasPane() {
         sandbox="allow-scripts allow-downloads"
         className="flex-1 bg-white"
       />
-      <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
-        Console output...
-      </div>
+      <pre
+        ref={consoleRef}
+        className="h-40 overflow-auto bg-black text-green-400 text-xs p-2"
+        aria-label="Console"
+      />
     </section>
   );
 }

--- a/tests/unit/ascii.test.js
+++ b/tests/unit/ascii.test.js
@@ -1,8 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { encodeASCII } from '../../app/src/lib/ascii.js';
+import { encodeASCII, decodeASCII } from '../../app/src/lib/ascii.js';
 
-test('encodeASCII replaces non-ascii', () => {
-  assert.strictEqual(encodeASCII('hello'), 'hello');
-  assert.strictEqual(encodeASCII('hi✓'), 'hi?');
+test('ASCII encode/decode replaces non-ascii', () => {
+  const encodedHello = encodeASCII('hello');
+  assert.strictEqual(decodeASCII(encodedHello), 'hello');
+
+  const encoded = encodeASCII('hi✓');
+  assert.deepStrictEqual(Array.from(encoded), [0x68, 0x69, 0x3f]);
+  assert.strictEqual(decodeASCII(encoded), 'hi?');
 });

--- a/workers/canvas-builder.ts
+++ b/workers/canvas-builder.ts
@@ -1,4 +1,24 @@
-export async function buildCanvas(entry: string) {
-  // placeholder build
-  return { bundleUrl: '/bundle.js', version: '0.0.0', sha256: '' };
+import { encodeASCII, decodeASCII } from '../app/src/lib/ascii.js';
+
+export async function buildCanvas(entry: string, asciiOnly = false) {
+  let code = entry;
+  if (asciiOnly) {
+    // Strip non-ASCII characters
+    code = decodeASCII(encodeASCII(code));
+
+    // Disable storage related APIs
+    const disable = `(() => {\n` +
+      `  const apis = ['localStorage', 'sessionStorage', 'indexedDB'];\n` +
+      `  for (const key of apis) {\n` +
+      `    Object.defineProperty(globalThis, key, {\n` +
+      `      get() { throw new Error('Storage disabled'); },\n` +
+      `      configurable: true\n` +
+      `    });\n` +
+      `  }\n` +
+      `})();\n`;
+    code = disable + code;
+  }
+
+  // placeholder build output with processed code
+  return { bundleUrl: '/bundle.js', version: '0.0.0', sha256: '', code };
 }


### PR DESCRIPTION
## Summary
- add ASCII encode/decode utilities
- strip non-ASCII and disable storage APIs in canvas build worker
- guard DOM text insertion in CanvasPane and iframe runtime

## Testing
- `node --test unit/ascii.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689c25fcf064832cbb8789c69c467da6