### PR TITLE
Batch 2 — cli-entry: apply --log-level, enforce exec --timeout

### DIFF
--- a/src/chatty_commander/__init__.py
+++ b/src/chatty_commander/__init__.py
@@ -25,8 +25,6 @@ from importlib.metadata import version as _version
 
 try:
     __version__ = _version("chatty-commander")
-
-# This is a demonstration comment added after __version__
 except PackageNotFoundError:
     __version__ = "0.0.0+dev"
 

--- a/src/chatty_commander/cli/cli.py
+++ b/src/chatty_commander/cli/cli.py
@@ -27,6 +27,7 @@ voice commands, and handles the execution of commands.
 """
 
 import argparse
+import logging
 import os
 import signal
 import sys
@@ -321,6 +322,12 @@ For detailed documentation and source code, visit: https://github.com/your-repo/
         action="store_true",
         help="Show what would be executed without running it",
     )
+    exec_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Abort the command if it runs longer than this many seconds",
+    )
 
     # dograh subcommand group (integration utilities)
     from chatty_commander.cli.dograh_cli import register_dograh_subparser
@@ -579,8 +586,11 @@ def cli_main():
     else:
         interactive_mode = False
 
-    # Ensure logger is created with the expected name for tests
-    logger = setup_logger("main", "logs/chattycommander.log")
+    # Ensure logger is created with the expected name for tests, honoring --log-level
+    _level_name = str(getattr(args, "log_level", "INFO") or "INFO").upper()
+    _level = getattr(logging, _level_name, logging.INFO)
+    logging.getLogger().setLevel(_level)
+    logger = setup_logger("main", "logs/chattycommander.log", level=_level)
     logger.info("Starting ChattyCommander application")
 
     # Generate default configuration if needed
@@ -697,8 +707,25 @@ def cli_main():
             print(f"DRY RUN: would execute command '{command_name}'")
             return 0
 
-        # Actually execute the command
-        command_executor.execute_command(str(command_name))
+        # Actually execute the command, honoring --timeout if provided.
+        timeout = getattr(args, "timeout", None)
+        if timeout is None:
+            command_executor.execute_command(str(command_name))
+            return 0
+
+        worker = threading.Thread(
+            target=command_executor.execute_command,
+            args=(str(command_name),),
+            daemon=True,
+        )
+        worker.start()
+        worker.join(timeout)
+        if worker.is_alive():
+            print(
+                f"Command '{command_name}' timed out after {timeout}s",
+                file=sys.stderr,
+            )
+            return 1
         return 0
 
     # Initialize AI intelligence core for enhanced conversations


### PR DESCRIPTION
Second per-subsystem cleanup PR from the codebase feature audit. Base is \`claude2/determined-wilson-ac1380\`.

## Changes (cli-entry subsystem)
| Audit finding | Status | Fix |
|---|---|---|
| `--log-level` parsed but never applied | 🟠→✅ | Sets root logger level + passed to `setup_logger()` |
| `exec --timeout` tested but flag undefined (argparse rejected it) | 🟠→✅ | Flag added; command runs in a worker thread joined with the timeout, exit 1 on overrun |
| Orphaned "demonstration comment" in `__init__.py` | ⚪→✅ | Removed |

## Verification
- `tests/test_cli_features.py` — all 12 pass (incl. `test_exec_timeout_flag`)
- Syntax/import checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)