### PR TITLE
🎨 Palette: Add aria-label to modal backdrop close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2026-04-28 - Modal Backdrop Accessibility
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden `<button>` needs a descriptive `aria-label`. Even if it contains the text 'close', a descriptive label provides better context for screen reader users about what exactly is being closed.
+**Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden `<button>` in DaisyUI modal backdrops.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
**💡 What:** Added a descriptive `aria-label` to the visually hidden `<button>` inside DaisyUI's `<form method="dialog" className="modal-backdrop">` pattern in `CommandsPage.tsx`.
**🎯 Why:** DaisyUI uses a visually hidden button covering the entire screen behind the modal to implement the "click outside to close" behavior. Without an `aria-label`, screen readers might just announce "button" or the default text ("close") without context. Explicitly defining `aria-label="Close dialog"` provides clarity to assistive technologies.
**📸 Before/After:** (Visuals are identical, change is purely semantic/accessibility DOM attributes). Screenshot verified locally via Playwright.
**♿ Accessibility:** Improved screen reader context for modal backdrop dismissals. Documented pattern in `.jules/palette.md`.

---
*PR created automatically by Jules for task [765281468603846869](https://jules.google.com/task/765281468603846869) started by @matthewhand*