### PR TITLE
⚡ Bolt: Memoize agent cards mapping in DashboardPage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,9 @@
 ## 2026-04-12 - [Module-Level Variable Imports]
 **Learning:** When a code review flags missing imports or predicts `NameError`s on startup, always verify their presence in the target file using bash commands (e.g., `grep`) before attempting a fix, as the reviewer's context may be hallucinated or outdated.
 **Action:** Use grep to check for imports like `import threading` and `from typing import Any` before assuming they are missing.
+## 2024-05-15 - [DashboardPage React Agent Cards Map Memoization]
+**Learning:** High-frequency WebSocket telemetry events on a dashboard trigger global re-renders. When expensive operations like  on large lists (like ) are defined inline within JSX, they re-execute on every frame, causing unnecessary DOM reallocation and thread blocking.
+**Action:** Extract static helper functions (like ) outside the component and wrap mapping of frequent unchanging data (like ) inside  to prevent reallocation.
+## 2024-05-15 - [DashboardPage React Agent Cards Map Memoization]
+**Learning:** High-frequency WebSocket telemetry events on a dashboard trigger global re-renders. When expensive operations like `.map` on large lists (like `agentData`) are defined inline within JSX, they re-execute on every frame, causing unnecessary DOM reallocation and thread blocking.
+**Action:** Extract static helper functions (like `getAgentStatusColor`) outside the component and wrap mapping of frequent unchanging data (like `agentData`) inside `useMemo` to prevent reallocation.

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -36,6 +36,16 @@ const CustomTooltip = React.memo(({ active, payload, label }: any) => {
   return null;
 });
 
+const getAgentStatusColor = (status: Agent["status"]) => {
+  switch (status) {
+    case "online": return "badge-success";
+    case "offline": return "badge-ghost";
+    case "error": return "badge-error";
+    case "processing": return "badge-warning";
+    default: return "badge-ghost";
+  }
+};
+
 const DashboardPage = React.memo(() => {
   useEffect(() => {
     document.title = "Dashboard | ChattyCommander";
@@ -155,15 +165,46 @@ const DashboardPage = React.memo(() => {
     retry: 2,
   });
 
-  const getAgentStatusColor = (status: Agent["status"]) => {
-    switch (status) {
-      case "online": return "badge-success";
-      case "offline": return "badge-ghost";
-      case "error": return "badge-error";
-      case "processing": return "badge-warning";
-      default: return "badge-ghost";
-    }
-  };
+  // ⚡ Bolt: Memoize the mapping of agent data into React elements.
+  // This prevents reallocation and re-rendering of all agent cards on every unrelated state update
+  // (like frequent WebSocket telemetry), reducing main thread blocking during active sessions.
+  const agentCards = useMemo(() => {
+    return agentData?.map((agent) => (
+      <div key={agent.id} className="card bg-base-100 shadow-xl border border-base-content/10">
+        <div className="card-body p-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="card-title text-xl font-bold">{agent.name}</h3>
+            <div className={`badge ${getAgentStatusColor(agent.status)} badge-lg font-bold uppercase`}>
+              {agent.status}
+            </div>
+          </div>
+
+          {agent.error && (
+            <div className="alert alert-error shadow-sm text-xs py-2 my-2 rounded-lg">
+              <span>{agent.error}</span>
+            </div>
+          )}
+
+          <div className="mockup-code bg-base-300 text-xs mt-2 before:hidden p-0">
+            <div className="px-4 py-3 space-y-3">
+              <div className="flex flex-col">
+                <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Sent</span>
+                <span className="font-mono text-primary">{agent.lastMessageSent || "-"}</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Received</span>
+                <span className="font-mono text-secondary">{agent.lastMessageReceived || "-"}</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Content</span>
+                <span className="font-mono text-base-content/70 break-words mt-1">{agent.lastMessageContent || "-"}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    ));
+  }, [agentData]);
 
   const handleWsMessage = useCallback((event: MessageEvent) => {
     try {
@@ -435,41 +476,7 @@ const DashboardPage = React.memo(() => {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {agentData?.map((agent) => (
-            <div key={agent.id} className="card bg-base-100 shadow-xl border border-base-content/10">
-              <div className="card-body p-4">
-                <div className="flex justify-between items-center mb-4">
-                  <h3 className="card-title text-xl font-bold">{agent.name}</h3>
-                  <div className={`badge ${getAgentStatusColor(agent.status)} badge-lg font-bold uppercase`}>
-                    {agent.status}
-                  </div>
-                </div>
-
-                {agent.error && (
-                  <div className="alert alert-error shadow-sm text-xs py-2 my-2 rounded-lg">
-                    <span>{agent.error}</span>
-                  </div>
-                )}
-
-                <div className="mockup-code bg-base-300 text-xs mt-2 before:hidden p-0">
-                  <div className="px-4 py-3 space-y-3">
-                    <div className="flex flex-col">
-                      <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Sent</span>
-                      <span className="font-mono text-primary">{agent.lastMessageSent || "-"}</span>
-                    </div>
-                    <div className="flex flex-col">
-                      <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Received</span>
-                      <span className="font-mono text-secondary">{agent.lastMessageReceived || "-"}</span>
-                    </div>
-                    <div className="flex flex-col">
-                      <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Content</span>
-                      <span className="font-mono text-base-content/70 break-words mt-1">{agent.lastMessageContent || "-"}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
+          {agentCards}
         </div>
       )}
     </div>


### PR DESCRIPTION
### 💡 What
Extracted the static `getAgentStatusColor` helper outside of the `DashboardPage` component and memoized the `agentData` mapping directly to `agentCards` via `useMemo`.

### 🎯 Why
High-frequency WebSocket events (like CPU/memory telemetry) cause frequent re-renders of the entire dashboard. Mapping large complex elements (like the agent status cards) inline inside the returned JSX means React has to constantly re-allocate those objects on every telemetry tick, which blocks the main thread.

### 📊 Impact
Reduces unnecessary component reallocation. The agent cards will now only re-render when the actual `agentData` array changes, significantly freeing up main thread processing during WebSocket telemetry streams.

### 🔬 Measurement
Load the dashboard and use React Developer Tools (Profiler). Trigger high frequency WebSocket telemetry updates (or simulate component re-renders). Observe that the `<DashboardPage>` component re-renders but the underlying agent card elements bypass heavy recalculation logic.

---
*PR created automatically by Jules for task [3591808025712051621](https://jules.google.com/task/3591808025712051621) started by @matthewhand*