### PR TITLE
🎨 Palette: Add aria-label to modal backdrop

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+## 2024-05-23 - Modal Backdrop Accessibility
+**Learning:** DaisyUI's `<form method="dialog">` modal backdrop pattern uses a visually hidden `<button>` to handle clicks outside the modal. Without an `aria-label`, screen readers just read the button text "close", which lacks context about what exactly is being closed.
+**Action:** Always add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden `<button>` inside modal backdrops to provide better context for screen reader users.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added `aria-label="Close dialog"` to the modal backdrop's hidden close button in `CommandsPage.tsx` and documented the learning in `palette.md`.
🎯 Why: DaisyUI's `<form method="dialog">` pattern uses a visually hidden `<button>` to handle clicks outside the modal. Without a descriptive `aria-label`, screen readers just read the button text "close", which lacks context about what exactly is being closed.
📸 Before/After: Not a visual change.
♿ Accessibility: Improved screen reader context for closing the delete confirmation dialog.

---
*PR created automatically by Jules for task [5921684651987852900](https://jules.google.com/task/5921684651987852900) started by @matthewhand*