### PR TITLE
🎨 Palette: Improve Dropdown accessibility by falling back aria-label to string triggers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2026-04-17 - Dynamic ARIA Labels in Custom Components
+**Learning:** Custom UI components with icon-only triggers or triggers that contain text often need accessible names. Hardcoding a default `aria-label` (like "Toggle dropdown") overrides the text content of the trigger, violating WCAG 2.5.3 (Label in Name) when the trigger contains text.
+**Action:** When creating custom components like dropdowns, fallback the `aria-label` to the trigger's string content if it exists, rather than a generic hardcoded string, ensuring text content remains accessible and usable with voice control.

--- a/webui/frontend/src/components/DaisyUI/Dropdown.tsx
+++ b/webui/frontend/src/components/DaisyUI/Dropdown.tsx
@@ -67,7 +67,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     <div className={`dropdown ${positionCls} ${alignCls} ${className}`} ref={dropdownRef}>
       <div tabIndex={disabled ? -1 : 0} role="button"
         className={`btn ${sizeCls} ${colorCls} ${disabled ? 'btn-disabled opacity-50' : ''} ${triggerClassName}`}
-        onClick={handleToggle} aria-haspopup="true" aria-expanded={isOpen} aria-label={ariaLabel || 'Toggle dropdown'}>
+        onClick={handleToggle} aria-haspopup="true" aria-expanded={isOpen} aria-label={ariaLabel || (typeof trigger === 'string' ? trigger : 'Toggle dropdown')}>
         {trigger}
         {!hideArrow && <ChevronDown className="h-5 w-5" aria-hidden="true" />}
       </div>


### PR DESCRIPTION
Previously, the custom DaisyUI Dropdown component defaulted its `aria-label` to 'Toggle dropdown'. If a developer passed a string as the trigger (e.g., "Menu"), the screen reader would announce "Toggle dropdown" instead of "Menu", and voice control users saying "Click Menu" would fail to activate it, violating WCAG 2.5.3 (Label in Name).

This change conditionally falls back the `aria-label` to the trigger's string content if it is a string, preserving voice accessibility. Included an updated entry in the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [3283020185007619605](https://jules.google.com/task/3283020185007619605) started by @matthewhand*