### PR TITLE
🎨 Palette: [a11y] Add descriptive aria-label to CommandsPage modal backdrop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+## 2024-05-19 - Accessible DaisyUI Modal Backdrops
+**Learning:** In DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden close `<button>` lacks descriptive context. Even if it contains the text "close", a descriptive `aria-label` provides better context for screen reader users about what exactly is being closed.
+**Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden button when implementing or updating DaisyUI modals.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 **What:** Added an `aria-label="Close dialog"` to the visually hidden close button in the delete confirmation modal backdrop on the `CommandsPage`.

🎯 **Why:** DaisyUI's `<form method="dialog">` modal backdrop pattern uses a visually hidden button stretched across the background to catch clicks outside the modal. Without a descriptive `aria-label`, screen reader users might just encounter an unhelpful "close" text or an empty button structure without knowing *what* it closes. This provides immediate, explicit context.

♿ **Accessibility:** Improves screen reader experience by making the purpose of the backdrop click-handler explicit.

---
*PR created automatically by Jules for task [15262770235896779039](https://jules.google.com/task/15262770235896779039) started by @matthewhand*