### PR TITLE
🎨 Palette: Add ARIA label to modal backdrop close button

### DIFF
--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: The UX enhancement added: `aria-label="Close dialog"` to the visually hidden close `<button>` inside the DaisyUI modal backdrop form in the `CommandsPage`.
🎯 Why: The user problem it solves: Screen readers only announce the button text ("close"), which may lack sufficient context about what is being closed (a dialog vs a panel vs an app). Adding a descriptive `aria-label` provides better context.
📸 Before/After: Not applicable (no visual change)
♿ Accessibility: Improves screen reader context for the hidden modal backdrop dismissal button.

---
*PR created automatically by Jules for task [16321768991267616976](https://jules.google.com/task/16321768991267616976) started by @matthewhand*