### PR TITLE
🎨 Palette: Add ARIA label to hidden modal backdrop button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+## 2024-04-24 - Add ARIA label to visually hidden modal backdrop
+**Learning:** DaisyUI's `<form method="dialog" className="modal-backdrop">` pattern uses an empty/sparse `<button>close</button>` that is visually hidden to provide a click-away-to-close behavior. Because it's a real button that screen readers might focus on, simply saying "close" is confusing.
+**Action:** Always add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to these specific backdrop buttons so screen reader users understand the exact action occurring.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 **What**: Added an `aria-label="Close dialog"` to the visually hidden modal backdrop `<button>` in `CommandsPage.tsx`.
🎯 **Why**: DaisyUI's `<form method="dialog">` backdrop pattern uses a `<button>` with minimal text (just "close") which is visually hidden but can be interpreted by screen readers. Adding a descriptive `aria-label` provides better context for users relying on assistive technologies.
♿ **Accessibility**: Improves screen reader context for modal close interactions.

---
*PR created automatically by Jules for task [5147239358273993655](https://jules.google.com/task/5147239358273993655) started by @matthewhand*