### PR TITLE
Batch 5 — advisors: surface silent memory load/save failures

### DIFF
--- a/src/chatty_commander/advisors/memory.py
+++ b/src/chatty_commander/advisors/memory.py
@@ -23,10 +23,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -73,9 +76,8 @@ class MemoryStore:
                             )
                     except (json.JSONDecodeError, KeyError):
                         continue
-        except Exception:
-            # If metrics/logging were available, we'd log this
-            pass
+        except Exception as e:
+            logger.warning("Failed to load advisor memory from %s: %s", self._path, e)
 
     def _ctx(self, platform: str, channel: str, user: str) -> str:
         return f"{platform}:{channel}:{user}"
@@ -105,8 +107,8 @@ class MemoryStore:
                         )
                         + "\n"
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Failed to persist advisor memory to %s: %s", self._path, e)
 
     def get(
         self, platform: str, channel: str, user: str, limit: int = 20


### PR DESCRIPTION
Fifth per-subsystem cleanup PR from the codebase feature audit. Base \`claude2/determined-wilson-ac1380\`.

## Changes (advisors subsystem)
| Audit finding | Status | Fix |
|---|---|---|
| `MemoryStore` load/save errors swallowed silently (`except: pass`) | 🟡→✅ | Added module logger; both paths now warn on failure (per-line JSON handling unchanged) |

Other advisors items (recurring-prompt validation, dead `switch_mode` tool) deferred — `switch_mode` removal is low-value and file deletion carries minor import risk, so left for a dedicated dead-code pass.

## Verification
- 106 advisor/memory tests pass; syntax check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)