### PR TITLE
🎨 Palette: Add descriptive ARIA label to modal backdrop close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
-**Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+**Action:** Always explicitly define uniquely generated IDs (e.g. `id={\`field-${index}\`}`) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2024-06-25 - Descriptive ARIA Labels for Modal Backdrop Close Buttons
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden close `<button>` inside it is often left as just `<button>close</button>`. This lacks context for screen reader users who might just hear "close button" without knowing what is being closed.
+**Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden `<button>` inside `<form method="dialog">` to provide better context for screen reader users.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close delete confirmation dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added `aria-label="Close delete confirmation dialog"` to the visually hidden close button inside the modal backdrop form in `CommandsPage.tsx`.
🎯 Why: To provide better context for screen reader users who might focus on the hidden button, ensuring they know exactly what dialogue is being closed.
♿ Accessibility: Improved screen reader context for the DaisyUI `<form method="dialog">` backdrop close pattern.

---
*PR created automatically by Jules for task [5822666628919578603](https://jules.google.com/task/5822666628919578603) started by @matthewhand*