### PR TITLE
fix(types): mypy batch 3 for voice optional imports

### DIFF
--- a/src/chatty_commander/voice/pipeline.py
+++ b/src/chatty_commander/voice/pipeline.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
+from typing import Any
 
 from .transcription import VoiceTranscriber
 from .tts import TextToSpeech
@@ -65,7 +66,7 @@ class VoicePipeline:
         # Use mock components if voice deps not available or explicitly requested
         if not VOICE_DEPS_AVAILABLE or use_mock:
             logger.info("Using mock voice components")
-            self.wake_detector = MockWakeWordDetector(wake_words=wake_words, **kwargs)
+            self.wake_detector: MockWakeWordDetector | WakeWordDetector = MockWakeWordDetector(wake_words=wake_words, **kwargs)
             transcription_backend = "mock"
         else:
             self.wake_detector = WakeWordDetector(wake_words=wake_words, **kwargs)
@@ -225,7 +226,7 @@ class VoicePipeline:
 
         try:
             # Get available commands from config
-            model_actions = getattr(self.config_manager, "model_actions", {})
+            model_actions: dict[str, Any] = getattr(self.config_manager, "model_actions", {})
             if not model_actions:
                 logger.debug("No model actions available")
                 return None
@@ -235,7 +236,7 @@ class VoicePipeline:
 
             # Direct name match first
             for command_name in model_actions.keys():
-                if command_name.lower() in transcription_lower:
+                if isinstance(command_name, str) and command_name.lower() in transcription_lower:
                     return command_name
 
             # Keyword-based matching
@@ -307,7 +308,7 @@ class VoicePipeline:
                 self.tts.speak(text)
         return None
 
