### PR TITLE
⚡ Bolt: Memoize mapped agent cards in DashboardPage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,7 @@
 ## 2026-04-12 - [Module-Level Variable Imports]
 **Learning:** When a code review flags missing imports or predicts `NameError`s on startup, always verify their presence in the target file using bash commands (e.g., `grep`) before attempting a fix, as the reviewer's context may be hallucinated or outdated.
 **Action:** Use grep to check for imports like `import threading` and `from typing import Any` before assuming they are missing.
+
+## 2024-05-21 - Memoizing frequent renders in DashboardPage
+**Learning:** In React, inline mappings (like `data?.map()`) inside heavily-rerendered components (e.g. ones receiving frequent WebSocket telemetry) cause unnecessary reconciliation. Extracting static helper functions out of the component and wrapping mapped JSX in `useMemo` significantly reduces reallocation overhead.
+**Action:** Always wrap mapped JSX arrays that depend on slower-changing data in `useMemo`, and place them at the top-level of the component (not inside conditional JSX) to satisfy hooks rules, especially in components receiving frequent external updates.

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -36,6 +36,16 @@ const CustomTooltip = React.memo(({ active, payload, label }: any) => {
   return null;
 });
 
+const getAgentStatusColor = (status: Agent["status"]) => {
+  switch (status) {
+    case "online": return "badge-success";
+    case "offline": return "badge-ghost";
+    case "error": return "badge-error";
+    case "processing": return "badge-warning";
+    default: return "badge-ghost";
+  }
+};
+
 const DashboardPage = React.memo(() => {
   useEffect(() => {
     document.title = "Dashboard | ChattyCommander";
@@ -155,15 +165,47 @@ const DashboardPage = React.memo(() => {
     retry: 2,
   });
 
-  const getAgentStatusColor = (status: Agent["status"]) => {
-    switch (status) {
-      case "online": return "badge-success";
-      case "offline": return "badge-ghost";
-      case "error": return "badge-error";
-      case "processing": return "badge-warning";
-      default: return "badge-ghost";
-    }
-  };
+  // Optimization: Memoize the rendered agent cards.
+  // The DashboardPage re-renders frequently due to WebSocket telemetry updates (cpu, memory).
+  // Without useMemo, this map function would re-allocate the entire array of agent cards
+  // on every tick, causing unnecessary reconciliation. This reduces reallocation overhead.
+  const agentCards = useMemo(() => {
+    return agentData?.map((agent) => (
+      <div key={agent.id} className="card bg-base-100 shadow-xl border border-base-content/10">
+        <div className="card-body p-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="card-title text-xl font-bold">{agent.name}</h3>
+            <div className={`badge ${getAgentStatusColor(agent.status)} badge-lg font-bold uppercase`}>
+              {agent.status}
+            </div>
+          </div>
+
+          {agent.error && (
+            <div className="alert alert-error shadow-sm text-xs py-2 my-2 rounded-lg">
+              <span>{agent.error}</span>
+            </div>
+          )}
+
+          <div className="mockup-code bg-base-300 text-xs mt-2 before:hidden p-0">
+            <div className="px-4 py-3 space-y-3">
+              <div className="flex flex-col">
+                <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Sent</span>
+                <span className="font-mono text-primary">{agent.lastMessageSent || "-"}</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Received</span>
+                <span className="font-mono text-secondary">{agent.lastMessageReceived || "-"}</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Content</span>
+                <span className="font-mono text-base-content/70 break-words mt-1">{agent.lastMessageContent || "-"}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    ));
+  }, [agentData]);
 
   const handleWsMessage = useCallback((event: MessageEvent) => {
     try {
@@ -435,41 +477,7 @@ const DashboardPage = React.memo(() => {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {agentData?.map((agent) => (
-            <div key={agent.id} className="card bg-base-100 shadow-xl border border-base-content/10">
-              <div className="card-body p-4">
-                <div className="flex justify-between items-center mb-4">
-                  <h3 className="card-title text-xl font-bold">{agent.name}</h3>
-                  <div className={`badge ${getAgentStatusColor(agent.status)} badge-lg font-bold uppercase`}>
-                    {agent.status}
-                  </div>
-                </div>
-
-                {agent.error && (
-                  <div className="alert alert-error shadow-sm text-xs py-2 my-2 rounded-lg">
-                    <span>{agent.error}</span>
-                  </div>
-                )}
-
-                <div className="mockup-code bg-base-300 text-xs mt-2 before:hidden p-0">
-                  <div className="px-4 py-3 space-y-3">
-                    <div className="flex flex-col">
-                      <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Sent</span>
-                      <span className="font-mono text-primary">{agent.lastMessageSent || "-"}</span>
-                    </div>
-                    <div className="flex flex-col">
-                      <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Last Received</span>
-                      <span className="font-mono text-secondary">{agent.lastMessageReceived || "-"}</span>
-                    </div>
-                    <div className="flex flex-col">
-                      <span className="text-base-content/50 uppercase text-[10px] tracking-wider font-bold">Content</span>
-                      <span className="font-mono text-base-content/70 break-words mt-1">{agent.lastMessageContent || "-"}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
+          {agentCards}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 💡 What
Extracted the `getAgentStatusColor` helper function out of the `DashboardPage` component body and wrapped the `agentData?.map()` list rendering inside a `useMemo` hook.

## 🎯 Why
The `DashboardPage` component receives frequent WebSocket updates for real-time telemetry (CPU, Memory). Because the agent cards list was mapped inline within the JSX, every telemetry tick forced React to re-allocate the entire array of JSX elements and re-evaluate the map function, causing unnecessary reconciliation overhead for data (`agentData`) that updates much less frequently (every 30 seconds).

## 📊 Impact
Eliminates redundant array reallocations and reduces React rendering work on the agent status section during high-frequency telemetry updates, leading to smoother real-time chart performance and lower JS thread utilization.

## 🔬 Measurement
1. Run the web UI locally: `cd webui/frontend && pnpm run dev`.
2. Connect to the backend and observe the "Agent Status" section.
3. Open React DevTools Profiler and record a trace while telemetry updates stream in.
4. Verify that the `agentCards` mapping logic is not re-executed on every single CPU/Memory update tick.

---
*PR created automatically by Jules for task [15320884028434796065](https://jules.google.com/task/15320884028434796065) started by @matthewhand*