### PR TITLE
🎨 Palette: Add aria-labels to select elements for screen-reader accessibility

### DIFF
--- a/webui/frontend/src/pages/ConfigurationPage.tsx
+++ b/webui/frontend/src/pages/ConfigurationPage.tsx
@@ -366,6 +366,7 @@ const ConfigurationPage: React.FC = () => {
                   </div>
 
                   <select
+                    aria-label="Select Input Device"
                     className="select select-bordered select-sm w-full select-primary mb-4"
                     value={inputDevice}
                     onChange={(e) => setInputDevice(e.target.value)}
@@ -413,6 +414,7 @@ const ConfigurationPage: React.FC = () => {
                   </div>
 
                   <select
+                    aria-label="Select Output Device"
                     className="select select-bordered select-sm w-full select-secondary mb-4"
                     value={outputDevice}
                     onChange={(e) => setOutputDevice(e.target.value)}
@@ -509,6 +511,7 @@ const ConfigurationPage: React.FC = () => {
                      <span className="label-text-alt">Target State</span>
                    </label>
                    <select
+                    aria-label="Target State"
                     className="select select-bordered select-xs w-full"
                     value={uploadState}
                     onChange={(e) => setUploadState(e.target.value as "idle" | "computer" | "chatty")}


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the three `<select>` dropdowns in `ConfigurationPage.tsx` (Input Device, Output Device, Target State).
🎯 **Why**: The visual labels preceding these dropdowns lacked an `htmlFor` property or `id` binding to the `<select>` input, preventing screen readers from announcing their purpose. Adding `aria-label` directly on the input solves this accessibility gap cleanly without breaking visual design.
♿ **Accessibility**: Ensures screen readers can successfully interpret and announce the intended functions of configuration dropdowns.

---
*PR created automatically by Jules for task [6526756104994533415](https://jules.google.com/task/6526756104994533415) started by @matthewhand*