### PR TITLE
🎨 Palette: Replace text 'X' characters with CloseIcon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+## 2024-05-23 - Standardizing Close Buttons
+**Learning:** Using raw text characters like 'X' or 'x' for close/dismiss actions creates visual inconsistencies and alignment issues compared to proper SVG icons.
+**Action:** Always utilize a scalable vector icon, such as `X as CloseIcon` from `lucide-react`, rather than text characters for dismiss, clear, or close actions across all UI components.

--- a/webui/frontend/src/components/DaisyUI/Modal.tsx
+++ b/webui/frontend/src/components/DaisyUI/Modal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { X as CloseIcon } from 'lucide-react';
 
 export interface ModalAction {
   label: string;
@@ -71,7 +72,7 @@ const Modal: React.FC<ModalProps> = ({
           <div className="flex items-center justify-between mb-4">
             {title && <h3 id="modal-dialog-title" className="font-bold text-lg">{title}</h3>}
             {showCloseButton && closable && (
-              <button className="btn btn-sm btn-circle btn-ghost" onClick={onClose} aria-label="Close modal">✕</button>
+              <button className="btn btn-sm btn-circle btn-ghost" onClick={onClose} aria-label="Close modal"><CloseIcon size={16} /></button>
             )}
           </div>
         )}

--- a/webui/frontend/src/pages/AgentsPage.tsx
+++ b/webui/frontend/src/pages/AgentsPage.tsx
@@ -5,6 +5,7 @@ import {
   Plus,
   Trash2,
   RefreshCw,
+  X as CloseIcon,
   Search,
   Info,
   Zap,
@@ -531,7 +532,7 @@ export default function AgentsPage() {
                 <div className="flex items-center justify-between">
                   <h2 className="text-xl font-bold">{selectedAgent.name}</h2>
                   <Button variant="ghost" size="sm" onClick={() => setDrawerOpen(false)} aria-label="Close drawer">
-                    X
+                    <CloseIcon size={18} />
                   </Button>
                 </div>
 

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -10,7 +10,8 @@ import {
   Trash2,
   RefreshCw,
   Search,
-  Upload
+  Upload,
+  X as CloseIcon
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
@@ -277,7 +278,7 @@ export default function CommandsPage() {
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
             >
-              x
+              <CloseIcon size={14} />
             </Button>
           )}
         </div>


### PR DESCRIPTION
💡 What: Replaced raw text characters ('X', 'x', '✕') with `CloseIcon` from `lucide-react` in dismiss/clear buttons across `Modal`, `AgentsPage`, and `CommandsPage`.
🎯 Why: Text characters create visual inconsistencies, alignment issues, and do not scale or style properly compared to dedicated SVG vector icons, reducing the overall UI polish.
📸 Before/After: Visuals verified via Playwright. Modals and drawers now show a clean `X` SVG icon instead of plain text.
♿ Accessibility: Preserved existing `aria-label`s ("Close modal", "Close drawer", "Clear search") so screen reader functionality remains fully intact.

---
*PR created automatically by Jules for task [7995079599345010008](https://jules.google.com/task/7995079599345010008) started by @matthewhand*