### PR TITLE
🎨 Palette: Replace raw text close character with X vector icon in search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2024-04-12 - Replace text characters with vector icons for interactive elements
+**Learning:** Using raw text characters like '×' for close/clear buttons can cause visual alignment issues, looks inconsistent, and doesn't scale well with different themes or font sizes.
+**Action:** Always prefer vector icons (e.g., `<X size={16} />` from `lucide-react`) over raw text characters for interactive UI elements.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -240,6 +240,7 @@ export default function CommandsPage() {
               className="absolute right-3 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs btn-circle"
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
+              title="Clear search"
             >
               <X size={16} />
             </button>

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -12,7 +12,8 @@ import {
   RefreshCw,
   Search,
   Download,
-  Upload
+  Upload,
+  X
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
@@ -240,7 +241,7 @@ export default function CommandsPage() {
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
             >
-              ×
+              <X size={16} />
             </button>
           )}
         </div>


### PR DESCRIPTION
Replaced the raw '×' text character with a scalable vector <X /> icon from
lucide-react for the clear search button. This improves visual alignment,
consistency with the rest of the application's iconography, and ensures
it scales properly across different font sizes and themes.

---
*PR created automatically by Jules for task [3914313737525063497](https://jules.google.com/task/3914313737525063497) started by @matthewhand*