### PR TITLE
fix(types): reduce mypy errors by 8 with batch 20 (126→118)

### DIFF
--- a/src/chatty_commander/llm/backends.py
+++ b/src/chatty_commander/llm/backends.py
@@ -69,7 +69,7 @@ class OpenAIBackend(LLMBackend):
         self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
         self.max_retries = kwargs.get("max_retries", 3)
         self.timeout = kwargs.get("timeout", 30.0)
-        self._client = None
+        self._client: Any = None
         self._initialize_client()
 
     def _initialize_client(self):
@@ -161,7 +161,7 @@ class OllamaBackend(LLMBackend):
         self.host = host or os.getenv("OLLAMA_HOST", "ollama:11434")
         self.model = model
         self.base_url = f"http://{self.host}"
-        self._available = None
+        self._available: bool | None = None
         logger.info(f"Initialized Ollama backend: {self.base_url}, model: {self.model}")
 
     def is_available(self) -> bool:


### PR DESCRIPTION
## Summary
- Fixed type annotations for optional client and availability state
- Reduced mypy errors from 126 to 118 (8 errors fixed)

## Changes
- **llm/backends.py**: 
  - Changed `_client` type to `Any` in OpenAIBackend
  - Changed `_available` type to `bool | None` in OllamaBackend

## Test plan
- [x] `uv run mypy src` - errors reduced from 126 to 118
- [x] `uv run pytest -q` - all tests pass
- [x] `uv run ruff check .` - no new warnings

👾 Generated with [Letta Code](https://letta.com)