### PR TITLE
fix(types): reduce mypy errors by 3 with batch 16 (146→143)

### DIFF
--- a/src/chatty_commander/app/command_executor.py
+++ b/src/chatty_commander/app/command_executor.py
@@ -39,12 +39,12 @@ from typing import Any
 try:  # pragma: no cover - exercised via tests with patching
     import pyautogui
 except Exception:  # pragma: no cover - catch Xlib.error.DisplayConnectionError and similar
-    pyautogui = None
+    pyautogui = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional
     import httpx
 except Exception:  # pragma: no cover - optional
-    httpx = None
+    httpx = None  # type: ignore[assignment]
 
 # Allow tests to patch legacy shim module attributes if present
 try:  # pragma: no cover

--- a/src/chatty_commander/utils/logging_config.py
+++ b/src/chatty_commander/utils/logging_config.py
@@ -103,6 +103,10 @@ def configure_logging(
     effective_level = level or os.environ.get("LOG_LEVEL", "INFO")
     effective_format = log_format or os.environ.get("LOG_FORMAT", "plain")
 
+    # Type guards - these should never be None due to defaults above
+    assert effective_level is not None
+    assert effective_format is not None
+
     numeric_level = getattr(logging, effective_level.upper(), logging.INFO)
 
     root_logger = logging.getLogger()


### PR DESCRIPTION
## Summary
- Fixed type annotations for optional imports and added type guards
- Reduced mypy errors from 146 to 143 (3 errors fixed)

## Changes
- **app/command_executor.py**: Added type ignores for optional pyautogui and httpx imports
- **utils/logging_config.py**: Added type guards for effective_level and effective_format to prevent union-attr errors

## Test plan
- [x] `uv run mypy src` - errors reduced from 146 to 143
- [x] `uv run pytest -q` - all tests pass
- [x] `uv run ruff check .` - no new warnings

👾 Generated with [Letta Code](https://letta.com)