### PR TITLE
feat: enhance sidecar with file viewing

### DIFF
--- a/app/src/lib/sse.ts
+++ b/app/src/lib/sse.ts
@@ -1,5 +1,6 @@
 export interface SSEHandlers {
   chunk?: (data: { id: string; delta: string }) => void;
+  tool?: (data: any) => void;
   done?: () => void;
   error?: (err: any) => void;
 }
@@ -37,6 +38,8 @@ export async function sse(url: string, body: any, handlers: SSEHandlers) {
         }
         if (event === 'chunk') {
           handlers.chunk?.(JSON.parse(data));
+        } else if (event === 'tool') {
+          handlers.tool?.(JSON.parse(data));
         } else if (event === 'done') {
           handlers.done?.();
         }

--- a/app/src/panes/SidecarPane.tsx
+++ b/app/src/panes/SidecarPane.tsx
@@ -1,10 +1,56 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useSidecarStore } from '../stores/sidecar';
+
+const TABS = [
+  { key: 'code', label: 'Code' },
+  { key: 'tests', label: 'Tests' },
+  { key: 'notes', label: 'Notes' },
+  { key: 'diff', label: 'Diff' },
+];
 
 export default function SidecarPane() {
+  const current = useSidecarStore(s => s.current);
+  const close = useSidecarStore(s => s.close);
+  const [tab, setTab] = useState<'code' | 'tests' | 'notes' | 'diff'>('code');
+  const [comment, setComment] = useState('');
+
+  useEffect(() => {
+    if (current?.kind) setTab(current.kind);
+  }, [current]);
+
   return (
-    <section className="h-full p-2">
-      <h2 className="font-semibold mb-2">Sidecar</h2>
-      <div>Open files and notes will appear here.</div>
+    <section className="h-full flex flex-col">
+      <header className="flex items-center justify-between p-2 border-b border-gray-700">
+        <h2 className="font-semibold">{current?.title || 'Sidecar'}</h2>
+        <button onClick={close} aria-label="Close" className="px-2">×</button>
+      </header>
+      <nav className="flex border-b border-gray-700">
+        {TABS.map(t => (
+          <button
+            key={t.key}
+            className={`px-3 py-1 text-sm ${tab === t.key ? 'bg-gray-800' : ''}`}
+            onClick={() => setTab(t.key as any)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+      <div className="flex-1 overflow-auto p-2">
+        {current?.snippet ? (
+          <pre className="text-xs whitespace-pre-wrap">{current.snippet}</pre>
+        ) : (
+          <div className="text-gray-400">Open files and notes will appear here.</div>
+        )}
+      </div>
+      <div className="p-2 border-t border-gray-700">
+        <textarea
+          className="w-full p-2 bg-gray-800"
+          placeholder="Add a comment"
+          value={comment}
+          onChange={e => setComment(e.target.value)}
+        />
+        <button className="mt-2 px-3 py-1 bg-blue-600 rounded">Comment</button>
+      </div>
     </section>
   );
 }

--- a/app/src/stores/sidecar.ts
+++ b/app/src/stores/sidecar.ts
@@ -18,6 +18,14 @@ interface SidecarStore {
 export const useSidecarStore = create<SidecarStore>(set => ({
   open: false,
   current: undefined,
-  set: item => set({ open: true, current: item }),
+  set: item => {
+    set({ open: true, current: item });
+    if (item.contentUrl && !item.snippet) {
+      fetch(item.contentUrl)
+        .then(res => res.text())
+        .then(text => set({ open: true, current: { ...item, snippet: text } }))
+        .catch(() => {});
+    }
+  },
   close: () => set({ open: false, current: undefined }),
 }));

--- a/server/routes/sidecar.ts
+++ b/server/routes/sidecar.ts
@@ -1,9 +1,31 @@
 import { Router } from 'express';
+import { readFile } from 'fs/promises';
+import { exec as execCb } from 'child_process';
+import { promisify } from 'util';
 
+const exec = promisify(execCb);
 const router = Router();
 
-router.get('/file', (req, res) => {
-  res.status(404).end();
+router.get('/file', async (req, res) => {
+  const filePath = req.query.path;
+  if (typeof filePath !== 'string') {
+    res.status(400).json({ error: 'path required' });
+    return;
+  }
+
+  const isDiff = req.query.diff === '1' || req.query.diff === 'true';
+
+  try {
+    if (isDiff) {
+      const { stdout } = await exec(`git diff HEAD -- ${filePath}`);
+      res.json({ content: stdout });
+    } else {
+      const content = await readFile(filePath, 'utf8');
+      res.json({ content });
+    }
+  } catch (err) {
+    res.status(404).json({ error: 'file not found' });
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- expand sidecar panel with tabs, header and comment input
- support file and diff loading through new sidecar API and store
- handle tool events to open files from chat

## Testing
- `pre-commit run --files server/routes/sidecar.ts app/src/stores/sidecar.ts app/src/panes/SidecarPane.tsx app/src/lib/sse.ts app/src/panes/ChatPane.tsx`
- `pnpm test`
- `pnpm --filter ./app test`
- `pnpm --filter ./server test`


------
https://chatgpt.com/codex/tasks/task_e_689c25fc8b74832c84abf5544ed60523