### PR TITLE
🎨 Palette: Add descriptive aria-label to modal backdrop close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2026-05-18 - Descriptive ARIA labels on DaisyUI modal backdrops
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden `<button>` element is used to close the dialog when the backdrop is clicked. Even if it contains the text "close", a generic label is not sufficient. A descriptive label provides much better context for screen reader users about what exactly is being closed.
+**Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the visually hidden `<button>` inside `<form method="dialog" className="modal-backdrop">`.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close delete confirmation dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added a specific `aria-label="Close delete confirmation dialog"` to the `<button>` used by the daisyUI modal backdrop form in `CommandsPage.tsx`.

🎯 Why: The visually hidden button used for `<form method="dialog">` backdrop dismissal previously lacked descriptive context, reading simply as "close", which provides insufficient context to screen reader users about what they are closing.

♿ Accessibility: Ensures that screen reader users navigating to or triggering the background modal dismissal will hear explicitly what dialog is being closed rather than a generic term.

---
*PR created automatically by Jules for task [17936786071151037886](https://jules.google.com/task/17936786071151037886) started by @matthewhand*