### PR TITLE
fix(types): reduce mypy errors by 7 with batch 17 (143→136)

### DIFF
--- a/src/chatty_commander/voice/pipeline.py
+++ b/src/chatty_commander/voice/pipeline.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
+from typing import Any
 
 from .transcription import VoiceTranscriber
 from .tts import TextToSpeech
@@ -307,7 +308,7 @@ class VoicePipeline:
                 self.tts.speak(text)
         return None
 
-    def get_status(self) -> dict[str, any]:
+    def get_status(self) -> dict[str, Any]:
         """Get pipeline status information."""
         return {
             "listening": self._listening,

--- a/src/chatty_commander/voice/transcription.py
+++ b/src/chatty_commander/voice/transcription.py
@@ -37,6 +37,7 @@ import tempfile
 import time
 import wave
 from abc import ABC, abstractmethod
+from typing import Any
 
 try:
     import numpy as np
@@ -44,8 +45,8 @@ try:
 
     AUDIO_DEPS_AVAILABLE = True
 except ImportError:
-    pyaudio = None
-    np = None
+    pyaudio = None  # type: ignore[assignment]
+    np = None  # type: ignore[assignment]
     AUDIO_DEPS_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ class WhisperAPIBackend(TranscriptionBackend):
 
     def __init__(self, api_key: str | None = None):
         self.api_key = api_key
-        self._client = None
+        self._client: Any = None
         self._initialize_client()
 
     def _initialize_client(self):
@@ -328,7 +329,7 @@ class VoiceTranscriber:
             finally:
                 self._audio = None
 
-    def get_backend_info(self) -> dict[str, any]:
+    def get_backend_info(self) -> dict[str, Any]:
         """Get information about the current backend."""
         return {
             "backend_type": type(self._backend).__name__,


### PR DESCRIPTION
## Summary
- Fixed type annotations for optional imports and fixed `any` → `Any` type hints
- Reduced mypy errors from 143 to 136 (7 errors fixed)

## Changes
- **voice/transcription.py**: Added type ignores for optional pyaudio/np imports, added Any import, fixed _client type
- **voice/pipeline.py**: Added Any import, fixed dict[str, any] → dict[str, Any]

## Test plan
- [x] `uv run mypy src` - errors reduced from 143 to 136
- [x] `uv run pytest -q` - all tests pass
- [x] `uv run ruff check .` - no new warnings

👾 Generated with [Letta Code](https://letta.com)