### PR TITLE
feat(chat): virtualized messages and store helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,9 @@ utils/__pycache__/
 htmlcov/
 .venv/
 node_modules/
+# Lockfiles from npm should not be committed; this repo uses pnpm.
+package-lock.json
+**/package-lock.json
 # Other common noise
 .DS_Store
 Thumbs.db

--- a/app/src/panes/ChatPane.tsx
+++ b/app/src/panes/ChatPane.tsx
@@ -1,13 +1,108 @@
-import React, { useState, KeyboardEvent } from 'react';
+import React, { useState, useRef, useEffect, KeyboardEvent } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useChatStore, ChatMessage } from '../stores/chat';
 import { sse } from '../lib/sse';
+
+interface MessageItemProps {
+  message: ChatMessage;
+}
+
+function MessageItem({ message }: MessageItemProps) {
+  const roleStyles: Record<string, string> = {
+    user: 'bg-blue-700 text-white',
+    assistant: 'bg-gray-700 text-white',
+    system: 'bg-yellow-800 text-yellow-100',
+    tool: 'bg-green-700 text-white',
+  };
+
+  const renderBlocks = (text: string) => {
+    const blocks: { type: 'text' | 'code'; value: string }[] = [];
+    const regex = /```(?:\w+)?\n([\s\S]*?)```/g;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(text))) {
+      if (match.index > lastIndex) {
+        blocks.push({ type: 'text', value: text.slice(lastIndex, match.index) });
+      }
+      blocks.push({ type: 'code', value: match[1] });
+      lastIndex = regex.lastIndex;
+    }
+    if (lastIndex < text.length) {
+      blocks.push({ type: 'text', value: text.slice(lastIndex) });
+    }
+    return blocks;
+  };
+
+  return (
+    <div className={`mb-2 p-2 rounded ${roleStyles[message.role] ?? ''}`}>
+      {renderBlocks(message.content[0]?.text ?? '').map((b, i) =>
+        b.type === 'code' ? (
+          <pre key={i} className="relative bg-black bg-opacity-40 p-2 rounded">
+            <button
+              onClick={() => navigator.clipboard.writeText(b.value)}
+              className="absolute top-1 right-1 text-xs text-gray-300 hover:text-white"
+            >
+              copy
+            </button>
+            <code>{b.value}</code>
+          </pre>
+        ) : (
+          <p key={i}>{b.value}</p>
+        ),
+      )}
+    </div>
+  );
+}
+
+function MessageList({ messages }: { messages: ChatMessage[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [range, setRange] = useState({ start: 0, end: 20 });
+  const itemHeight = 64;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const scrollTop = el.scrollTop;
+      const height = el.clientHeight;
+      const start = Math.max(0, Math.floor(scrollTop / itemHeight) - 5);
+      const end = Math.min(
+        messages.length,
+        start + Math.ceil(height / itemHeight) + 10,
+      );
+      setRange({ start, end });
+    };
+    el.addEventListener('scroll', onScroll);
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [messages.length]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length]);
+
+  const slice = messages.slice(range.start, range.end);
+  const topPadding = range.start * itemHeight;
+  const bottomPadding = (messages.length - range.end) * itemHeight;
+
+  return (
+    <div ref={containerRef} className="flex-1 overflow-auto p-2">
+      <div style={{ paddingTop: topPadding, paddingBottom: bottomPadding }}>
+        {slice.map(m => (
+          <MessageItem key={m.id} message={m} />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default function ChatPane() {
   const messages = useChatStore(s => s.messages);
   const push = useChatStore(s => s.push);
   const update = useChatStore(s => s.update);
   const [text, setText] = useState('');
+  const [useSidecar, setUseSidecar] = useState(true);
+  const [useCanvas, setUseCanvas] = useState(true);
 
   const send = async () => {
     const content = text.trim();
@@ -17,6 +112,11 @@ export default function ChatPane() {
       role: 'user',
       createdAt: new Date().toISOString(),
       content: [{ type: 'text', text: content }],
+      contextRef: useSidecar
+        ? { pane: 'sidecar' }
+        : useCanvas
+        ? { pane: 'canvas' }
+        : undefined,
     };
     push(userMsg);
     setText('');
@@ -33,7 +133,12 @@ export default function ChatPane() {
       chunk: ({ delta }) => {
         update(assistantId, m => ({
           ...m,
-          content: [{ type: 'text', text: (m.content?.[0]?.text ?? '') + delta }],
+          content: [
+            {
+              type: 'text',
+              text: (m.content?.[0]?.text ?? '') + delta,
+            },
+          ],
         }));
       },
       done: () => {},
@@ -49,13 +154,9 @@ export default function ChatPane() {
 
   return (
     <section className="h-full flex flex-col" aria-label="Chat">
-      <div className="flex-1 overflow-auto p-2">
-        {messages.map(m => (
-          <div key={m.id} className="mb-2">
-            <div className="text-xs text-gray-400">{m.role}</div>
-            <div>{m.content[0]?.text}</div>
-          </div>
-        ))}
+      <MessageList messages={messages} />
+      <div className="px-2 py-1 text-xs text-yellow-400">
+        Responses may be inaccurate. Do not share sensitive information.
       </div>
       <div className="p-2 border-t border-gray-700">
         <textarea
@@ -65,12 +166,34 @@ export default function ChatPane() {
           onChange={e => setText(e.target.value)}
           onKeyDown={handleKey}
         />
-        <button
-          className="mt-2 px-3 py-1 bg-blue-600 rounded"
-          onClick={send}
-        >
-          Send
-        </button>
+        <div className="flex items-center justify-between mt-2">
+          <div className="text-xs text-gray-300 space-x-2">
+            <label>
+              <input
+                type="checkbox"
+                checked={useSidecar}
+                onChange={e => setUseSidecar(e.target.checked)}
+                className="mr-1"
+              />
+              Sidecar
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={useCanvas}
+                onChange={e => setUseCanvas(e.target.checked)}
+                className="mr-1"
+              />
+              Canvas
+            </label>
+          </div>
+          <button
+            className="px-3 py-1 bg-blue-600 rounded"
+            onClick={send}
+          >
+            Send
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/app/src/stores/chat.ts
+++ b/app/src/stores/chat.ts
@@ -14,7 +14,25 @@ export interface ChatMessage {
 interface ChatStore {
   messages: ChatMessage[];
   push: (m: ChatMessage) => void;
+  /**
+   * Apply a transformation to a message by id.
+   */
   update: (id: string, fn: (m: ChatMessage) => ChatMessage) => void;
+  /**
+   * Replace a message entirely by id.
+   */
+  replace: (id: string, msg: ChatMessage) => void;
+  /**
+   * Summarise the conversation so that the estimated token
+   * count does not exceed the provided budget. The summariser
+   * function is invoked with the messages that were removed
+   * from the start of the conversation and should return a
+   * new summary message.
+   */
+  summariseForBudget: (
+    tokenBudget: number,
+    summariser: (msgs: ChatMessage[]) => ChatMessage,
+  ) => void;
 }
 
 export const useChatStore = create<ChatStore>(set => ({
@@ -22,4 +40,28 @@ export const useChatStore = create<ChatStore>(set => ({
   push: m => set(s => ({ messages: [...s.messages, m] })),
   update: (id, fn) =>
     set(s => ({ messages: s.messages.map(m => (m.id === id ? fn(m) : m)) })),
+  replace: (id, msg) =>
+    set(s => ({ messages: s.messages.map(m => (m.id === id ? msg : m)) })),
+  summariseForBudget: (tokenBudget, summariser) =>
+    set(s => {
+      const estimateTokens = (msgs: ChatMessage[]) =>
+        msgs.reduce(
+          (sum, m) => sum + (m.content?.[0]?.text?.length ?? 0),
+          0,
+        );
+
+      let msgs = [...s.messages];
+      if (estimateTokens(msgs) <= tokenBudget) return { messages: msgs };
+
+      const removed: ChatMessage[] = [];
+      while (msgs.length && estimateTokens(msgs) > tokenBudget) {
+        removed.push(msgs.shift()!);
+      }
+
+      if (removed.length) {
+        msgs.unshift(summariser(removed));
+      }
+
+      return { messages: msgs };
+    }),
 }));


### PR DESCRIPTION
## Summary
- add role-based message styling with copyable code fences and a virtualized list
- include system notice banner and toggles in the chat composer
- extend chat store with replace and summariseForBudget helpers

## Testing
- `pnpm -C app build`
- `pnpm test`
- `pytest` *(fails: pyenv: version `3.11.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c25f99750832c805696964de82f5c