### PR TITLE
🎨 Palette: Add Tooltip to Disabled Execute Button on Dashboard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-04-18 - Fallback ARIA labels for dynamic dropdown triggers
 **Learning:** Components like `Dropdown.tsx` wrap trigger elements that may just be text, but sometimes lack a provided `ariaLabel`. If an icon is used instead of text, `ariaLabel` is critical. But if text is provided via the `trigger` prop and `ariaLabel` is omitted, the component fell back to a generic 'Toggle dropdown' which overrides the visual text if voice control is used, violating WCAG 2.5.3 (Label in Name).
 **Action:** Conditionally fallback `ariaLabel` to the string value of the `trigger` prop if one is provided and `ariaLabel` is omitted. This ensures voice control maps correctly to the visible text.
+
+## 2026-04-13 - Tooltip explaining disabled Execute button
+**Learning:** On `DashboardPage.tsx` the "Execute" button is disabled when `isSending`, `!isConnected`, or `!commandInput.trim()`. A bare disabled button leaves users guessing why. DaisyUI tooltips don't fire on disabled elements (`pointer-events: none`), so the tooltip must wrap the button in a `<div className="tooltip" data-tip="...">` and the button itself gets `pointer-events: none` while disabled.
+**Action:** Wrap disabled buttons in a `tooltip` container with a conditional `data-tip` explaining the disabled reason ("System disconnected" vs "Enter a command"), rather than putting a `title`/tooltip directly on the disabled control.

--- a/webui/frontend/src/hooks/useWebSocket.test.ts
+++ b/webui/frontend/src/hooks/useWebSocket.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useWebSocket } from "./useWebSocket";
 
 type WSHandler = ((ev?: any) => void) | null;

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -8,7 +8,6 @@ import {
   Plus,
   Edit3,
   Trash2,
-  FileAudio,
   RefreshCw,
   Search,
   Download,

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -446,15 +446,20 @@ const DashboardPage = React.memo(() => {
                 </div>
               )}
             </div>
-            <button
-              type="submit"
-              className="btn btn-primary"
-              disabled={!commandInput.trim() || isSending || !isConnected}
-              title={!isConnected ? "WebSocket connection required" : ""}
+            <div
+              className={(!isConnected || (!commandInput.trim() && !isSending)) ? "tooltip" : ""}
+              data-tip={!isConnected ? "System disconnected" : "Enter a command"}
             >
-              {isSending ? <span className="loading loading-spinner" aria-hidden="true"></span> : <Send size={18} aria-hidden="true" />}
-              Execute
-            </button>
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={!commandInput.trim() || isSending || !isConnected}
+                style={(!commandInput.trim() || isSending || !isConnected) ? { pointerEvents: "none" } : undefined}
+              >
+                {isSending ? <span className="loading loading-spinner" aria-hidden="true"></span> : <Send size={18} aria-hidden="true" />}
+                Execute
+              </button>
+            </div>
           </form>
         </div>
       </div>

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -449,6 +449,8 @@ const DashboardPage = React.memo(() => {
             <div
               className={(!isConnected || (!commandInput.trim() && !isSending)) ? "tooltip" : ""}
               data-tip={!isConnected ? "System disconnected" : "Enter a command"}
+              role="tooltip"
+              aria-label={!isConnected ? "System disconnected" : "Enter a command"}
             >
               <button
                 type="submit"


### PR DESCRIPTION
This PR adds a small UX improvement to the `DashboardPage` component by adding a tooltip to the "Execute" button when it is disabled.

*   When the WebSocket is disconnected, it shows "System disconnected".
*   When there is no input, it shows "Enter a command".
*   Fixes unused imports in `CommandsPage.tsx` and `useWebSocket.test.ts`.

This adheres to the Palette persona requirements of enhancing accessibility and user feedback without doing major redesigns.

---
*PR created automatically by Jules for task [8785858402795907742](https://jules.google.com/task/8785858402795907742) started by @matthewhand*