### PR TITLE
feat: add global hotkey handler and accessibility

### DIFF
--- a/app/src/app-shell/Grid.tsx
+++ b/app/src/app-shell/Grid.tsx
@@ -7,15 +7,30 @@ interface Props {
 export default function GridLayout({ children }: Props) {
   return (
     <div className="flex flex-1 overflow-hidden">
-      <div className="w-90 border-r border-gray-700 overflow-y-auto" aria-label="Chat">
+      <section
+        id="chat-pane"
+        className="w-90 border-r border-gray-700 overflow-y-auto"
+        aria-label="Chat"
+        tabIndex={-1}
+      >
         {children[0]}
-      </div>
-      <div className="flex-1 flex flex-col" aria-label="Canvas">
+      </section>
+      <section
+        id="canvas-pane"
+        className="flex-1 flex flex-col"
+        aria-label="Canvas"
+        tabIndex={-1}
+      >
         {children[1]}
-      </div>
-      <div className="w-130 border-l border-gray-700 overflow-y-auto" aria-label="Review">
+      </section>
+      <section
+        id="review-pane"
+        className="w-130 border-l border-gray-700 overflow-y-auto"
+        aria-label="Review"
+        tabIndex={-1}
+      >
         {children[2]}
-      </div>
+      </section>
     </div>
   );
 }

--- a/app/src/lib/hotkeys.ts
+++ b/app/src/lib/hotkeys.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { useSettingsStore } from '../stores/settings';
+
+function isMac() {
+  return typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+}
+
+export function useGlobalHotkeys() {
+  const reducedMotion = useSettingsStore(s => s.reducedMotion);
+
+  useEffect(() => {
+    const focusPane = (id: string) => {
+      const el = document.getElementById(id);
+      if (el) {
+        (el as HTMLElement).focus();
+        el.scrollIntoView({
+          behavior: reducedMotion ? 'auto' : 'smooth',
+          block: 'nearest',
+          inline: 'nearest',
+        });
+      }
+    };
+
+    const handler = (e: KeyboardEvent) => {
+      const meta = isMac() ? e.metaKey : e.ctrlKey;
+      const key = e.key;
+
+      if (meta && key.toLowerCase() === 'k') {
+        e.preventDefault();
+        (document.getElementById('chat-input') as HTMLElement | null)?.focus();
+      } else if (meta && key === 'Enter') {
+        e.preventDefault();
+        window.dispatchEvent(new Event('chat:send'));
+      } else if (e.altKey && ['1', '2', '3'].includes(key)) {
+        e.preventDefault();
+        if (key === '1') focusPane('chat-pane');
+        if (key === '2') focusPane('canvas-pane');
+        if (key === '3') focusPane('review-pane');
+      } else if (key === '`') {
+        e.preventDefault();
+        focusPane('console-pane');
+      } else if (key === 'F1') {
+        e.preventDefault();
+        window.open('/docs', '_blank');
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [reducedMotion]);
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -5,9 +5,11 @@ import GridLayout from './app-shell/Grid';
 import ChatPane from './panes/ChatPane';
 import CanvasPane from './panes/CanvasPane';
 import SidecarPane from './panes/SidecarPane';
+import { useGlobalHotkeys } from './lib/hotkeys';
 import './styles/index.css';
 
 function App() {
+  useGlobalHotkeys();
   return (
     <div className="h-screen flex flex-col bg-gray-900 text-gray-100">
       <TopBar />

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -10,7 +10,12 @@ export default function CanvasPane() {
         sandbox="allow-scripts allow-downloads"
         className="flex-1 bg-white"
       />
-      <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
+      <div
+        id="console-pane"
+        className="h-40 overflow-auto bg-black text-green-400 text-xs p-2"
+        aria-label="Console"
+        tabIndex={-1}
+      >
         Console output...
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add `section` elements with ARIA labels and focus ids for grid panes
- implement central hotkey handler respecting reduced motion
- wire chat pane to handler and expose console focusing

## Testing
- `npm test`
- `./run_tests.sh` *(fails: pyenv version `3.11.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c25fe66a8832cbfd7c89de6828edd