### PR TITLE
Add CSP middleware and harden ASCII-safe mode

### DIFF
--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -57,7 +57,8 @@ export default function CanvasPane() {
     if (!doc) return;
     const script = doc.createElement('script');
     script.textContent = `
-      Object.defineProperty(window, 'localStorage', { value: undefined });
+      Object.defineProperty(window, 'localStorage', { get: () => undefined });
+      Object.defineProperty(window, 'sessionStorage', { get: () => undefined });
       Object.defineProperty(window, 'indexedDB', { value: undefined });
     `;
     doc.head.appendChild(script);

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -51,6 +51,17 @@ export default function CanvasPane() {
     };
   }, [addLog, asciiOnly, setStatus]);
 
+  useEffect(() => {
+    if (!asciiOnly || !iframeRef.current) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    const script = doc.createElement('script');
+    script.textContent = `
+      Object.defineProperty(window, 'localStorage', { value: undefined });
+      Object.defineProperty(window, 'indexedDB', { value: undefined });
+    `;
+    doc.head.appendChild(script);
+  }, [asciiOnly]);
   return (
     <section className="flex-1 flex flex-col bg-gray-900">
       <iframe

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,11 +4,11 @@ import chat from "./routes/chat.js";
 import canvas from "./routes/canvas.js";
 import consoleRoute from "./routes/console.js";
 import sidecar from "./routes/sidecar.js";
-import { cspHeaders } from "./middleware/csp.js";
+import { csp } from "./middleware/csp.js";
 
 const app = express();
 app.use(cors());
-app.use(cspHeaders);
+app.use(csp);
 app.use(express.json());
 
 app.use("/api/chat", chat);

--- a/server/middleware/csp.ts
+++ b/server/middleware/csp.ts
@@ -1,19 +1,11 @@
-import { Request, Response, NextFunction } from "express";
+import helmet from 'helmet';
 
-export function cspHeaders(req: Request, res: Response, next: NextFunction) {
-  const policy = [
-    "default-src 'self'",
-    "base-uri 'self'",
-    "block-all-mixed-content",
-    "font-src 'self' https: data:",
-    "frame-ancestors 'self'",
-    "img-src 'self' data:",
-    "object-src 'none'",
-    "script-src 'self'",
-    "script-src-attr 'none'",
-    "style-src 'self' https: 'unsafe-inline'",
-    "upgrade-insecure-requests",
-  ].join("; ");
-  res.setHeader("Content-Security-Policy", policy);
-  next();
-}
+export const csp = helmet.contentSecurityPolicy({
+  useDefaults: true,
+  directives: {
+    defaultSrc: ["'self'"],
+    scriptSrc: ["'self'"],
+    objectSrc: ["'none'"],
+    baseUri: ["'self'"]
+  }
+});

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,9 @@
     "@types/node": "^24.3.3",
     "esbuild": "^0.20.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.0.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "helmet": "^7.2.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Summary
- enforce Content Security Policy via helmet
- block localStorage and IndexedDB when ASCII-safe mode is on
- add helmet dependency and audit code for eval usage

## Testing
- `pre-commit run --files server/index.ts server/middleware/csp.ts app/src/panes/CanvasPane.tsx server/package.json`
- `pnpm test`
- `pnpm --filter chatty-commander-server build` *(fails: Could not find declaration file for module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689c25efbc5c832c95e5b78ba5a9ad8c