### PR TITLE
feat: stream chat events and handle tool outputs

### DIFF
--- a/app/src/lib/sse.ts
+++ b/app/src/lib/sse.ts
@@ -1,5 +1,7 @@
 export interface SSEHandlers {
   chunk?: (data: { id: string; delta: string }) => void;
+  tool_call?: (data: any) => void;
+  tool_result?: (data: any) => void;
   done?: () => void;
   error?: (err: any) => void;
 }
@@ -35,8 +37,13 @@ export async function sse(url: string, body: any, handlers: SSEHandlers) {
           if (line.startsWith('event:')) event = line.replace('event:', '').trim();
           if (line.startsWith('data:')) data += line.replace('data:', '').trim();
         }
+        const json = data ? JSON.parse(data) : {};
         if (event === 'chunk') {
-          handlers.chunk?.(JSON.parse(data));
+          handlers.chunk?.(json);
+        } else if (event === 'tool_call') {
+          handlers.tool_call?.(json);
+        } else if (event === 'tool_result') {
+          handlers.tool_result?.(json);
         } else if (event === 'done') {
           handlers.done?.();
         }

--- a/app/src/panes/ChatPane.tsx
+++ b/app/src/panes/ChatPane.tsx
@@ -36,6 +36,20 @@ export default function ChatPane() {
           content: [{ type: 'text', text: (m.content?.[0]?.text ?? '') + delta }],
         }));
       },
+      tool_call: ({ id }) => {
+        push({
+          id,
+          role: 'tool',
+          createdAt: new Date().toISOString(),
+          content: [{ type: 'text', text: '' }],
+        });
+      },
+      tool_result: ({ id, delta }) => {
+        update(id, m => ({
+          ...m,
+          content: [{ type: 'text', text: (m.content?.[0]?.text ?? '') + delta }],
+        }));
+      },
       done: () => {},
     });
   };

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -2,10 +2,21 @@ import { Router } from 'express';
 
 const router = Router();
 
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');
-  res.write('event: done\n');
-  res.write('data: {}\n\n');
+
+  const send = (event: string, data: any) => {
+    res.write(`event: ${event}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  // simulate streaming of an assistant response with a tool call
+  send('chunk', { id: 'assistant', delta: 'Hello from ChattyCommander. ' });
+  send('tool_call', { id: 'tool-1', name: 'clock' });
+  send('tool_result', { id: 'tool-1', delta: 'The current time is high noon.' });
+  send('chunk', { id: 'assistant', delta: 'Hope that helps!' });
+  send('done', {});
+
   res.end();
 });
 


### PR DESCRIPTION
## Summary
- stream chat SSE responses including chunk, tool_call, tool_result, and done events
- add frontend SSE helper to dispatch new events
- update chat pane to handle tool messages and results

## Testing
- `./run_tests.sh` *(fails: pyenv: version `3.11.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c25fa8eb4832cbff2b86640dfbbfe