### PR TITLE
feat: stream console logs via SSE and capture canvas logs

### DIFF
--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,7 +1,42 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useCanvasStore } from '../stores/canvas';
+
+const iframeSrcDoc = `
+<script>
+const send = line => parent.postMessage({ type: 'canvas:log', line }, '*');
+['log','warn','error'].forEach(m => {
+  const orig = console[m];
+  console[m] = (...args) => { send(args.join(' ')); orig.apply(console, args); };
+});
+</script>
+`;
 
 export default function CanvasPane() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const logs = useCanvasStore(s => s.logs);
+  const addLog = useCanvasStore(s => s.addLog);
+
+  useEffect(() => {
+    const es = new EventSource('/api/console/stream');
+    es.addEventListener('line', (e) => {
+      try {
+        const data = JSON.parse((e as MessageEvent).data);
+        if (data?.line) addLog(data.line);
+      } catch {}
+    });
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'canvas:log') {
+        addLog(event.data.line);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => {
+      es.close();
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [addLog]);
+
   return (
     <section className="flex-1 flex flex-col">
       <iframe
@@ -9,9 +44,12 @@ export default function CanvasPane() {
         title="canvas"
         sandbox="allow-scripts allow-downloads"
         className="flex-1 bg-white"
+        srcDoc={iframeSrcDoc}
       />
       <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
-        Console output...
+        {logs.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
       </div>
     </section>
   );

--- a/server/routes/console.ts
+++ b/server/routes/console.ts
@@ -1,11 +1,53 @@
-import { Router } from 'express';
+import { Router, Response } from 'express';
 
 const router = Router();
 
+const clients: Response[] = [];
+
+function broadcastLine(level: string, line: string) {
+  const payload = `event: line\ndata: ${JSON.stringify({ level, line })}\n\n`;
+  for (const client of clients) {
+    client.write(payload);
+  }
+}
+
 router.get('/stream', (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  clients.push(res);
+
   res.write('event: line\n');
-  res.write('data: {"level":"info","line":"ready"}\n\n');
+  res.write(`data: ${JSON.stringify({ level: 'info', line: 'ready' })}\n\n`);
+
+  req.on('close', () => {
+    const idx = clients.indexOf(res);
+    if (idx !== -1) {
+      clients.splice(idx, 1);
+    }
+  });
 });
 
+const originalLog = console.log;
+const originalError = console.error;
+const originalWarn = console.warn;
+
+console.log = (...args: any[]) => {
+  broadcastLine('info', args.join(' '));
+  originalLog.apply(console, args);
+};
+
+console.error = (...args: any[]) => {
+  broadcastLine('error', args.join(' '));
+  originalError.apply(console, args);
+};
+
+console.warn = (...args: any[]) => {
+  broadcastLine('warn', args.join(' '));
+  originalWarn.apply(console, args);
+};
+
+export { broadcastLine };
 export default router;


### PR DESCRIPTION
## Summary
- Stream server console output to clients via `/api/console/stream`
- Forward iframe console messages to parent window and display canvas logs

## Testing
- `npm --prefix server test`
- `npm --prefix server run build` *(fails: Could not find a declaration file for module 'express')*
- `npm --prefix app test`
- `./run_tests.sh` *(fails: pyenv: version `3.11.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c25ee6214832c926cfae3fd1d4648