### PR TITLE
🎨 Palette: Add aria-label to modal backdrop close button

### DIFF
--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label="Close dialog"` to the modal backdrop close button in `CommandsPage.tsx`.
🎯 **Why:** DaisyUI's `<form method="dialog">` pattern relies on a visually hidden button to capture backdrop clicks. Without an `aria-label`, screen readers might announce this button generically (or just read its text content, "close", out of context). Adding the descriptive label makes the interface more accessible.
♿ **Accessibility:** Improved screen reader context for the hidden backdrop close button.

---
*PR created automatically by Jules for task [13550666858830068289](https://jules.google.com/task/13550666858830068289) started by @matthewhand*