### PR TITLE
chore(test): fix Ruff issues in shim/root tests

### DIFF
--- a/tests/test_root_main.py
+++ b/tests/test_root_main.py
@@ -1,14 +1,13 @@
-import pytest
 from unittest.mock import patch
-import sys
+
 
 def test_root_main():
     """Verify that src/main.py delegates to chatty_commander.main.main()"""
     with patch("chatty_commander.main.main", return_value=0) as mock_main:
         # Import dynamically to ensure the patch is applied when it executes
         import src.main as root_main
-        
+
         result = root_main.main()
-        
+
         assert result == 0
         mock_main.assert_called_once()

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -1,13 +1,14 @@
-import pytest
 import warnings
 from unittest.mock import patch
+
+import pytest
+
 
 def test_shims_import():
     import chatty_commander.config
     assert hasattr(chatty_commander.config, "Config")
 
     import chatty_commander.helpers
-
     import chatty_commander.model_manager
     assert hasattr(chatty_commander.model_manager, "ModelManager")
 
@@ -28,7 +29,6 @@ def test_handle_config_cli(mock_wizard):
     mock_wizard.assert_called_once()
 
 def test_compat():
-    import warnings
 
     import chatty_commander.compat as compat
 
@@ -50,7 +50,6 @@ def test_compat():
 
 
 def test_compat_no_alias():
-    import warnings
 
     import chatty_commander.compat as compat
 


### PR DESCRIPTION
## Summary
- Apply Ruff auto-fixes to `tests/test_root_main.py` and `tests/test_shims.py`
- Clean up import ordering, remove unused imports, and trim whitespace-only lines
- Restore full `uv run ruff check .` pass state

## Validation
- [x] `uv run ruff check tests/test_root_main.py tests/test_shims.py --fix`
- [x] `uv run ruff check .`

👾 Generated with [Letta Code](https://letta.com)