### PR TITLE
🎨 Palette: Add descriptive aria-label to modal backdrop close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2024-07-26 - DaisyUI Modal Backdrop Labeling
+**Learning:** When using the common DaisyUI pattern of `<form method="dialog">` wrapped around a hidden "close" button to create an invisible modal backdrop, leaving the inner button text as just "close" is technically accessible but highly ambiguous to screen readers if focused.
+**Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the `<button>` element inside a `<form method="dialog" className="modal-backdrop">`, as it provides much better context for assistive technology users compared to the default inner text.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
This PR addresses a minor accessibility ambiguity when using DaisyUI's `<form method="dialog" className="modal-backdrop">` pattern.

💡 **What:** Added `aria-label="Close dialog"` to the hidden close button in the delete confirmation modal backdrop in `CommandsPage.tsx`.
🎯 **Why:** To provide clear, descriptive context to screen readers, preventing the button from simply announcing as "close".
♿ **Accessibility:** Improves the contextual labeling of a semantic modal dismissal button for non-visual users.

---
*PR created automatically by Jules for task [10652160077502720623](https://jules.google.com/task/10652160077502720623) started by @matthewhand*