### PR TITLE
🔒 [security fix] Restrict overly permissive CORS policy and enforce credential safety

### DIFF
--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -86,6 +86,39 @@ class TestSecurity:
         # CORS should be properly configured
         assert server.no_auth is True
 
+        # Verify CORS middleware is present and restrictive
+        from fastapi.middleware.cors import CORSMiddleware
+        cors_middleware = next(
+            m for m in server.app.user_middleware if m.cls is CORSMiddleware
+        )
+        allow_origins = cors_middleware.options.get("allow_origins", [])
+        allow_credentials = cors_middleware.options.get("allow_credentials", False)
+
+        # Wildcard should NOT be present in dev mode anymore
+        assert "*" not in allow_origins
+        assert "http://localhost:3000" in allow_origins
+
+        # If wildcard WERE present, allow_credentials must be False
+        if "*" in allow_origins:
+            assert not allow_credentials
+
+    def test_apply_cors_wildcard_safety(self):
+        """Test that apply_cors enforces allow_credentials=False for wildcard origins."""
+        from fastapi import FastAPI
+        from chatty_commander.web.auth import apply_cors
+        from fastapi.middleware.cors import CORSMiddleware
+
+        app = FastAPI()
+        # Manually provide wildcard origin
+        apply_cors(app, no_auth=False, origins=["*"])
+
+        cors_middleware = next(
+            m for m in app.user_middleware if m.cls is CORSMiddleware
+        )
+        assert cors_middleware.options["allow_origins"] == ["*"]
+        # Must be False for wildcard
+        assert cors_middleware.options["allow_credentials"] is False
+
 
 class TestClientIPSecurity:
     """Tests for secure client IP extraction to prevent IP spoofing attacks."""


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an overly permissive CORS policy that used a wildcard `"*"` for `allow_origins` while having `allow_credentials=True` enabled in development/no-auth mode.

⚠️ **Risk:**
1.  **Insecure Configuration:** Allowing any origin to make credentialed requests (cookies, auth headers) can lead to Cross-Site Request Forgery (CSRF) or data theft if an attacker can lure an authenticated user to a malicious site.
2.  **Browser Blocking:** Modern browsers block CORS requests where both `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Credentials: true` are set, causing breakage in legitimate development scenarios.

🛡️ **Solution:**
1.  **Restrictive Origins:** Replaced the wildcard `"*"` in `no_auth` mode with a specific list of common local development origins (`localhost` and `127.0.0.1` on ports 3000 and 5173).
2.  **Credential Safety:** Implemented a dynamic check to ensure `allow_credentials` is only `True` if no wildcard origin is present.
3.  **Consistency:** Refactored `web_mode.py` to use the centralized `apply_cors` logic from `auth.py`, ensuring a uniform security policy across the application.

Tests added to `tests/test_security.py` verify both the restrictive origin list in dev mode and the wildcard-credential safety check.

---
*PR created automatically by Jules for task [12251663537268521011](https://jules.google.com/task/12251663537268521011) started by @matthewhand*