### PR TITLE
🎨 Palette: [a11y] Add ARIA label to DaisyUI modal backdrop button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+## 2026-05-07 - Explicit Labeling of DaisyUI Modal Backdrops
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden close `<button>` covering the background should have an explicit `aria-label` (e.g. "Close dialog"). This is because the text content 'close' alone lacks context when read by a screen reader navigating outside the modal content.
+**Action:** Always explicitly define a descriptive `aria-label` on visually hidden `<button>` elements used for closing modals or popovers to improve context for screen readers.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
Added `aria-label="Close dialog"` to the DaisyUI modal backdrop close button in `CommandsPage.tsx` to provide better context for screen reader users when dismissing the modal dialog. Tested cleanly using `pnpm lint`, `pnpm type-check`, and `pnpm build`. Added UX learning to `.jules/palette.md`.

---
*PR created automatically by Jules for task [5434068618782716932](https://jules.google.com/task/5434068618782716932) started by @matthewhand*