### PR TITLE
Batch 1 — frontend-pages: complete Edit flow + harden Commands page

### DIFF
--- a/webui/frontend/src/pages/CommandAuthoringPage.tsx
+++ b/webui/frontend/src/pages/CommandAuthoringPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -233,9 +233,13 @@ const ActionField: React.FC<{
 // --- Main Page Component ---
 
 export default function CommandAuthoringPage() {
+  const [searchParams] = useSearchParams();
+  const editName = searchParams.get('edit');
+  const isEditing = Boolean(editName);
+
   useEffect(() => {
-    document.title = "Command Editor | ChattyCommander";
-  }, []);
+    document.title = (isEditing ? "Edit Command" : "Command Editor") + " | ChattyCommander";
+  }, [isEditing]);
 
   const queryClient = useQueryClient();
   const [mode, setMode] = useState<'ai' | 'manual'>('ai');
@@ -250,6 +254,44 @@ export default function CommandAuthoringPage() {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+
+  // When arriving with ?edit=<name>, load that command from config and
+  // preload the manual editor so the existing definition can be modified.
+  useEffect(() => {
+    if (!editName) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/v1/config');
+        if (!res.ok) throw new Error('Failed to load configuration');
+        const config = await res.json();
+        const cmd = config?.commands?.[editName];
+        if (!cmd) {
+          if (!cancelled) setError(`Command "${editName}" was not found.`);
+          return;
+        }
+        const actions: CommandAction[] = Array.isArray(cmd.actions)
+          ? cmd.actions
+          : cmd.action
+            ? [cmd.action]
+            : [];
+        if (!cancelled) {
+          setManualCommand({
+            name: editName,
+            display_name: cmd.name || editName,
+            wakeword: cmd.wakeword || '',
+            actions,
+          });
+          setMode('manual');
+        }
+      } catch (e: unknown) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load command for editing');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [editName]);
 
   const validateField = useCallback((field: string, value: string) => {
     let errorMsg = '';
@@ -429,15 +471,17 @@ export default function CommandAuthoringPage() {
           <div className="text-sm breadcrumbs mb-2 text-base-content/60" aria-label="breadcrumbs">
             <ul>
               <li><Link to="/commands">Commands</Link></li>
-              <li>Command Authoring</li>
+              <li>{isEditing ? 'Edit Command' : 'Command Authoring'}</li>
             </ul>
           </div>
           <h1 className="text-3xl font-bold text-gradient-primary flex items-center gap-3">
             <Wand2 size={32} />
-            Command Authoring
+            {isEditing ? `Edit: ${editName}` : 'Command Authoring'}
           </h1>
           <p className="text-base-content/60 mt-1">
-            Create new voice commands using AI assistance or manual configuration.
+            {isEditing
+              ? 'Update the actions, display name, and wake word for this command, then save your changes.'
+              : 'Create new voice commands using AI assistance or manual configuration.'}
           </p>
         </div>
 

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -35,6 +35,7 @@ export default function CommandsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const searchQuery = searchParams.get('q') || '';
   const [pendingDeleteCommand, setPendingDeleteCommand] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
   const deleteDialogRef = useRef<HTMLDialogElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { data: commands, isLoading, isError, error, refetch } = useQuery<Record<string, CommandConfig>>({
@@ -64,12 +65,16 @@ export default function CommandsPage() {
   };
 
   const handleDeleteConfirm = async () => {
-    if (pendingDeleteCommand) {
+    if (!pendingDeleteCommand || isDeleting) return;
+    setIsDeleting(true);
+    try {
       await apiService.deleteCommand(pendingDeleteCommand);
       refetch();
+    } finally {
+      setIsDeleting(false);
+      deleteDialogRef.current?.close();
+      setPendingDeleteCommand(null);
     }
-    deleteDialogRef.current?.close();
-    setPendingDeleteCommand(null);
   };
 
   const handleDeleteCancel = () => {
@@ -106,7 +111,21 @@ export default function CommandsPage() {
       try {
         const parsed = JSON.parse(event.target?.result as string);
         if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-          alert('Invalid JSON: expected an object.');
+          alert('Invalid JSON: expected an object mapping command names to definitions.');
+          return;
+        }
+        // Validate each command entry has a recognizable shape before importing,
+        // so a malformed file can't silently overwrite the live config.
+        const invalid = Object.entries(parsed as Record<string, unknown>).filter(([, def]) => {
+          if (typeof def !== 'object' || def === null || Array.isArray(def)) return true;
+          const d = def as Record<string, unknown>;
+          const hasActions = Array.isArray(d.actions) && d.actions.length > 0;
+          const hasLegacyAction = typeof d.action === 'string' || typeof d.keypress === 'string' || typeof d.url === 'string';
+          return !hasActions && !hasLegacyAction;
+        });
+        if (invalid.length > 0) {
+          const names = invalid.map(([n]) => n).slice(0, 5).join(', ');
+          alert(`Import rejected: ${invalid.length} command(s) have no valid actions (${names}${invalid.length > 5 ? ', …' : ''}).`);
           return;
         }
         await apiService.updateConfig({ commands: parsed });
@@ -290,10 +309,10 @@ export default function CommandsPage() {
                       ariaLabel={`Options for ${name}`}
                     >
                       <li>
-                        <button aria-label={`Edit ${name}`}>
+                        <Link to={`/commands/authoring?edit=${encodeURIComponent(name)}`} aria-label={`Edit ${name}`}>
                           <Edit3 size={16} className="text-primary" />
                           Edit Command
-                        </button>
+                        </Link>
                       </li>
                       <li>
                         <button className="text-error hover:bg-error/10 hover:text-error" aria-label={`Delete ${name}`} onClick={() => handleDeleteClick(name)}>
@@ -358,8 +377,11 @@ export default function CommandsPage() {
           <h3 className="font-bold text-lg">Confirm Deletion</h3>
           <p className="py-4">Are you sure you want to delete <strong>{pendingDeleteCommand}</strong>?</p>
           <div className="modal-action">
-            <button className="btn" onClick={handleDeleteCancel}>Cancel</button>
-            <button className="btn btn-error" onClick={handleDeleteConfirm}>Delete</button>
+            <button className="btn" onClick={handleDeleteCancel} disabled={isDeleting}>Cancel</button>
+            <button className="btn btn-error" onClick={handleDeleteConfirm} disabled={isDeleting}>
+              {isDeleting ? <span className="loading loading-spinner loading-sm" aria-hidden="true"></span> : null}
+              Delete
+            </button>
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">


### PR DESCRIPTION
First of the per-subsystem cleanup PRs from the codebase feature audit. Base is \`claude2/determined-wilson-ac1380\` (the healthy baseline; \`main\` currently has syntax errors in 35 files and is non-importable).

## Changes (frontend-pages subsystem)
| Audit finding | Status | Fix |
|---|---|---|
| CommandsPage "Edit" button is dead UI (no onClick) | 🔴→✅ | Edit now opens the authoring page in Manual mode, pre-filled from config (`?edit=<name>`) |
| Import only checks top-level object type, not command schema | 🟡→✅ | Each entry validated for a usable action shape before overwriting config |
| Delete dialog allows double-clicks | 🟡→✅ | Confirm/Cancel disabled + spinner while delete is in flight |

## Verification
- `tsc --noEmit` clean, `vite build` succeeds
- Before/after screenshots of the Edit flow shared in the working session

🤖 Generated with [Claude Code](https://claude.com/claude-code)