### PR TITLE
fix(types): reduce mypy errors by 8 with batch 13 (180→172)

### DIFF
--- a/src/chatty_commander/advisors/context.py
+++ b/src/chatty_commander/advisors/context.py
@@ -274,6 +274,8 @@ class ContextManager:
 
         to_clear = []
         for context_key, context in self.contexts.items():
+            # last_activity is set in __post_init__, guaranteed non-None after initialization
+            assert context.last_activity is not None
             if current_time - context.last_activity > max_age_seconds:
                 to_clear.append(context_key)
 

--- a/src/chatty_commander/cli/config.py
+++ b/src/chatty_commander/cli/config.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from typing import Any
 
 from chatty_commander.app.config import Config
 
@@ -62,7 +63,7 @@ class ConfigCLI:
         except json.JSONDecodeError:
             print(f"Error: Invalid JSON in {self.config_path}", file=sys.stderr)
         # Fallback to empty config on error
-        empty_data = {
+        empty_data: dict[str, dict[str, Any]] = {
             "model_actions": {},
             "state_models": {},
             "listen_for": {},

--- a/src/chatty_commander/voice/enhanced_processor.py
+++ b/src/chatty_commander/voice/enhanced_processor.py
@@ -68,8 +68,8 @@ class EnhancedVoiceProcessor:
         self.config = config
         self.logger = logging.getLogger(__name__)
         self.is_listening = False
-        self.audio_queue = queue.Queue()
-        self.processing_thread = None
+        self.audio_queue: queue.Queue[np.ndarray[Any, np.dtype[Any]]] = queue.Queue()
+        self.processing_thread: threading.Thread | None = None
 
         # Voice activity detection state
         self.vad_enabled = config.voice_activity_detection
@@ -77,13 +77,14 @@ class EnhancedVoiceProcessor:
         self.speech_detected = False
 
         # Audio processing components
-        self.noise_reducer = None
-        self.echo_canceller = None
-        self.auto_gain = None
+        self.noise_reducer: Any = None
+        self.echo_canceller: Any = None
+        self.auto_gain: Any = None
 
         # Transcription components
-        self.transcriber = None
-        self.wake_word_detector = None
+        self.transcriber: Any = None
+        self.wake_word_detector: str | None = None
+        self.transcription_method: str | None = None
 
         # Callbacks
         self.on_speech_start: Callable | None = None

--- a/src/chatty_commander/voice/wakeword.py
+++ b/src/chatty_commander/voice/wakeword.py
@@ -180,6 +180,10 @@ class WakeWordDetector:
                     time.sleep(1.0)  # Mock detection interval
                     continue
 
+                # Type narrowing - these are guaranteed non-None when running
+                assert self._stream is not None
+                assert self._model is not None
+
                 # Read audio chunk
                 audio_data = self._stream.read(
                     self.chunk_size, exception_on_overflow=False


### PR DESCRIPTION
## Summary
- Fixed type annotations across 3 files to resolve common mypy error patterns
- Reduced mypy errors from 180 to 172 (8 errors fixed)

## Changes
- **advisors/context.py**: Added assertion for type narrowing on `last_activity`
- **cli/config.py**: Added type annotation for `empty_data` dict, added `Any` import
- **voice/enhanced_processor.py**: 
  - Added explicit type annotation for `audio_queue`
  - Added explicit type for `processing_thread`
  - Changed audio processing components to use `Any` type
  - Added explicit types for `wake_word_detector` and `transcription_method`

## Test plan
- [x] `uv run mypy src` - errors reduced from 180 to 172
- [x] `uv run pytest -q` - all tests pass
- [x] `uv run ruff check .` - no new warnings

👾 Generated with [Letta Code](https://letta.com)