### PR TITLE
fix(types): mypy batch 8 for voice self_test and auth middleware

### DIFF
--- a/src/chatty_commander/voice/self_test.py
+++ b/src/chatty_commander/voice/self_test.py
@@ -36,6 +36,7 @@ import json
 import logging
 import tempfile
 import time
+from typing import Any
 
 try:
     import openai
@@ -43,16 +44,16 @@ try:
 
     OPENAI_AVAILABLE = True
 except ImportError:
-    openai = None
-    OpenAI = None
+    openai = None  # type: ignore[assignment,misc]
+    OpenAI = None  # type: ignore[assignment,misc]
     OPENAI_AVAILABLE = False
 
 try:
-    import pyttsx3
+    import pyttsx3  # type: ignore[import-not-found]
 
     TTS_AVAILABLE = True
 except ImportError:
-    pyttsx3 = None
+    pyttsx3 = None  # type: ignore[assignment,misc]
     TTS_AVAILABLE = False
 
 from .transcription import VoiceTranscriber
@@ -70,13 +71,13 @@ class VoiceSelfTester:
         test_phrases: list[str] | None = None,
     ):
         self.transcriber = transcriber or VoiceTranscriber(backend="whisper_local")
-        self.openai_client = None
+        self.openai_client: Any = None
 
         if OPENAI_AVAILABLE and openai_api_key:
             self.openai_client = OpenAI(api_key=openai_api_key)
 
         self.test_phrases = test_phrases or self._get_default_test_phrases()
-        self._tts_engine = None
+        self._tts_engine: Any = None
 
         if TTS_AVAILABLE:
             self._initialize_tts()

--- a/src/chatty_commander/web/middleware/auth.py
+++ b/src/chatty_commander/web/middleware/auth.py
@@ -26,6 +26,7 @@ import logging
 import posixpath
 import urllib.parse
 from collections.abc import Callable
+from typing import cast
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
@@ -61,7 +62,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """Process request and validate authentication if required."""
         # Skip auth in no_auth mode
         if self.no_auth:
-            return await call_next(request)
+            return cast(Response, await call_next(request))
 
         # Decode path to prevent URL-encoded or double-encoded path traversal bypasses
         raw_path = request.url.path
@@ -83,11 +84,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
             )
             or path in self.public_exact_endpoints
         ):
-            return await call_next(request)
+            return cast(Response, await call_next(request))
 
         # Skip auth for OPTIONS requests (CORS preflight)
         if request.method == "OPTIONS":
-            return await call_next(request)
+            return cast(Response, await call_next(request))
 
         # Validate API key for protected endpoints
         if path == "/api" or path.startswith("/api/"):
@@ -137,4 +138,4 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
             logger.debug("Authentication successful")
 
-        return await call_next(request)
+        return cast(Response, await call_next(request))


### PR DESCRIPTION
## Summary
- Fixed 13 mypy errors across 2 files

## Changes
1. **voice/self_test.py**: Type guards for optional openai/pyttsx3 imports, instance attrs as Any
2. **web/middleware/auth.py**: Cast call_next() return values to Response

## Test plan
- [x] `uv run mypy src` shows reduced error count (77 → 64)
- [x] `uv run ruff check` passes
- [x] `uv run pytest -q` passes

👾 Generated with [Letta Code](https://letta.com)