### PR TITLE
fix: address test failures and add type ignores

### DIFF
--- a/src/chatty_commander/cli/cli.py
+++ b/src/chatty_commander/cli/cli.py
@@ -255,7 +255,8 @@ def run_gui_mode(
             f"Tray popup GUI unavailable ({e}); falling back to legacy tkinter GUI"
         )
         try:
-            from chatty_commander.gui import main as gui_main
+            # Legacy GUI fallback; gui module may not define main()
+            from chatty_commander.gui import main as gui_main  # type: ignore[attr-defined]  # noqa: I001
 
             logger.info("Starting legacy tkinter GUI mode")
             rc = gui_main()

--- a/src/chatty_commander/cli/main.py
+++ b/src/chatty_commander/cli/main.py
@@ -266,7 +266,8 @@ def run_gui_mode(
             f"Tray popup GUI unavailable ({e}); falling back to legacy tkinter GUI"
         )
         try:
-            from chatty_commander.gui import main as gui_main
+            # Legacy GUI fallback; gui module may not define main()
+            from chatty_commander.gui import main as gui_main  # type: ignore[attr-defined]  # noqa: I001
 
             logger.info("Starting legacy tkinter GUI mode")
             rc = gui_main()

--- a/src/chatty_commander/gui/pyqt5_avatar.py
+++ b/src/chatty_commander/gui/pyqt5_avatar.py
@@ -34,10 +34,10 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from PyQt5.QtCore import Qt, QUrl, pyqtSignal
-    from PyQt5.QtGui import QIcon
-    from PyQt5.QtWebEngineWidgets import QWebEngineView
-    from PyQt5.QtWidgets import (
+    from PyQt5.QtCore import Qt, QUrl, pyqtSignal  # type: ignore[import-not-found]
+    from PyQt5.QtGui import QIcon  # type: ignore[import-not-found]
+    from PyQt5.QtWebEngineWidgets import QWebEngineView  # type: ignore[import-not-found]
+    from PyQt5.QtWidgets import (  # type: ignore[import-not-found]
         QAction,
         QApplication,
         QMainWindow,
@@ -52,16 +52,16 @@ except ImportError:
     PYQT5_AVAILABLE = False
 
     # Create dummy classes for type hints
-    class QMainWindow:
+    class QMainWindow:  # type: ignore[no-redef]
         pass
 
-    class QWebEngineView:
+    class QWebEngineView:  # type: ignore[no-redef]
         pass
 
-    class QSystemTrayIcon:
+    class QSystemTrayIcon:  # type: ignore[no-redef]
         pass
 
-    class QApplication:
+    class QApplication:  # type: ignore[no-redef]
         pass
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -616,7 +616,8 @@ class TestWebModeServer:
         config, _, _, _ = mock_managers
         config.save_config = Mock()
 
-        new_config = {"new_key": "new_value"}
+        # Use an allowed key from ALLOWED_CONFIG_KEYS
+        new_config = {"general": {"debug_mode": True}}
         response = test_client.put("/api/v1/config", json=new_config)
         assert response.status_code == 200
 
@@ -628,7 +629,8 @@ class TestWebModeServer:
         """Test update config endpoint failure when config saving fails."""
         config, _, _, _ = mock_managers
         config.save_config = Mock(side_effect=Exception("Save failed"))
-        new_config = {"new_key": "new_value"}
+        # Use an allowed key from ALLOWED_CONFIG_KEYS
+        new_config = {"general": {"debug_mode": False}}
         response = test_client.put("/api/v1/config", json=new_config)
         assert response.status_code == 500
         data = response.json()


### PR DESCRIPTION
## Summary
- Fixes 2 failing web server tests
- Adds type ignores for optional dependencies
- Partial mypy cleanup from major merge

## Changes
- tests/test_web_server.py: Use allowed config key `general` instead of `new_key`
- cli/main.py, cli/cli.py: Add type ignore for gui.main import
- gui/pyqt5_avatar.py: Add type ignores for PyQt5 stubs

## Test plan
- [x] Tests pass: `uv run pytest -q`
- [ ] Remaining: 207 mypy errors need new batch PR

## Note
The major merge brought in significant changes requiring additional mypy cleanup batches.