### PR TITLE
fix(types): reduce mypy errors by 6 with batch 25 (74→68)

### DIFF
--- a/src/chatty_commander/voice/self_test.py
+++ b/src/chatty_commander/voice/self_test.py
@@ -385,7 +385,7 @@ class VoiceSelfTester:
 
         return suggestions
 
-    def auto_tune_parameters(self, test_results: dict[str, any]) -> dict[str, any]:
+    def auto_tune_parameters(self, test_results: dict[str, Any]) -> dict[str, Any]:
         """Automatically suggest parameter adjustments based on test results."""
         tuning_recommendations = {
             "transcription_backend": "current",
@@ -435,7 +435,7 @@ def create_self_improvement_loop(
     transcriber: VoiceTranscriber | None = None,
     openai_api_key: str | None = None,
     iterations: int = 5,
-) -> dict[str, any]:
+) -> dict[str, Any]:
     """Create a self-improvement loop for the voice system."""
 
     tester = VoiceSelfTester(transcriber, openai_api_key)


### PR DESCRIPTION
## Summary
- Fixed any→Any in function signatures
- Reduced mypy errors from 74 to 68 (6 errors fixed)

## Changes
- **voice/self_test.py**: 
  - Fixed dict[str, any] in auto_tune_parameters
  - Fixed dict[str, any] in create_self_improvement_loop

## Test plan
- [x] `uv run mypy src` - errors reduced from 74 to 68
- [x] `uv run pytest -q` - all tests pass

👾 Generated with [Letta Code](https://letta.com)