### PR TITLE
🎨 Palette: Make audio test buttons screen reader accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-19 - Accessible DaisyUI Modal Backdrops
 **Learning:** In DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden close `<button>` lacks descriptive context. Even if it contains the text "close", a descriptive `aria-label` provides better context for screen reader users about what exactly is being closed.
 **Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden button when implementing or updating DaisyUI modals.
+## 2026-05-13 - Dynamic ARIA labels for dynamic text
+**Learning:** When adding an `aria-label` to a button whose inner text changes dynamically based on state (e.g., `isTesting ? "Testing..." : "Test"`), the `aria-label` must also be dynamic to match the state (e.g., `aria-label={isTesting ? "Testing device" : "Test device"}`). A static `aria-label` completely overrides the inner text for screen readers, hiding the visual state change from assistive technologies.
+**Action:** Always check if a component has dynamic inner text before adding an `aria-label`. If the text changes based on state, make sure the `aria-label` also reflects that state.

--- a/webui/frontend/src/pages/ConfigurationPage.tsx
+++ b/webui/frontend/src/pages/ConfigurationPage.tsx
@@ -382,6 +382,7 @@ const ConfigurationPage: React.FC = () => {
                         onClick={handleTestMic}
                         disabled={isTestingMic || !inputDevice}
                         title={inputDevice ? "Test microphone" : "Select a device first"}
+                        aria-label={isTestingMic ? "Testing microphone device" : "Test microphone device"}
                       >
                         {isTestingMic ? "Testing..." : "Test"}
                       </button>
@@ -431,6 +432,7 @@ const ConfigurationPage: React.FC = () => {
                         onClick={handleTestOutput}
                         disabled={isTestingOutput || !outputDevice}
                         title={outputDevice ? "Test audio output" : "Select a device first"}
+                        aria-label={isTestingOutput ? "Playing output device" : "Test output device"}
                       >
                         {isTestingOutput ? "Playing..." : "Test"}
                       </button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the "Test" buttons for microphone and output device in the Configuration page.
🎯 Why: Screen readers would previously just read "Test", without context of what was being tested. Furthermore, when the button is pressed, the text changes to "Testing..." or "Playing...", but a static `aria-label` would override this dynamic text change for assistive technologies. Making the label dynamic ensures the state is correctly announced.
♿ Accessibility: Improves screen reader context and state announcement for the configuration test buttons.

---
*PR created automatically by Jules for task [10698440448832354229](https://jules.google.com/task/10698440448832354229) started by @matthewhand*