### PR TITLE
Use shared ASCII utilities in canvas builder

### DIFF
--- a/workers/canvas-builder.ts
+++ b/workers/canvas-builder.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import { fileURLToPath } from 'url';
+import { assertASCII } from '@shared/ascii';
 
 /**
  * Build a browser bundle for a given entry file.
@@ -16,6 +17,7 @@ export async function buildCanvas(entry: string) {
   await fs.mkdir(outDir, { recursive: true });
 
   const absEntry = path.isAbsolute(entry) ? entry : path.join(root, entry);
+  assertASCII(absEntry);
   const tmpOut = path.join(outDir, 'bundle.js');
 
   await build({

--- a/workers/tsconfig.json
+++ b/workers/tsconfig.json
@@ -4,7 +4,11 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "esModuleInterop": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["../shared/*"]
+    }
   },
   "include": [
     "./**/*.ts",


### PR DESCRIPTION
## Summary
- import shared ASCII helper with path alias in canvas builder
- add path alias configuration in workers tsconfig

## Testing
- `npm --prefix workers run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf9bef180832c98be17d1e089ce06