### PR TITLE
Initialize canvas iframe runtime

### DIFF
--- a/app/src/lib/iframe-runtime.ts
+++ b/app/src/lib/iframe-runtime.ts
@@ -1,8 +1,0 @@
-import { createBus } from './bus';
-
-const bus = createBus(window.parent);
-
-bus.post('canvas:ready');
-
-export default bus;
-

--- a/app/src/lib/iframe-runtime.ts
+++ b/app/src/lib/iframe-runtime.ts
@@ -1,0 +1,8 @@
+import { createBus } from './bus';
+
+const bus = createBus(window.parent);
+
+bus.post('canvas:ready');
+
+export default bus;
+

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+// Render a sandboxed iframe for canvas experiments
+
 export default function CanvasPane() {
   return (
     <section className="flex-1 flex flex-col bg-gray-900">

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,43 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { createBus } from '../lib/bus';
-
-const RUNTIME_SRC = `<!DOCTYPE html>
-<html>
-  <body class="bg-gray-800">
-    <script type="module" src="/src/lib/iframe-runtime.ts"></script>
-  </body>
-</html>`;
+import React from 'react';
 
 export default function CanvasPane() {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [log, setLog] = useState<string[]>([]);
-
-  useEffect(() => {
-    const iframe = iframeRef.current;
-    if (!iframe || !iframe.contentWindow) return;
-    const bus = createBus(iframe.contentWindow);
-    const off = bus.onAny((type, payload) => {
-      if (type.startsWith('canvas:')) {
-        setLog((l) => [...l, `${type}: ${JSON.stringify(payload)}`]);
-      }
-    });
-    return () => off();
-  }, []);
-
   return (
     <section className="flex-1 flex flex-col bg-gray-900">
       <iframe
-        ref={iframeRef}
         title="canvas"
         sandbox="allow-scripts allow-downloads"
         className="flex-1 bg-gray-800"
-        srcDoc={RUNTIME_SRC}
       />
-      <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
-        {log.map((l, i) => (
-          <div key={i}>{l}</div>
-        ))}
-      </div>
     </section>
   );
 }

--- a/app/src/panes/CanvasPane.tsx
+++ b/app/src/panes/CanvasPane.tsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { createBus } from '../lib/bus';
 
+const RUNTIME_SRC = `<!DOCTYPE html>
+<html>
+  <body class="bg-gray-800">
+    <script type="module" src="/src/lib/iframe-runtime.ts"></script>
+  </body>
+</html>`;
+
 export default function CanvasPane() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [log, setLog] = useState<string[]>([]);
@@ -14,7 +21,6 @@ export default function CanvasPane() {
         setLog((l) => [...l, `${type}: ${JSON.stringify(payload)}`]);
       }
     });
-    bus.post('canvas:ready');
     return () => off();
   }, []);
 
@@ -25,6 +31,7 @@ export default function CanvasPane() {
         title="canvas"
         sandbox="allow-scripts allow-downloads"
         className="flex-1 bg-gray-800"
+        srcDoc={RUNTIME_SRC}
       />
       <div className="h-40 overflow-auto bg-black text-green-400 text-xs p-2" aria-label="Console">
         {log.map((l, i) => (


### PR DESCRIPTION
## Summary
- Embed iframe runtime script in CanvasPane to initialize canvas sandbox.
- Add `iframe-runtime.ts` that posts a ready message to the parent window.

## Testing
- `npm test`
- `npm --prefix app run build` *(fails: `@tailwindcss/postcss` plugin missing)*
- `pytest -q` *(fails: pyenv Python 3.11.6 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689cf9bf3ad4832c9c035ebce7f08954