### PR TITLE
🎨 Palette: Add ARIA label to Dropdown component for icon-only triggers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2026-04-09 - Accessible Reusable Dropdowns
+**Learning:** Reusable components like `Dropdown` that allow arbitrary `trigger` elements (such as icon-only SVGs) must explicitly expose and apply `aria-label` to their internal interactive wrappers (`role="button"`). Without this, the component cannot be made accessible when consumers pass raw icons instead of labeled components.
+**Action:** Always ensure reusable container components that wrap interactive triggers accept an `ariaLabel` prop and apply it to the internal focusable element, enabling consumers to provide necessary context for screen readers.

--- a/webui/frontend/src/components/DaisyUI/Dropdown.tsx
+++ b/webui/frontend/src/components/DaisyUI/Dropdown.tsx
@@ -16,12 +16,13 @@ type DropdownProps = {
   contentClassName?: string;
   disabled?: boolean;
   hideArrow?: boolean;
+  ariaLabel?: string;
 };
 
 const Dropdown: React.FC<DropdownProps> = ({
   trigger, children, position = 'bottom', align = 'left', color = 'ghost', variant, size = 'md',
   isOpen: controlledIsOpen, onToggle, className = '', triggerClassName = '',
-  contentClassName = '', disabled = false, hideArrow = false,
+  contentClassName = '', disabled = false, hideArrow = false, ariaLabel,
 }) => {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -66,7 +67,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     <div className={`dropdown ${positionCls} ${alignCls} ${className}`} ref={dropdownRef}>
       <div tabIndex={disabled ? -1 : 0} role="button"
         className={`btn ${sizeCls} ${colorCls} ${disabled ? 'btn-disabled opacity-50' : ''} ${triggerClassName}`}
-        onClick={handleToggle} aria-haspopup="true" aria-expanded={isOpen}>
+        onClick={handleToggle} aria-haspopup="true" aria-expanded={isOpen} aria-label={ariaLabel}>
         {trigger}
         {!hideArrow && <ChevronDown className="h-5 w-5" aria-hidden="true" />}
       </div>

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -330,6 +330,7 @@ export default function CommandsPage() {
                             <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.75a.75.75 0 110-1.5.75.75 0 010 1.5zM12 12.75a.75.75 0 110-1.5.75.75 0 010 1.5zM12 18.75a.75.75 0 110-1.5.75.75 0 010 1.5z" />
                           </svg>
                         }
+                        ariaLabel={`Command actions for ${name}`}
                         color="ghost"
                         size="sm"
                         triggerClassName="btn-circle"


### PR DESCRIPTION
💡 What: Added an `ariaLabel` prop to the reusable `Dropdown` component and applied it to the trigger element. Passed specific `ariaLabel` context in `CommandsPage.tsx` for the command actions dropdown which uses an inline SVG trigger. Also recorded this learning in the Palette journal.
🎯 Why: Ensures that interactive icon-only triggers wrapped in custom reusable components remain accessible to screen readers by providing clear context.
📸 Before/After: Code change only, ensuring screen readers announce "Command actions for [Command Name]" instead of a generic button with no name.
♿ Accessibility: Directly addresses a missing accessible name on a focusable element, significantly improving the experience for users dependent on screen reading technology.

---
*PR created automatically by Jules for task [11308090725502701956](https://jules.google.com/task/11308090725502701956) started by @matthewhand*