### PR TITLE
fix(types): mypy batch 6 for web server and routes

### DIFF
--- a/src/chatty_commander/web/routes/audio.py
+++ b/src/chatty_commander/web/routes/audio.py
@@ -49,7 +49,7 @@ def include_audio_routes(
     @router.get("/api/v1/audio/devices", response_model=AudioDevices)
     async def get_audio_devices():
         try:
-            import pyaudio
+            import pyaudio  # type: ignore[import-untyped]
 
             p = pyaudio.PyAudio()
             input_devices = []

--- a/src/chatty_commander/web/routes/core.py
+++ b/src/chatty_commander/web/routes/core.py
@@ -203,7 +203,7 @@ def include_core_routes(
         cpu_usage = "unknown"
 
         try:
-            import psutil
+            import psutil  # type: ignore[import-untyped]
 
             memory = psutil.virtual_memory()
             memory_usage = f"{memory.percent:.1f}%"
@@ -432,7 +432,7 @@ def include_core_routes(
             if response_time_middleware is not None
             else 0.0
         )
-        metrics_dict["response_time_avg"] = round(avg_duration, 2)
+        metrics_dict["response_time_avg"] = round(avg_duration, 2)  # type: ignore[assignment]
         return metrics_dict
 
     return router

--- a/src/chatty_commander/web/routes/models.py
+++ b/src/chatty_commander/web/routes/models.py
@@ -85,7 +85,7 @@ def _format_size(size_bytes: int) -> str:
     for unit in ["B", "KB", "MB", "GB"]:
         if size_bytes < 1024:
             return f"{size_bytes:.1f} {unit}"
-        size_bytes /= 1024
+        size_bytes = size_bytes / 1024  # type: ignore[assignment]
     return f"{size_bytes:.1f} TB"
 
 

--- a/src/chatty_commander/web/server.py
+++ b/src/chatty_commander/web/server.py
@@ -45,58 +45,58 @@ except Exception:  # very minimal stub if FastAPI missing (tests won't hit real 
 try:
     from .routes.avatar_ws import router as avatar_ws_router
 except ImportError:
-    avatar_ws_router = None
+    avatar_ws_router = None  # type: ignore[assignment]
 
 try:
     from .routes.avatar_api import router as avatar_api_router
 except ImportError:
-    avatar_api_router = None
+    avatar_api_router = None  # type: ignore[assignment]
 
 try:
     from .routes.avatar_selector import router as avatar_selector_router
 except ImportError:
-    avatar_selector_router = None
+    avatar_selector_router = None  # type: ignore[assignment]
 
 try:
     from .routes.avatar_settings import include_avatar_settings_routes
 except ImportError:
-    include_avatar_settings_routes = None
+    include_avatar_settings_routes = None  # type: ignore[assignment]
 
 try:
     from .routes.audio import include_audio_routes
 except ImportError:
-    include_audio_routes = None
+    include_audio_routes = None  # type: ignore[assignment]
 
 try:
     from .routes.version import router as version_router
 except ImportError:
-    version_router = None
+    version_router = None  # type: ignore[assignment]
 
 try:
     from .routes.agents import router as agents_router
 except ImportError:
-    agents_router = None
+    agents_router = None  # type: ignore[assignment]
 
 try:
     from .routes.models import router as models_router
 except ImportError:
-    models_router = None
+    models_router = None  # type: ignore[assignment]
 
 try:
     from .routes.command_authoring import router as command_authoring_router
 except ImportError:
-    command_authoring_router = None
+    command_authoring_router = None  # type: ignore[assignment]
 
 try:
     from ..obs.metrics import create_metrics_router
 
     metrics_router = create_metrics_router()
 except ImportError:
-    metrics_router = None
+    metrics_router = None  # type: ignore[assignment]
 
 # Settings router needs to be created with config manager
-settings_router = None
-audio_router = None
+settings_router: Any = None
+audio_router: Any = None
 
 
 def _include_optional(app: FastAPI, name: str) -> None:
@@ -122,14 +122,14 @@ def create_app(no_auth: bool = False, config_manager: Any = None) -> FastAPI:
         _include_optional(app, nm)
 
     # Handle settings router separately since it needs config manager
-    if include_avatar_settings_routes and config_manager:
+    if include_avatar_settings_routes is not None and config_manager:
         global settings_router
         settings_router = include_avatar_settings_routes(
             get_config_manager=lambda: config_manager
         )
         _include_optional(app, "settings_router")
 
-    if include_audio_routes and config_manager:
+    if include_audio_routes is not None and config_manager:
         global audio_router
         audio_router = include_audio_routes(get_config_manager=lambda: config_manager)
         _include_optional(app, "audio_router")

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -45,7 +45,7 @@ from typing import Any
 try:
     import uvicorn
 except ImportError:
-    uvicorn = None
+    uvicorn = None  # type: ignore[assignment]
 
 from collections import defaultdict
 
@@ -90,7 +90,7 @@ except Exception:  # pragma: no cover - optional dependency path
 try:
     from chatty_commander.web.routes.audio import include_audio_routes
 except ImportError:
-    include_audio_routes = None
+    include_audio_routes = None  # type: ignore[assignment]
 from chatty_commander.web.routes.version import router as version_router
 from chatty_commander.web.routes.voice import include_voice_routes
 from chatty_commander.web.routes.ws import include_ws_routes
@@ -99,24 +99,24 @@ from chatty_commander.web.routes.ws import include_ws_routes
 try:
     from chatty_commander.web.routes.avatar_api import router as avatar_api_router
 except ImportError:
-    avatar_api_router = None
+    avatar_api_router = None  # type: ignore[assignment]
 
 try:
     from chatty_commander.web.routes.avatar_ws import router as avatar_ws_router
 except ImportError:
-    avatar_ws_router = None
+    avatar_ws_router = None  # type: ignore[assignment]
 
 try:
     from chatty_commander.web.routes.avatar_selector import (
         router as avatar_selector_router,
     )
 except ImportError:
-    avatar_selector_router = None
+    avatar_selector_router = None  # type: ignore[assignment]
 
 try:
     from .routes.agents import router as agents_router
 except ImportError:
-    agents_router = None
+    agents_router = None  # type: ignore[assignment]
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Fixed 22 mypy errors across 5 files in web server and route modules
- Added type: ignore comments for optional imports and assignment mismatches

## Changes
1. **web/server.py**: Type ignore for optional router imports, explicit `is not None` checks for truthy-function test
2. **web/web_mode.py**: Type ignore for uvicorn, import_audio_routes, and avatar router imports
3. **web/routes/models.py**: Guard size_bytes reassignment with type: ignore
4. **web/routes/audio.py**: pyaudio import guard
5. **web/routes/core.py**: psutil import guard, metrics_dict assignment fix

## Test plan
- [x] `uv run mypy src` shows reduced error count (121 → 99)
- [x] `uv run ruff check` passes
- [x] `uv run pytest -q` passes

👾 Generated with [Letta Code](https://letta.com)