### PR TITLE
fix: codebase sweep — TypeScript errors and test import paths

### DIFF
--- a/src/shared/ascii.ts
+++ b/src/shared/ascii.ts
@@ -1,11 +1,20 @@
 const NON_ASCII = /[^\x00-\x7F]/g;
 
-export function encodeASCII(s: string): string {
-  return s.replace(NON_ASCII, "?");
+export function encodeASCII(s: string): Uint8Array {
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    bytes[i] = code > 127 ? 63 : code; // 63 is '?'
+  }
+  return bytes;
 }
 
-export function decodeASCII(s: string): string {
-  // Identity function - encoded ASCII is already valid string
+export function decodeASCII(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const code = bytes[i];
+    s += String.fromCharCode(code > 127 ? 63 : code); // '?' for non-ASCII
+  }
   return s;
 }
 

--- a/tests/unit/ascii.test.js
+++ b/tests/unit/ascii.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { encodeASCII, decodeASCII, isASCII } from "../../shared/ascii.ts";
+import { encodeASCII, decodeASCII, isASCII } from "../../src/shared/ascii.ts";
 
 test("encodeASCII returns Uint8Array and replaces non-ascii", () => {
   const hello = encodeASCII("hello");

--- a/webui/frontend/src/components/WebSocketProvider.tsx
+++ b/webui/frontend/src/components/WebSocketProvider.tsx
@@ -22,7 +22,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
   const [lastMessageTime, setLastMessageTime] = useState<number | null>(null);
 
   // Refs to manage reconnection timer and state without triggering re-renders
-  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptRef = useRef(0);
   const shouldReconnectRef = useRef(true);
   const maxReconnectAttempts = 10;

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -279,40 +279,6 @@ export default function CommandsPage() {
               <div className="card-body p-0">
                 {/* Command Header */}
                 <div className="p-6 bg-base-200/50 border-b border-base-content/10 flex justify-between items-start">
-                  <div className="flex gap-3">
-                    <div className="p-3 rounded-xl bg-primary/20 text-primary">
-                      <TerminalSquare size={24} />
-                    </div>
-                    <div className="flex gap-1">
-                      <Dropdown
-                        trigger={
-                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.75a.75.75 0 110-1.5.75.75 0 010 1.5zM12 12.75a.75.75 0 110-1.5.75.75 0 010 1.5zM12 18.75a.75.75 0 110-1.5.75.75 0 010 1.5z" />
-                          </svg>
-                        }
-                        ariaLabel={`Options for ${name}`}
-                        color="ghost"
-                        size="sm"
-                        triggerClassName="btn-circle"
-                        align="right"
-                        hideArrow
-                        contentClassName="w-52 border border-base-content/10"
-                      >
-                        <li>
-                          <button aria-label={`Edit ${name}`}>
-                            <Edit3 size={16} className="text-primary" />
-                            Edit Command
-                          </button>
-                        </li>
-                        <li>
-                          <button className="text-error hover:bg-error/10 hover:text-error" aria-label={`Delete ${name}`} onClick={() => handleDeleteClick(name)}>
-                            <Trash2 size={16} />
-                            Delete Command
-                          </button>
-                        </li>
-                      </Dropdown>
-                    </div>
-                  </div>
                   <div className="flex gap-1">
                     <DynamicDropdown
                       buttonContent={

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -63,23 +63,10 @@ const DashboardPage = React.memo(() => {
     return () => clearInterval(id);
   }, [lastMessageTime]);
 
-  // Performance optimization: Memoize the recent messages derived array
-  // to avoid inline `messages.slice(-15)` during frequent real-time re-renders.
+  // Memoize the recent messages slice to avoid inline allocation during frequent re-renders.
   const recentMessages = useMemo(() => {
     return messages.length > MAX_RECENT_MESSAGES ? messages.slice(-MAX_RECENT_MESSAGES) : messages;
   }, [messages]);
-
-  // Performance optimization: Memoize mapped chat messages to avoid allocating
-  // a new array and forcing `<Chat>` to re-render every time telemetry updates.
-  const chatMessages = useMemo(() => {
-    return recentMessages.map((msg) => ({
-      content: msg.content,
-      sender: msg.source || 'System',
-      timestamp: msg.timestamp instanceof Date ? formatTimestamp(msg.timestamp) : (msg.timestamp || undefined),
-      isUser: msg.isCommand,
-      variant: msg.isCommand ? 'primary' : (msg.isError ? 'error' : 'secondary')
-    }));
-  }, [recentMessages]);
 
   const [commandInput, setCommandInput] = useState("");
   const [isSending, setIsSending] = useState(false);
@@ -397,9 +384,11 @@ const DashboardPage = React.memo(() => {
         <div className="card-body">
           <h3 className="card-title text-xl mb-4">Real-time Command Log</h3>
 
-          <div className="bg-base-300 rounded-box h-[20rem] overflow-y-auto w-full custom-scrollbar p-4">
-            {chatMessages.length > 0 ? (
-              <Chat messages={chatMessages} />
+          <div className="bg-base-300 rounded-box h-[20rem] overflow-y-auto w-full custom-scrollbar p-4 font-mono text-xs space-y-1">
+            {recentMessages.length > 0 ? (
+              recentMessages.map((msg, i) => (
+                <div key={i} className="text-base-content/80 leading-relaxed">{msg}</div>
+              ))
             ) : (
               <div className="p-4 text-base-content/50 italic text-center pt-24">
                 Waiting for commands...

--- a/webui/frontend/src/reportWebVitals.ts
+++ b/webui/frontend/src/reportWebVitals.ts
@@ -1,11 +1,11 @@
 const reportWebVitals = (onPerfEntry?: (metric: any) => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
+    import("web-vitals").then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
+      onCLS(onPerfEntry);
+      onINP(onPerfEntry);
+      onFCP(onPerfEntry);
+      onLCP(onPerfEntry);
+      onTTFB(onPerfEntry);
     });
   }
 };


### PR DESCRIPTION
## Summary

Squash commit of all fixes from the codebase sweep session.

## Changes

| File | Fix |
|------|-----|
| `src/shared/ascii.ts` | Rewrote `encodeASCII`/`decodeASCII` to use `Uint8Array` per unit test contract |
| `tests/unit/ascii.test.js` | Fixed import path (`../../shared/` → `../../src/shared/`) |
| `webui/frontend/src/pages/DashboardPage.tsx` | Removed broken `chatMessages` useMemo (treated `string[]` as objects) and undefined `<Chat>` component; replaced with simple log render |
| `webui/frontend/src/pages/CommandsPage.tsx` | Replaced undefined `Dropdown` component with existing `DynamicDropdown`; removed duplicate duplicate menu |
| `webui/frontend/src/components/WebSocketProvider.tsx` | `NodeJS.Timeout` → `ReturnType<typeof setTimeout>` (browser context) |
| `webui/frontend/src/reportWebVitals.ts` | Updated to web-vitals v5 API: `onCLS/onINP/onFCP/onLCP/onTTFB` (FID removed, replaced by INP) |

## Before / After

- `npx tsc --noEmit`: **18 errors → 0 errors**
- Unit tests: **2 failing → 5/5 passing**