### PR TITLE
🎨 Palette: Add aria-label to delete confirmation modal backdrop button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+## 2026-05-17 - Added descriptive aria-label to DaisyUI modal backdrop close button
+**Learning:** In DaisyUI's `<form method="dialog">` modal backdrop pattern, the `<button>` used to close the dialog is typically visually hidden and stretched across the background. Even if it contains the text "close", providing a specific `aria-label` (like "Close delete confirmation dialog") gives better context to screen reader users about what exactly is being closed.
+**Action:** When implementing modal backdrops using `<form method="dialog">`, always explicitly add a descriptive `aria-label` to the internal button element.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close delete confirmation dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 **What**: Added an explicit `aria-label` to the modal backdrop close button in the Delete Confirmation dialog.
🎯 **Why**: In DaisyUI's `<form method="dialog">` modal backdrop pattern, the `<button>` to close the dialog stretches across the background. Even if it contains the text 'close', adding a descriptive `aria-label` like "Close delete confirmation dialog" provides much better context for screen reader users about what exactly is being closed when they interact with the backdrop.
♿ **Accessibility**: Enhanced screen reader context for modal backdrop interactions.

---
*PR created automatically by Jules for task [4033824116995571732](https://jules.google.com/task/4033824116995571732) started by @matthewhand*