### PR TITLE
fix(types): mypy batch 2 for runtime typing modules

### DIFF
--- a/src/chatty_commander/app/command_executor.py
+++ b/src/chatty_commander/app/command_executor.py
@@ -35,29 +35,38 @@ import shlex
 import subprocess
 from typing import Any
 
+pyautogui: Any = None
+httpx: Any = None
+
 # Optional deps that may not be present in CI/headless environments
 try:  # pragma: no cover - exercised via tests with patching
-    import pyautogui
+    import pyautogui as _pyautogui
+
+    pyautogui = _pyautogui
 except (
     Exception
 ):  # pragma: no cover - catch Xlib.error.DisplayConnectionError and similar
     pyautogui = None
 
 try:  # pragma: no cover - optional
-    import httpx
+    import httpx as _httpx
+
+    httpx = _httpx
 except Exception:  # pragma: no cover - optional
     httpx = None
 
 # Allow tests to patch legacy shim module attributes if present
 try:  # pragma: no cover
-    from command_executor import pyautogui as _shim_pg
+    from command_executor import pyautogui as _shim_pg  # type: ignore[import-not-found]
 except Exception:  # pragma: no cover - optional
     _shim_pg = None
 if _shim_pg is not None:  # pragma: no cover - optional
     pyautogui = _shim_pg
 
 try:  # pragma: no cover
-    from command_executor import requests as _shim_requests
+    from command_executor import (
+        requests as _shim_requests,  # type: ignore[import-not-found]
+    )
 except Exception:  # pragma: no cover - optional
     _shim_requests = None
 if _shim_requests is not None:  # pragma: no cover - optional

--- a/src/chatty_commander/avatars/thinking_state.py
+++ b/src/chatty_commander/avatars/thinking_state.py
@@ -39,6 +39,9 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+BroadcastCallback = Callable[[dict[str, Any]], None] | Callable[[dict[str, Any]], Awaitable[None]]
+
+
 class ThinkingState(Enum):
     """States that an agent can be in during conversation."""
 
@@ -62,7 +65,7 @@ class AgentStateInfo:
     state: ThinkingState
     message: str | None = None
     progress: float | None = None  # 0.0 to 1.0 for progress bars
-    timestamp: float = None
+    timestamp: float | None = None
 
     def __post_init__(self):
         if self.timestamp is None:
@@ -91,7 +94,7 @@ class ThinkingStateManager:
     def __init__(self):
         self.agent_states: dict[str, AgentStateInfo] = {}
         self.avatar_mappings: dict[str, str] = {}  # agent_id -> avatar_id
-        self.broadcast_callbacks: set[Callable[[dict[str, Any]], None]] = set()
+        self.broadcast_callbacks: set[BroadcastCallback] = set()
 
     def register_agent(
         self, agent_id: str, persona_id: str, avatar_id: str | None = None
@@ -147,20 +150,14 @@ class ThinkingStateManager:
 
     def add_broadcast_callback(
         self,
-        callback: (
-            Callable[[dict[str, Any]], None]
-            | Callable[[dict[str, Any]], Awaitable[None]]
-        ),
+        callback: BroadcastCallback,
     ) -> None:
         """Add a callback to receive state change broadcasts."""
         self.broadcast_callbacks.add(callback)
 
     def remove_broadcast_callback(
         self,
-        callback: (
-            Callable[[dict[str, Any]], None]
-            | Callable[[dict[str, Any]], Awaitable[None]]
-        ),
+        callback: BroadcastCallback,
     ) -> None:
         """Remove a broadcast callback."""
         self.broadcast_callbacks.discard(callback)

--- a/src/chatty_commander/utils/logger.py
+++ b/src/chatty_commander/utils/logger.py
@@ -175,10 +175,10 @@ def setup_logger(name, log_file=None, level=logging.INFO, config=None, **kwargs)
             logger.addHandler(handler)
     else:
         # Add console handler if no log file
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
         if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
-            logger.addHandler(handler)
+            logger.addHandler(stream_handler)
 
     return logger
 


### PR DESCRIPTION
## Summary
Second incremental typing cleanup batch focused on runtime-sensitive modules:

- `src/chatty_commander/app/command_executor.py`
  - Added explicit optional import placeholders (`pyautogui`, `httpx`) with `Any`
  - Normalized optional imports to avoid mypy redefinition/assignment issues
  - Added targeted `type: ignore[import-not-found]` for legacy shim import path
- `src/chatty_commander/avatars/thinking_state.py`
  - Added typed callback alias for broadcast callbacks
  - Made timestamp dataclass field nullable when initialized with `None`
  - Updated callback set annotation to support sync + async callbacks consistently
- `src/chatty_commander/utils/logger.py`
  - Fixed handler variable typing split between rotating file and stream handlers

## Validation
- [x] `uv run mypy src/chatty_commander/utils/logger.py src/chatty_commander/avatars/thinking_state.py src/chatty_commander/app/command_executor.py`
- [x] `uv run ruff check src/chatty_commander/utils/logger.py src/chatty_commander/avatars/thinking_state.py src/chatty_commander/app/command_executor.py`

This follows the small-batch approach for frequent squash merges.

👾 Generated with [Letta Code](https://letta.com)