### PR TITLE
feat: add CSP middleware

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,9 +4,11 @@ import chat from './routes/chat.js';
 import canvas from './routes/canvas.js';
 import consoleRoute from './routes/console.js';
 import sidecar from './routes/sidecar.js';
+import { cspHeaders } from './middleware/csp.js';
 
 const app = express();
 app.use(cors());
+app.use(cspHeaders);
 app.use(express.json());
 
 app.use('/api/chat', chat);

--- a/server/middleware/csp.ts
+++ b/server/middleware/csp.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function cspHeaders(req: Request, res: Response, next: NextFunction) {
+  const policy = [
+    "default-src 'self'",
+    "base-uri 'self'",
+    'block-all-mixed-content',
+    "font-src 'self' https: data:",
+    "frame-ancestors 'self'",
+    "img-src 'self' data:",
+    "object-src 'none'",
+    "script-src 'self'",
+    "script-src-attr 'none'",
+    "style-src 'self' https: 'unsafe-inline'",
+    'upgrade-insecure-requests',
+  ].join('; ');
+  res.setHeader('Content-Security-Policy', policy);
+  next();
+}


### PR DESCRIPTION
## Summary
- add CSP middleware with restrictive defaults
- apply middleware to Express server

## Testing
- `npm test`
- `npm --prefix server run build` *(fails: Could not find a declaration file for module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_689c25fdeef8832c8dfeba90feb73725