### PR TITLE
🎨 Palette: Add accessible aria-label to DaisyUI modal backdrop close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2024-04-22 - Explicit Aria Label on DaisyUI Modal Backdrop
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden `<button>` lacks a descriptive accessible name by default. Even if it contains the text "close", it fails to provide adequate context for screen reader users about what exactly is being closed.
+**Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden `<button>` inside `<form method="dialog" className="modal-backdrop">` to ensure screen reader accessibility.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added `aria-label="Close dialog"` to the visually hidden close button inside the `<form method="dialog" className="modal-backdrop">` on the Commands page.
🎯 Why: DaisyUI uses a hidden button inside a form to trigger dialog closures when the backdrop is clicked. Without an `aria-label`, screen readers may only announce "close" (the button text) without context, or sometimes struggle to provide a meaningful accessible name. This small change provides explicit context for screen reader users that this button closes the dialog.
♿ Accessibility: Improves accessibility for screen reader users interacting with modal backdrops.
📓 Journal: Added learning to `.jules/palette.md` for future reference when using this DaisyUI pattern.

---
*PR created automatically by Jules for task [14970831664558985961](https://jules.google.com/task/14970831664558985961) started by @matthewhand*