### PR TITLE
🎨 Palette: Add explicit aria-label to DaisyUI modal close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
-**Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+**Action:** Always explicitly define uniquely generated IDs (e.g. `id={`field-${index}`}`) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2026-05-14 - Explicit aria-label for 'close' form modals in DaisyUI
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern, always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden `<button>`. Even if it contains the text 'close', a descriptive label provides better context for screen reader users about what exactly is being closed.
+**Action:** Add `aria-label="Close dialog"` to the internal button of `<form method="dialog" className="modal-backdrop">`.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
Adds a descriptive `aria-label="Close dialog"` to the visually hidden `<button>` inside the `<form method="dialog">` in the `CommandsPage` delete confirmation modal. Even though the button contains the text "close", providing a descriptive label improves context for screen reader users when dismissing the dialog.

---
*PR created automatically by Jules for task [5436248009115658707](https://jules.google.com/task/5436248009115658707) started by @matthewhand*