### PR TITLE
🎨 Palette: Fallback aria-label to visible text for Dropdown trigger

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2026-04-18 - Fallback ARIA labels for dynamic dropdown triggers
+**Learning:** Components like `Dropdown.tsx` wrap trigger elements that may just be text, but sometimes lack a provided `ariaLabel`. If an icon is used instead of text, `ariaLabel` is critical. But if text is provided via the `trigger` prop and `ariaLabel` is omitted, the component fell back to a generic 'Toggle dropdown' which overrides the visual text if voice control is used, violating WCAG 2.5.3 (Label in Name).
+**Action:** Conditionally fallback `ariaLabel` to the string value of the `trigger` prop if one is provided and `ariaLabel` is omitted. This ensures voice control maps correctly to the visible text.

--- a/webui/frontend/src/components/DaisyUI/Dropdown.tsx
+++ b/webui/frontend/src/components/DaisyUI/Dropdown.tsx
@@ -63,11 +63,13 @@ const Dropdown: React.FC<DropdownProps> = ({
   const sizeCls = size === 'none' ? '' : `btn-${size}`;
   const colorCls = appliedColor === 'none' ? '' : `btn-${appliedColor}`;
 
+  const computedAriaLabel = ariaLabel || (typeof trigger === 'string' ? trigger : 'Toggle dropdown');
+
   return (
     <div className={`dropdown ${positionCls} ${alignCls} ${className}`} ref={dropdownRef}>
       <div tabIndex={disabled ? -1 : 0} role="button"
         className={`btn ${sizeCls} ${colorCls} ${disabled ? 'btn-disabled opacity-50' : ''} ${triggerClassName}`}
-        onClick={handleToggle} aria-haspopup="true" aria-expanded={isOpen} aria-label={ariaLabel || 'Toggle dropdown'}>
+        onClick={handleToggle} aria-haspopup="true" aria-expanded={isOpen} aria-label={computedAriaLabel}>
         {trigger}
         {!hideArrow && <ChevronDown className="h-5 w-5" aria-hidden="true" />}
       </div>


### PR DESCRIPTION
🎨 Palette: Fallback aria-label to visible text for Dropdown trigger

💡 What: Conditionally fallback the `aria-label` attribute on `Dropdown.tsx` to the value of the `trigger` prop if it is a string and no `ariaLabel` prop was explicitly provided.
🎯 Why: Prevents generic default labels (like "Toggle dropdown") from overriding the visible text trigger for screen readers and voice control software, resolving a WCAG 2.5.3 (Label in Name) violation.
♿ Accessibility: Ensures the accessible name matches the visible label when a string trigger is used. Recorded this finding in the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [13524515307439693302](https://jules.google.com/task/13524515307439693302) started by @matthewhand*