### PR TITLE
🎨 Palette: Use vector icons for close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2024-05-23 - Visual Consistency in Close Buttons
+**Learning:** Using raw text characters like `✕` for close buttons leads to inconsistent visual alignment and sizing across different browsers and operating systems, which degrades the polish of UI components like Alerts and Modals.
+**Action:** Always use proper vector icons (e.g., `X` from `lucide-react`) for close or dismiss actions instead of raw text characters to ensure pixel-perfect consistency and better integration with component styling.

--- a/webui/frontend/src/components/DaisyUI/Alert.tsx
+++ b/webui/frontend/src/components/DaisyUI/Alert.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { X as CloseIcon } from 'lucide-react';
 
 type AlertStatus = 'info' | 'success' | 'warning' | 'error';
 
@@ -38,7 +39,9 @@ export const Alert: React.FC<AlertProps> = ({
       {message && <span>{message}</span>}
       {children}
       {onClose && (
-        <button aria-label="Close alert" onClick={handleClose} className="btn btn-sm btn-circle btn-ghost">✕</button>
+        <button aria-label="Close alert" onClick={handleClose} className="btn btn-sm btn-circle btn-ghost">
+          <CloseIcon size={16} />
+        </button>
       )}
     </div>
   );

--- a/webui/frontend/src/components/DaisyUI/Alert.tsx
+++ b/webui/frontend/src/components/DaisyUI/Alert.tsx
@@ -40,7 +40,7 @@ export const Alert: React.FC<AlertProps> = ({
       {children}
       {onClose && (
         <button aria-label="Close alert" onClick={handleClose} className="btn btn-sm btn-circle btn-ghost">
-          <CloseIcon size={16} />
+          <CloseIcon size={16} aria-hidden="true" />
         </button>
       )}
     </div>

--- a/webui/frontend/src/components/DaisyUI/Modal.tsx
+++ b/webui/frontend/src/components/DaisyUI/Modal.tsx
@@ -73,7 +73,7 @@ const Modal: React.FC<ModalProps> = ({
             {title && <h3 id="modal-dialog-title" className="font-bold text-lg">{title}</h3>}
             {showCloseButton && closable && (
               <button className="btn btn-sm btn-circle btn-ghost" onClick={onClose} aria-label="Close modal">
-                <CloseIcon size={20} />
+                <CloseIcon size={20} aria-hidden="true" />
               </button>
             )}
           </div>

--- a/webui/frontend/src/components/DaisyUI/Modal.tsx
+++ b/webui/frontend/src/components/DaisyUI/Modal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { X as CloseIcon } from 'lucide-react';
 
 export interface ModalAction {
   label: string;
@@ -71,7 +72,9 @@ const Modal: React.FC<ModalProps> = ({
           <div className="flex items-center justify-between mb-4">
             {title && <h3 id="modal-dialog-title" className="font-bold text-lg">{title}</h3>}
             {showCloseButton && closable && (
-              <button className="btn btn-sm btn-circle btn-ghost" onClick={onClose} aria-label="Close modal">✕</button>
+              <button className="btn btn-sm btn-circle btn-ghost" onClick={onClose} aria-label="Close modal">
+                <CloseIcon size={20} />
+              </button>
             )}
           </div>
         )}


### PR DESCRIPTION
Replaced raw text character '✕' with `X` vector icon from `lucide-react` for close actions in the `Alert` and `Modal` components to improve cross-browser visual consistency and alignment.

---
*PR created automatically by Jules for task [15420357966365294917](https://jules.google.com/task/15420357966365294917) started by @matthewhand*