-    def get_status(self) -> dict[str, any]:
+    def get_status(self) -> dict[str, Any]:
         """Get pipeline status information."""
         return {
             "listening": self._listening,

--- a/src/chatty_commander/voice/transcription.py
+++ b/src/chatty_commander/voice/transcription.py
@@ -37,15 +37,16 @@ import tempfile
 import time
 import wave
 from abc import ABC, abstractmethod
+from typing import Any
 
 try:
-    import numpy as np
-    import pyaudio
+    import numpy as np  # type: ignore[import-untyped]
+    import pyaudio  # type: ignore[import-untyped]
 
     AUDIO_DEPS_AVAILABLE = True
 except ImportError:
-    pyaudio = None
-    np = None
+    pyaudio = None  # type: ignore[assignment]
+    np = None  # type: ignore[assignment]
     AUDIO_DEPS_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
@@ -73,10 +74,10 @@ class WhisperLocalBackend(TranscriptionBackend):
         self._model = None
         self._initialize_model()
 
-    def _initialize_model(self):
+    def _initialize_model(self) -> None:
         """Initialize Whisper model."""
         try:
-            import whisper
+            import whisper  # type: ignore[import-not-found]
 
             self._model = whisper.load_model(self.model_size)
             logger.info(f"Loaded Whisper model: {self.model_size}")
@@ -118,10 +119,10 @@ class WhisperAPIBackend(TranscriptionBackend):
 
     def __init__(self, api_key: str | None = None):
         self.api_key = api_key
-        self._client = None
+        self._client: Any = None
         self._initialize_client()
 
-    def _initialize_client(self):
+    def _initialize_client(self) -> None:
         """Initialize OpenAI client."""
         try:
             import openai
@@ -158,7 +159,7 @@ class WhisperAPIBackend(TranscriptionBackend):
 
                 text = transcript.text.strip()
                 logger.debug(f"OpenAI Whisper transcription: '{text}'")
-                return text
+                return str(text)
 
         except Exception as e:
             logger.error(f"OpenAI Whisper API transcription failed: {e}")
@@ -215,8 +216,8 @@ class VoiceTranscriber:
         self.silence_timeout = silence_timeout
 
         self._backend = self._create_backend(backend, **backend_kwargs)
-        self._audio = None
-        self._stream = None
+        self._audio: Any = None
+        self._stream: Any = None
 
     def _create_backend(self, backend: str, **kwargs) -> TranscriptionBackend:
         """Create transcription backend."""
@@ -259,7 +260,7 @@ class VoiceTranscriber:
 
         try:
             self._audio = pyaudio.PyAudio()
-            self._stream = self._audio.open(
+            self._stream = self._audio.open(  # type: ignore[attr-defined]
                 format=pyaudio.paInt16,
                 channels=self.channels,
                 rate=self.sample_rate,
@@ -274,7 +275,7 @@ class VoiceTranscriber:
 
             while True:
                 try:
-                    data = self._stream.read(
+                    data = self._stream.read(  # type: ignore[attr-defined]
                         self.chunk_size, exception_on_overflow=False
                     )
                     frames.append(data)
@@ -330,7 +331,7 @@ class VoiceTranscriber:
             finally:
                 self._audio = None
 
-    def get_backend_info(self) -> dict[str, any]:
+    def get_backend_info(self) -> dict[str, Any]:
         """Get information about the current backend."""
         return {
             "backend_type": type(self._backend).__name__,

--- a/src/chatty_commander/voice/wakeword.py
+++ b/src/chatty_commander/voice/wakeword.py
@@ -32,17 +32,18 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from typing import Any
 
 try:
-    import numpy as np
-    import openwakeword
-    import pyaudio
+    import numpy as np  # type: ignore[import-untyped]
+    import openwakeword  # type: ignore[import-untyped]
+    import pyaudio  # type: ignore[import-untyped]
 
     VOICE_DEPS_AVAILABLE = True
 except ImportError:
-    openwakeword = None
-    pyaudio = None
-    np = None
+    openwakeword = None  # type: ignore[assignment]
+    pyaudio = None  # type: ignore[assignment]
+    np = None  # type: ignore[assignment]
     VOICE_DEPS_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
@@ -71,11 +72,11 @@ class WakeWordDetector:
         self.sample_rate = sample_rate
         self.channels = channels
 
-        self._model = None
-        self._audio = None
-        self._stream = None
+        self._model: Any = None
+        self._audio: Any = None
+        self._stream: Any = None
         self._running = False
-        self._thread = None
+        self._thread: Any = None
         self._callbacks: list[Callable[[str, float], None]] = []
 
         self._initialize_model()
@@ -120,7 +121,7 @@ class WakeWordDetector:
 
         try:
             self._audio = pyaudio.PyAudio()
-            self._stream = self._audio.open(
+            self._stream = self._audio.open(  # type: ignore[attr-defined]
                 format=pyaudio.paInt16,
                 channels=self.channels,
                 rate=self.sample_rate,
@@ -130,7 +131,7 @@ class WakeWordDetector:
 
             self._running = True
             self._thread = threading.Thread(target=self._listen_loop, daemon=True)
-            self._thread.start()
+            self._thread.start()  # type: ignore[attr-defined]
             logger.info("Started wake word detection")
 
         except Exception as e:
@@ -176,13 +177,13 @@ class WakeWordDetector:
                     continue
 
                 # Read audio chunk
-                audio_data = self._stream.read(
+                audio_data = self._stream.read(  # type: ignore[attr-defined]
                     self.chunk_size, exception_on_overflow=False
                 )
                 audio_array = np.frombuffer(audio_data, dtype=np.int16)
 
                 # Get predictions from model
-                predictions = self._model.predict(audio_array)
+                predictions = self._model.predict(audio_array)  # type: ignore[attr-defined]
 
                 # Check for wake word detections
                 for wake_word in self.wake_words:


### PR DESCRIPTION
## Summary
- Fixed 17 mypy errors across 3 voice module files (`wakeword.py`, `transcription.py`, `pipeline.py`)
- Added proper type annotations for optional audio dependencies (pyaudio, numpy, openwakeword, whisper)
- Guarded runtime attribute access with `type: ignore` comments where modules may be `None`

## Changes
1. **voice/wakeword.py**: Optional import typing with `# type: ignore[import-untyped]` and `# type: ignore[assignment]`, instance attributes typed as `Any`
2. **voice/transcription.py**: Similar patterns for pyaudio/numpy; `_client` as `Any`; guarded stream access; cast return type
3. **voice/pipeline.py**: Union type for `wake_detector`, explicit dict typing for `model_actions`, fixed `any` → `Any`

## Test plan
- [x] `uv run mypy src/chatty_commander/voice/` passes (0 errors)
- [x] `uv run ruff check src/chatty_commander/voice/` passes
- [x] `uv run pytest -q` passes (~400 tests)

👾 Generated with [Letta Code](https://letta.com)