### PR TITLE
feat: initialize canvas pane via bundle

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "zustand": "^4.4.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.11",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",

--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -1,6 +1,6 @@
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [tailwindcss(), autoprefixer()],
 };

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,22 +1,55 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createBus } from '../lib/bus';
+import { useCanvasStore } from '../stores/canvas';
 
 export default function CanvasPane() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [log, setLog] = useState<string[]>([]);
+  const { logs, addLog, setStatus, asciiOnly } = useCanvasStore((s) => ({
+    logs: s.logs,
+    addLog: s.addLog,
+    setStatus: s.setStatus,
+    asciiOnly: s.asciiOnly,
+  }));
 
   useEffect(() => {
     const iframe = iframeRef.current;
-    if (!iframe || !iframe.contentWindow) return;
-    const bus = createBus(iframe.contentWindow);
-    const off = bus.onAny((type, payload) => {
-      if (type.startsWith('canvas:')) {
-        setLog((l) => [...l, `${type}: ${JSON.stringify(payload)}`]);
+    if (!iframe) return;
+
+    let off: (() => void) | undefined;
+
+    async function load() {
+      setStatus('loading');
+      try {
+        const res = await fetch('/api/canvas/build', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ asciiOnly }),
+        });
+        const info = await res.json();
+        iframe.src = info.bundleUrl;
+        iframe.onload = () => {
+          if (!iframe.contentWindow) return;
+          const bus = createBus(iframe.contentWindow);
+          off = bus.onAny((type, payload) => {
+            if (type.startsWith('canvas:')) {
+              addLog(`${type}: ${JSON.stringify(payload)}`);
+            }
+          });
+          bus.post('canvas:init', info);
+          setStatus('ready');
+        };
+      } catch (err: any) {
+        addLog(`error: ${err.message}`);
+        setStatus('error');
       }
-    });
-    bus.post('canvas:ready');
-    return () => off();
-  }, []);
+    }
+
+    load();
+
+    return () => {
+      off?.();
+    };
+  }, [addLog, asciiOnly, setStatus]);
 
   return (
     <section className="flex-1 flex flex-col bg-gray-900">
@@ -27,7 +60,7 @@ export default function CanvasPane() {
         className="flex-1 bg-gray-800"
       />
       <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
-        {log.map((l, i) => (
+        {logs.map((l, i) => (
           <div key={i}>{l}</div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- load canvas bundle in CanvasPane and post `canvas:init`
- log canvas bus traffic through zustand store
- configure Tailwind via `@tailwindcss/postcss`

## Testing
- `pnpm --filter ./app test`
- `pnpm --filter ./app build`


------
https://chatgpt.com/codex/tasks/task_e_689cfc117c78832cb7c8c0202b4715f1