### PR TITLE
🎨 Palette: Add aria-label to CommandsPage modal backdrop button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+## 2026-05-19 - Modal Backdrop ARIA Labels
+**Learning:** When using DaisyUI's `<form method="dialog">` modal backdrop pattern, the visually hidden `<button>` inside it acts as the click-outside-to-close mechanism. While visually invisible, it is still focusable and readable by screen readers. A bare `close` text is less descriptive than an explicit action like `Close dialog`.
+**Action:** Always add `aria-label="Close dialog"` to the visually hidden `<button>` inside `<form method="dialog" className="modal-backdrop">` to provide better context for assistive technologies.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
Added descriptive aria-label to the hidden modal backdrop button for improved screen reader context when closing the delete confirmation modal.

---
*PR created automatically by Jules for task [2463504644076576716](https://jules.google.com/task/2463504644076576716) started by @matthewhand*