### PR TITLE
🎨 Palette: Add descriptive aria-label to DaisyUI modal backdrop close button

### DIFF
--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
Added a descriptive `aria-label="Close dialog"` to the visually hidden close `<button>` within the modal backdrop form in the `CommandsPage`. This improves screen reader accessibility by providing better context than the default "close" text, adhering to UX and accessibility guidelines for DaisyUI components.

---
*PR created automatically by Jules for task [15343427757511684488](https://jules.google.com/task/15343427757511684488) started by @matthewhand*