### PR TITLE
🎨 Palette: Replace raw text close character with lucide vector icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2024-05-23 - Visual Polish and Vector Icons
+**Learning:** Using raw text characters (like `X` or `×`) for UI controls like "Clear" or "Close" buttons results in poor visual alignment and inconsistency across different fonts and OSs. They also lack standard accessibility characteristics compared to SVG icons.
+**Action:** Always replace raw text characters used for icons with proper vector equivalents from the project's icon library (e.g., `X` from `lucide-react`).

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -12,7 +12,8 @@ import {
   RefreshCw,
   Search,
   Download,
-  Upload
+  Upload,
+  X
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
@@ -240,7 +241,7 @@ export default function CommandsPage() {
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
             >
-              ×
+              <X size={14} />
             </button>
           )}
         </div>


### PR DESCRIPTION
🎨 Palette: Replace raw text close character with lucide vector icon

What: Replaced the raw text character '×' in the "Clear search" button on the Commands page with the `<X />` vector icon from `lucide-react`.

Why: Raw text characters render inconsistently across different fonts, operating systems, and browsers, leading to misaligned icons. Vector icons ensure perfect pixel alignment, proper scaling, and standard semantic representation.

Accessibility: Improves the semantic structure. While the button already had an `aria-label`, standardizing on SVG icons prevents screen readers from unexpectedly vocalizing typographical math symbols or punctuation if properties are ever omitted.

---
*PR created automatically by Jules for task [10264177419428417752](https://jules.google.com/task/10264177419428417752) started by @matthewhand*