### PR TITLE
🎨 Palette: Add descriptive aria-label to delete confirmation modal backdrop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+## 2024-05-12 - Explicit Labeling for Modal Backdrops
+**Learning:** When using `<form method="dialog">` in DaisyUI (and similar frameworks) where a `<button>` acts as a visually hidden click-to-close background overlay, standard implementations often use raw text like `<button>close</button>`. This creates an inaccessible "close" button for screen reader users without appropriate context.
+**Action:** Always add an explicit, descriptive `aria-label` (e.g. `aria-label="Close dialog"`) to modal backdrop buttons to ensure clear function description for assistive technologies, regardless of the internal button text.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added an `aria-label` to the background-click dismiss button on the delete confirmation modal.
🎯 Why: DaisyUI's `<form method="dialog">` pattern uses a visually hidden button to handle clicking the backdrop to close the modal. Screen readers announce this button simply as "close", which lacks context. Adding an explicit label improves the accessibility of this component.
♿ Accessibility: Ensures that screen reader users navigating to the hidden dismiss button understand its purpose in context.

---
*PR created automatically by Jules for task [15433449783628414844](https://jules.google.com/task/15433449783628414844) started by @matthewhand*