### PR TITLE
🎨 Palette: Add aria-label to modal backdrop close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2024-05-14 - Add ARIA label to DaisyUI modal backdrops
+**Learning:** DaisyUI's `<form method="dialog">` modal backdrop pattern implicitly creates a hidden button for closing the dialog by clicking outside. While visually hidden and containing the text 'close', adding an explicit `aria-label="Close dialog"` ensures screen readers accurately convey the action (closing the dialog) rather than just reading the word "close" which might be ambiguous out of context.
+**Action:** Always explicitly add a descriptive `aria-label` to visually hidden backdrop close buttons in DaisyUI modals.

--- a/src/chatty_commander/cli/main.py
+++ b/src/chatty_commander/cli/main.py
@@ -122,7 +122,6 @@ def run_cli_mode(config, model_manager, state_manager, command_executor, logger)
 
 
 def run_web_mode(
-    """run web mode."""
     config,
     model_manager,
     state_manager,
@@ -238,7 +237,6 @@ def run_web_mode(
 
 
 def run_gui_mode(
-    """run gui mode."""
     config,
     model_manager,
     state_manager,
@@ -571,7 +569,6 @@ def run_interactive_shell(
 
 
 def run_orchestrator_mode(
-    """run orchestrator mode."""
     config, model_manager, state_manager, command_executor, logger, args
 ):
     """Run orchestrator-driven mode; adapters route to the same command sink."""

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
Added an `aria-label="Close dialog"` to the visually hidden modal backdrop close button in `CommandsPage.tsx` to improve screen reader accessibility. Also recorded this learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [266635190753173912](https://jules.google.com/task/266635190753173912) started by @matthewhand*