### PR TITLE
test: enable tsx for ascii unit tests

### DIFF
--- a/tests/unit/ascii.test.js
+++ b/tests/unit/ascii.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { encodeASCII, isASCII } from "../../shared/ascii.mjs";
+import { encodeASCII, isASCII } from "../../shared/ascii.ts";
 
 test("encodeASCII replaces non-ascii", () => {
   assert.strictEqual(encodeASCII("hello"), "hello");


### PR DESCRIPTION
## Summary
- run ascii unit test against TypeScript source
- enable tsx loader so tests can import .ts modules

## Testing
- `pnpm --filter ./tests test unit/ascii.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c36c763e0832c84f0b94acac1b268