### PR TITLE
🎨 Palette: Add accessible label to modal backdrop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2026-04-25 - Accessible DaisyUI Modal Backdrops
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern to close modals when clicking outside, always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden `<button>` element inside. Even if the text content is 'close', a descriptive aria-label provides better context for screen reader users about what exactly is being closed.
+**Action:** Ensure all `modal-backdrop` forms have an accessible name on their closing button.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added an explicit `aria-label="Close dialog"` to the visually hidden backdrop button that closes the Delete Confirmation modal in the Commands Page.
🎯 Why: DaisyUI's `<form method="dialog">` modal backdrop pattern uses an invisible button to capture clicks outside the modal box to close it. Without an explicit `aria-label`, screen readers might announce this vaguely (e.g., just "close"), or if the button was entirely empty, announce nothing at all. This explicit label provides clear context on what action will be performed.
♿ Accessibility: Improved screen reader context for modal dismissal via the backdrop overlay. Added an entry to the `.jules/palette.md` journal detailing this pattern so it can be applied to future modals.

---
*PR created automatically by Jules for task [9491301105729990622](https://jules.google.com/task/9491301105729990622) started by @matthewhand*