### PR TITLE
feat: add sidecar file API and pane support

### DIFF
--- a/app/src/lib/sse.ts
+++ b/app/src/lib/sse.ts
@@ -1,4 +1,5 @@
 export interface SSEHandlers {
+  [event: string]: ((data: any) => void) | undefined;
   chunk?: (data: { id: string; delta: string }) => void;
   done?: () => void;
   error?: (err: any) => void;
@@ -39,6 +40,12 @@ export async function sse(url: string, body: any, handlers: SSEHandlers) {
           handlers.chunk?.(JSON.parse(data));
         } else if (event === 'done') {
           handlers.done?.();
+        } else if (event && handlers[event]) {
+          try {
+            (handlers[event] as any)(JSON.parse(data));
+          } catch {
+            (handlers[event] as any)(data);
+          }
         }
       }
     }

--- a/app/src/panes/ChatPane.tsx
+++ b/app/src/panes/ChatPane.tsx
@@ -2,11 +2,13 @@ import React, { useState, KeyboardEvent } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useChatStore, ChatMessage } from '../stores/chat';
 import { sse } from '../lib/sse';
+import { useSidecarStore } from '../stores/sidecar';
 
 export default function ChatPane() {
   const messages = useChatStore(s => s.messages);
   const push = useChatStore(s => s.push);
   const update = useChatStore(s => s.update);
+  const setSidecar = useSidecarStore(s => s.set);
   const [text, setText] = useState('');
 
   const send = async () => {
@@ -37,6 +39,9 @@ export default function ChatPane() {
         }));
       },
       done: () => {},
+      'sidecar.open': data => {
+        setSidecar(data);
+      },
     });
   };
 

--- a/app/src/panes/SidecarPane.tsx
+++ b/app/src/panes/SidecarPane.tsx
@@ -1,10 +1,64 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSidecarStore } from '../stores/sidecar';
+
+type Tab = 'code' | 'tests' | 'notes' | 'diff';
+const TABS: { value: Tab; label: string }[] = [
+  { value: 'code', label: 'Code' },
+  { value: 'tests', label: 'Tests' },
+  { value: 'notes', label: 'Notes' },
+  { value: 'diff', label: 'Diff' },
+];
 
 export default function SidecarPane() {
+  const { open, current } = useSidecarStore();
+  const [active, setActive] = useState<Tab>('code');
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    if (current) {
+      setActive(current.kind);
+      if (current.contentUrl) {
+        fetch(current.contentUrl)
+          .then(r => r.text())
+          .then(setContent)
+          .catch(() => setContent(''));
+      } else {
+        setContent(current.snippet || '');
+      }
+    } else {
+      setContent('');
+    }
+  }, [current]);
+
+  if (!open || !current) {
+    return (
+      <section className="h-full p-2">
+        <h2 className="font-semibold mb-2">Sidecar</h2>
+        <div>Open files and notes will appear here.</div>
+      </section>
+    );
+  }
+
   return (
-    <section className="h-full p-2">
-      <h2 className="font-semibold mb-2">Sidecar</h2>
-      <div>Open files and notes will appear here.</div>
+    <section className="h-full flex flex-col">
+      <div className="flex border-b border-gray-700">
+        {TABS.map(t => (
+          <button
+            key={t.value}
+            className={`px-3 py-1 ${active === t.value ? 'bg-gray-800' : ''}`}
+            onClick={() => setActive(t.value)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex-1 overflow-auto p-2">
+        {content ? (
+          <pre className="whitespace-pre-wrap">{content}</pre>
+        ) : (
+          <div>No content</div>
+        )}
+      </div>
     </section>
   );
 }

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,8 @@
   },
   "devDependencies": {
     "typescript": "^5.0.0",
-    "ts-node-dev": "^2.0.0"
+    "ts-node-dev": "^2.0.0",
+    "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.13"
   }
 }

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -2,8 +2,19 @@ import { Router } from 'express';
 
 const router = Router();
 
+// Minimal chat handler that can emit tool-call events. When the request body
+// contains `{ tool: { name: 'sidecar.open', input: {...} } }` an SSE event is
+// streamed to the client so the UI can react to the tool call.
 router.post('/', (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');
+
+  const tool = req.body?.tool;
+  if (tool?.name === 'sidecar.open') {
+    const payload = JSON.stringify(tool.input || {});
+    res.write('event: sidecar.open\n');
+    res.write(`data: ${payload}\n\n`);
+  }
+
   res.write('event: done\n');
   res.write('data: {}\n\n');
   res.end();

--- a/server/routes/sidecar.ts
+++ b/server/routes/sidecar.ts
@@ -1,9 +1,55 @@
 import { Router } from 'express';
+import path from 'path';
+import fs from 'fs';
+import { createHmac } from 'crypto';
 
 const router = Router();
+const SECRET = process.env.SIDECAR_SECRET || 'dev-secret';
 
+function sign(p: string) {
+  return createHmac('sha256', SECRET).update(p).digest('hex');
+}
+
+// Generate a signed URL for the requested file. The returned URL can be used
+// to fetch the file contents via `/api/sidecar/file/content`.
 router.get('/file', (req, res) => {
-  res.status(404).end();
+  const file = req.query.path as string;
+  if (!file) {
+    res.status(400).json({ error: 'path required' });
+    return;
+  }
+
+  const abs = path.resolve(file);
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+
+  const url = `/api/sidecar/file/content?path=${encodeURIComponent(abs)}&sig=${sign(abs)}`;
+  res.json({ url });
+});
+
+// Serve file contents after verifying the signature.
+router.get('/file/content', (req, res) => {
+  const file = req.query.path as string;
+  const sig = req.query.sig as string;
+  if (!file || !sig) {
+    res.status(400).end();
+    return;
+  }
+
+  const abs = path.resolve(file);
+  if (sig !== sign(abs)) {
+    res.status(403).end();
+    return;
+  }
+
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+    res.status(404).end();
+    return;
+  }
+
+  res.sendFile(abs);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- sign and serve sidecar files with simple HMAC based URLs
- stream `sidecar.open` tool call events from chat endpoint
- add tabbed sidecar pane wired to SSE events

## Testing
- `pnpm build` (app)
- `pnpm build` (server)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689c25eeb3b4832c85072e48b45afae6