### PR TITLE
fix(types): reduce mypy errors in context/config/url modules

### DIFF
--- a/src/chatty_commander/advisors/context.py
+++ b/src/chatty_commander/advisors/context.py
@@ -56,7 +56,7 @@ class ContextIdentity:
     username: str | None = None
     display_name: str | None = None
     avatar_url: str | None = None
-    created_at: float = None
+    created_at: float | None = None
 
     def __post_init__(self):
         if self.created_at is None:
@@ -89,7 +89,7 @@ class ContextState:
     system_prompt: str
     memory_key: str
     metadata: dict[str, Any]
-    last_activity: float = None
+    last_activity: float | None = None
 
     def __post_init__(self):
         if self.last_activity is None:
@@ -278,6 +278,8 @@ class ContextManager:
 
         to_clear = []
         for context_key, context in self.contexts.items():
+            if context.last_activity is None:
+                continue
             if current_time - context.last_activity > max_age_seconds:
                 to_clear.append(context_key)
 
@@ -307,7 +309,7 @@ class ContextManager:
             return identity.platform.value
 
         # Fall back to default persona
-        return self.default_persona
+        return str(self.default_persona)
 
     def _load_contexts(self) -> None:
         """Load contexts from persistence file."""
@@ -343,8 +345,8 @@ class ContextManager:
 
     def get_stats(self) -> dict[str, Any]:
         """Get statistics about current contexts."""
-        platform_counts = {}
-        persona_counts = {}
+        platform_counts: dict[str, int] = {}
+        persona_counts: dict[str, int] = {}
 
         for context in self.contexts.values():
             platform = context.identity.platform.value

--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -112,21 +112,7 @@ class Config:
             self.config_data.get("general", {}).get("inference_framework", "onnx")
         )
 
-        # Commands for model actions
-        default_commands = {}
-        if (
-            not self.config_file or "commands" not in self.config_data
-        ):  # Use defaults if file missing or commands missing
-            default_commands = {
-                "hello": {
-                    "action": "custom_message",
-                    "message": "Hello from ChattyCommander!",
-                },
-                "take_screenshot": {"action": "keypress", "keys": "take_screenshot"},
-                "paste": {"action": "keypress", "keys": "paste"},
-                "submit": {"action": "keypress", "keys": "submit"},
-            }
-        self.commands: dict = self.config_data.get("commands", default_commands)
+        # Commands already initialized above from config/defaults.
 
         # Start on boot setting
         self.start_on_boot: bool = bool(

--- a/src/chatty_commander/utils/url_validator.py
+++ b/src/chatty_commander/utils/url_validator.py
@@ -45,7 +45,7 @@ def is_safe_url(url: str) -> bool:
 
         # ALL resolved addresses must be safe
         for _family, _type, _proto, _canonname, sockaddr in addr_infos:
-            ip_str = sockaddr[0]
+            ip_str = str(sockaddr[0])
             if _is_restricted(ip_str):
                 return False
 


### PR DESCRIPTION
## Summary
This PR applies a focused first batch of typing fixes in core modules:

- `src/chatty_commander/utils/url_validator.py`
  - Cast resolved socket host tuple value to `str` before restricted-IP checks.
- `src/chatty_commander/advisors/context.py`
  - Make dataclass timestamp fields nullable where initialized as `None`.
  - Guard context cleanup arithmetic when `last_activity` is missing.
  - Add explicit dict typing in context statistics.
  - Return `default_persona` as `str` explicitly.
- `src/chatty_commander/app/config.py`
  - Remove duplicate `self.commands` redefinition block that triggered `no-redef`.

## Validation
- [x] `uv run mypy src/chatty_commander/utils/url_validator.py src/chatty_commander/advisors/context.py src/chatty_commander/app/config.py`
- [x] `uv run ruff check .`

This is intentionally scoped as batch 1 so we can keep squash merges small and frequent.

👾 Generated with [Letta Code](https://letta.com)