### PR TITLE
🎨 Palette: Add aria-label to delete confirmation modal backdrop button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2024-05-23 - DaisyUI Modal Dialog A11y
+**Learning:** The `<form method="dialog">` backdrop pattern from DaisyUI requires an explicit `aria-label` on the visually hidden `<button>close</button>` to provide adequate context for screen readers when closing modals.
+**Action:** Always add an `aria-label="Close dialog"` (or similar descriptive text) to the visually hidden submit button in DaisyUI modal backdrops.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -8,7 +8,6 @@ import {
   Plus,
   Edit3,
   Trash2,
-  FileAudio,
   RefreshCw,
   Search,
   Download,
@@ -363,7 +362,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added an `aria-label="Close dialog"` to the DaisyUI modal backdrop close button in `CommandsPage.tsx` and removed an unused `FileAudio` import.
🎯 Why: The visually hidden `<button>close</button>` in `<form method="dialog">` lacked sufficient context for screen reader users when interacting with the modal backdrop.
♿ Accessibility: Improved screen reader announcements for the modal dismissal action.

---
*PR created automatically by Jules for task [7312913947097876738](https://jules.google.com/task/7312913947097876738) started by @matthewhand*