### PR TITLE
docs: outline background Docker task runner

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,5 +11,6 @@
 | Provider persona templates | 🟠 | Next: templating + tests |
 | Orchestrator adapter matrix tests | �� | Next: matrix coverage |
 | CI pipeline (GitHub Actions) | 🟢 | Basic tests workflow added |
+| Background Docker task runner w/ LLM summaries | 🔴 | Queue codex containers, show live 3-word summaries & stop button |
 
-Progress score: 8.5/10 (core features shipped, tests green, docs linked; remaining polish queued).
+Progress score: 8.3/10 (core features shipped, tests green, docs linked; background task runner planned).

--- a/README.md
+++ b/README.md
@@ -396,6 +396,10 @@ Alternatively, edit `config.py` manually for static changes.
 
 Enjoy using ChattyCommander! If you have questions, feel free to open an issue.
 
+## Future Plans
+
+- Background Docker task runner that schedules `--yolo -p` Codex containers, surfaces live 3-word summaries, and provides a stop button.
+
 ## Avatar GUI and Settings
 
 ## Standalone CLI (PyInstaller)

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # ChattyCommander TODO
 
-Last updated: 2025-08-03 by Kilo Code
+Last updated: 2025-08-13 by OpenAI Assistant
 
 Legend:
 - [x] Completed
@@ -8,6 +8,16 @@ Legend:
 - Now = Current sprint focus (max 7 items)
 - Next = Upcoming, ready to pull
 - Later = Backlog, not yet scheduled
+
+## Background Docker Task Runner & Summaries
+
+Goal: allow users to queue `--yolo -p` prompts that spawn Dockerized Codex tasks, surface rolling 3-word summaries, and expose a kill button.
+
+### Tasks
+- [ ] **Scheduler & Queue** – launch container jobs with prompt, model selection (`gpt-oss:20b` default), and persistent metadata.
+- [ ] **Log Tail & Summarizer** – buffer last _N_ lines, invoke LLM to output enforced 3-word summaries at intervals.
+- [ ] **UI Badge & Stop Control** – display rotating summaries and a square-in-circle stop button that terminates the container.
+- [ ] **Cleanup & History** – remove summaries when jobs finish; optional persistence of logs and summaries.
 
 ## Verification Audit (Old TODO → Current Implementation)
 

--- a/docs/BACKGROUND_TASK_RUNNER.md
+++ b/docs/BACKGROUND_TASK_RUNNER.md
@@ -1,0 +1,47 @@
+# Background Task Runner and Summary UI
+
+## Overview
+
+This design introduces an action for scheduling long-running commands inside ephemeral Docker containers. Users supply a `--yolo` flag with a `-p` prompt that is passed to an OpenAI Codex compatible model (default `gpt-oss:20b`). The task executes in the background, allowing the Chatty Commander interface to remain responsive.
+
+Key goals:
+- Queue and track containerized commands.
+- Summarize recent log output with a separate LLM.
+- Present a minimal 3‑word summary in the UI that refreshes periodically.
+- Offer a kill button (square inside a circle) to terminate the job.
+
+## Architecture
+
+1. **Task Scheduler**
+   - Accepts user request (`--yolo -p <prompt>`) and spins up a Docker container with the given command.
+   - Stores metadata (start time, prompt, model, container id) in a persistent queue.
+
+2. **Log Aggregator**
+   - Streams stdout/stderr from the running container.
+   - Maintains an in‑memory ring buffer of the last _N_ lines for summarization.
+
+3. **Summary Worker**
+   - Periodically invokes an LLM (`gpt-oss:20b` by default, but configurable) to summarize the ring buffer.
+   - Enforces 3‑word output via regex or JSON schema.
+   - Publishes summary snippets to the UI channel.
+
+4. **UI Integration**
+   - Displays a small badge with the rotating 3‑word summary for each active task.
+   - Renders a stop button (square inside circle). Clicking sends a kill signal to the scheduler which stops the container and removes its UI elements.
+   - When the task completes or is killed, the badge and button disappear.
+
+## Configuration
+
+```toml
+[background_tasks]
+summary_model = "gpt-oss:20b"
+refresh_interval_sec = 5
+ring_buffer_lines = 40
+```
+
+## Future Enhancements
+
+- Support arbitrary model selection for both execution and summarization.
+- Persist completed task logs and summaries for later review.
+- Expose an API endpoint to query task status and history.
+- Allow concurrent task execution with fairness policies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 - [API Documentation](API.md) - Comprehensive API reference
 - [OpenAPI Specification](openapi.json) - Machine-readable API spec
+- [Background Task Runner & Summaries](BACKGROUND_TASK_RUNNER.md) - Planned queue and live-summary system
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- outline a new background Docker task runner with live 3-word summaries and stop control
- track the feature in progress and TODO lists
- link design doc in docs index and mention upcoming feature in README

## Testing
- `PYENV_VERSION=3.11.12 uv run pytest -q --maxfail=1` *(fails: assert 1 in (0, None))*

------
https://chatgpt.com/codex/tasks/task_e_689c26ec8e2c832c8b04993c34ffa513