### PR TITLE
feat: wire canvas bundle and messaging

### DIFF
--- a/app/src/lib/bus.ts
+++ b/app/src/lib/bus.ts
@@ -1,0 +1,22 @@
+export type BusHandler<T = any> = (data: T) => void;
+
+// Registered listeners for postMessage events.
+const listeners: Record<string, BusHandler[]> = {};
+
+// Listen for messages from iframe or other windows.
+window.addEventListener('message', evt => {
+  const { type, payload } = (evt.data || {}) as { type?: string; payload?: any };
+  if (!type) return;
+  (listeners[type] || []).forEach(fn => fn(payload));
+});
+
+export function on<T = any>(type: string, handler: BusHandler<T>) {
+  (listeners[type] ||= []).push(handler);
+  return () => {
+    listeners[type] = (listeners[type] || []).filter(h => h !== handler);
+  };
+}
+
+export function post(win: Window | null | undefined, type: string, payload?: any) {
+  win?.postMessage({ type, payload }, '*');
+}

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,7 +1,49 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { on, post } from '../lib/bus';
+import { useCanvasStore } from '../stores/canvas';
 
 export default function CanvasPane() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const { logs, addLog, setStatus, asciiOnly } = useCanvasStore();
+
+  useEffect(() => {
+    let readyOff: (() => void) | undefined;
+    let logOff: (() => void) | undefined;
+
+    async function load() {
+      setStatus('loading');
+      try {
+        const res = await fetch('/api/canvas/build', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ asciiOnly })
+        });
+        const data = await res.json();
+        if (iframeRef.current) {
+          iframeRef.current.src = data.bundleUrl;
+        }
+      } catch (err) {
+        setStatus('error');
+      }
+
+      readyOff = on('canvas:ready', () => {
+        setStatus('ready');
+        post(iframeRef.current?.contentWindow, 'canvas:init');
+      });
+
+      logOff = on<string>('canvas:log', line => {
+        addLog(line);
+      });
+    }
+
+    load();
+
+    return () => {
+      readyOff?.();
+      logOff?.();
+    };
+  }, [asciiOnly, setStatus, addLog]);
+
   return (
     <section className="flex-1 flex flex-col">
       <iframe
@@ -11,7 +53,9 @@ export default function CanvasPane() {
         className="flex-1 bg-white"
       />
       <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
-        Console output...
+        {logs.map((line, i) => (
+          <div key={i}>{line}</div>
+        ))}
       </div>
     </section>
   );

--- a/server/routes/canvas.ts
+++ b/server/routes/canvas.ts
@@ -1,9 +1,17 @@
 import { Router } from 'express';
+import { build } from '../services/builder.js';
 
 const router = Router();
 
-router.post('/build', (req, res) => {
-  res.json({ bundleUrl: '', version: '0.0.0', sha256: '' });
+// Build the canvas bundle and return metadata needed by the client.
+router.post('/build', async (req, res, next) => {
+  try {
+    const { entry, asciiOnly } = req.body || {};
+    const result = await build(entry, asciiOnly);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- implement /api/canvas/build endpoint to return bundle metadata
- add message bus bridging postMessage events for canvas iframe
- load canvas bundle and route log messages to canvas store

## Testing
- `pnpm --filter ./app test`
- `pnpm --filter ./server test`
- `pnpm test`
- `pnpm --filter ./app build`
- `pnpm --filter ./server build` *(fails: Could not find a declaration file for module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_689c25fb0770832cadc6ae0623782921