### PR TITLE
feat: validate canvas build input

### DIFF
--- a/server/routes/canvas.ts
+++ b/server/routes/canvas.ts
@@ -4,12 +4,16 @@ import { build } from '../services/builder.js';
 const router = Router();
 
 router.post('/build', async (req, res) => {
-  const { entry = '' } = req.body || {};
+  const entry = req.body?.entry;
+  if (typeof entry !== 'string' || entry.length === 0) {
+    res.status(400).json({ error: 'entry is required' });
+    return;
+  }
   try {
     const result = await build(entry);
     res.json(result);
   } catch (err: any) {
-    res.status(500).json({ error: err.message });
+    res.status(500).json({ error: err?.message || String(err) });
   }
 });
 


### PR DESCRIPTION
## Summary
- validate `entry` is provided before building a canvas bundle
- respond with 400 on missing `entry` and return bundle metadata when present
- harden error handling for `/api/canvas/build`

## Testing
- `pnpm --filter ./server test`
- `pnpm --filter ./server build`


------
https://chatgpt.com/codex/tasks/task_e_689cfc127630832c951c8e0aad57da4b