### PR TITLE
fix(types): reduce mypy errors by 8 with batch 15 (154→146)

### DIFF
--- a/src/chatty_commander/web/routes/core.py
+++ b/src/chatty_commander/web/routes/core.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import threading
 import time
@@ -36,6 +37,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from chatty_commander.utils.security import mask_sensitive_data
+
+logger = logging.getLogger(__name__)
 
 ALLOWED_CONFIG_KEYS = frozenset({
     "general",

--- a/src/chatty_commander/web/routes/system.py
+++ b/src/chatty_commander/web/routes/system.py
@@ -62,6 +62,13 @@ def include_system_routes(
         ]
 
         info = SystemInfo(
+            cpu_percent=None,
+            memory_total_mb=None,
+            memory_used_mb=None,
+            memory_percent=None,
+            disk_total_gb=None,
+            disk_used_gb=None,
+            disk_percent=None,
             python_version=sys.version,
             platform=platform.platform(),
             architecture=platform.machine(),


### PR DESCRIPTION
## Summary
- Fixed missing imports and explicit None values for Pydantic models
- Reduced mypy errors from 154 to 146 (8 errors fixed)

## Changes
- **web/routes/core.py**: Added missing `logging import` and `logger` definition
- **web/routes/system.py**: Fixed SystemInfo initialization to pass explicit None values for optional fields

## Test plan
- [x] `uv run mypy src` - errors reduced from 154 to 146
- [x] `uv run pytest -q` - all tests pass
- [x] `uv run ruff check .` - no new warnings

👾 Generated with [Letta Code](https://letta.com)