### PR TITLE
Fix ruff lint issues

### DIFF
--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -72,7 +72,7 @@ class Config:
         self.web_host = host
         self.web_port = port
         self.web_auth_enabled = auth
-        
+
     @staticmethod
     def _get_int_env(var_name: str, fallback: int) -> int:
         """Return an integer from the environment or the provided fallback."""
@@ -269,7 +269,7 @@ class Config:
     def _load_config(self):
         """Load configuration from file or defaults."""
         try:
-            with open(self.config_file, 'r', encoding='utf-8') as f:
+            with open(self.config_file, encoding='utf-8') as f:
                 return json.load(f)
         except FileNotFoundError:
             logger.warning(f"Config file {self.config_file} not found. Using defaults.")
@@ -345,7 +345,6 @@ class Config:
         update_check_config = self.config_data.get("update_check", {})
 
         enabled = update_check_config.get("enabled", False)
-        url = update_check_config.get("url", "https://api.github.com/repos/username/repo/releases/latest")
         interval_hours = update_check_config.get("interval_hours", 24)
 
         if not enabled:

--- a/src/chatty_commander/llm/backends.py
+++ b/src/chatty_commander/llm/backends.py
@@ -64,7 +64,7 @@ class OpenAIBackend(LLMBackend):
 
         try:
             # Test with a minimal request
-            response = self._client.chat.completions.create(
+            self._client.chat.completions.create(
                 model="gpt-3.5-turbo",
                 messages=[{"role": "user", "content": "test"}],
                 max_tokens=1

--- a/src/chatty_commander/llm/manager.py
+++ b/src/chatty_commander/llm/manager.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import Any
 
 from .backends import (

--- a/src/chatty_commander/llm/processor.py
+++ b/src/chatty_commander/llm/processor.py
@@ -48,7 +48,7 @@ class CommandProcessor:
     def process_command(self, user_input: str) -> tuple[str | None, float, str]:
         """
         Process natural language command.
-        
+
         Returns:
             Tuple of (command_name, confidence, explanation)
         """
@@ -121,7 +121,7 @@ class CommandProcessor:
         """Build prompt for LLM command interpretation."""
         available_commands = list(self._available_commands.keys())
 
-        prompt = f"""You are a voice assistant command interpreter. 
+        prompt = f"""You are a voice assistant command interpreter.
 
 Available commands: {', '.join(available_commands)}
 

--- a/src/chatty_commander/main.py
+++ b/src/chatty_commander/main.py
@@ -551,7 +551,6 @@ def main():
         config_cli.run_wizard()
         return 0
     elif getattr(args, "web", False):
-        no_auth = not auth_enabled
         # Ensure web_server config exists and reflect CLI overrides
         if not hasattr(config, "web_server") or config.web_server is None:
             config.web_server = {}

--- a/src/chatty_commander/voice/tts.py
+++ b/src/chatty_commander/voice/tts.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Light‑weight text‑to‑speech helpers.
 
 This module provides a small facade around optional text‑to‑speech backends.  The
@@ -9,8 +7,10 @@ missing the system gracefully falls back to an in‑memory mock backend so unit
 tests can run without additional requirements.
 """
 
-from abc import ABC, abstractmethod
+from __future__ import annotations
+
 import logging
+from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
 

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -661,11 +661,7 @@ class WebModeServer:
         env_port = os.getenv("CHATCOMM_PORT")
         env_log_level = os.getenv("CHATCOMM_LOG_LEVEL")
 
-        cfg = getattr(self.config_manager, "web_server", {}) or {}
-#         if host is None:
-#             host = cfg.get("host", "0.0.0.0")
-#         if port is None:
-#             port = int(cfg.get("port", 8100))
+        # Prefer configuration defaults when explicit host/port not provided
         if host is None and getattr(self.config_manager, "web_server", None):
             host = self.config_manager.web_server.get("host", "0.0.0.0")
         if port is None and getattr(self.config_manager, "web_server", None):
@@ -775,7 +771,7 @@ def create_app(no_auth: bool = True, config: Config | None = None) -> FastAPI:
             cfg_origins = web_cfg.get("allowed_origins") if isinstance(web_cfg, dict) else None
             if isinstance(cfg_origins, str):
                 origins = [cfg_origins]
-            elif isinstance(cfg_origins, (list, tuple)):
+            elif isinstance(cfg_origins, list | tuple):
                 origins = [str(o) for o in cfg_origins]
         # Fall back to environment variable
         if origins is None:


### PR DESCRIPTION
## Summary
- remove unused variables and tidy whitespace flagged by ruff
- reorder TTS module imports so docstring precedes them
- simplify web CORS origin type check to new `|` syntax

## Testing
- `uv run ruff check .`
- `uv run pytest` *(fails: TypeError: run_orchestrator_mode...)*

------
https://chatgpt.com/codex/tasks/task_e_689d0cc16468832ca4a7eff333d34b0c