### PR TITLE
Batch 8 — avatar: preserve decorator metadata + honest audio stub

### DIFF
--- a/src/chatty_commander/avatars/thinking_state.py
+++ b/src/chatty_commander/avatars/thinking_state.py
@@ -28,6 +28,7 @@ to connected avatar UIs for synchronized animations and visual feedback.
 """
 
 import asyncio
+import functools
 import inspect
 import logging
 import time
@@ -326,6 +327,7 @@ def with_thinking_state(
     """Decorator to automatically manage thinking states during function execution."""
 
     def decorator(func):
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             with ThinkingStateContext(agent_id, thinking_msg, responding_msg) as ctx:
                 result = func(*args, **kwargs)

--- a/src/chatty_commander/web/routes/avatar_ws.py
+++ b/src/chatty_commander/web/routes/avatar_ws.py
@@ -167,12 +167,25 @@ class AvatarAudioQueue:
             self._current_play_task is not None and not self._current_play_task.done()
         )
 
-    async def _play_audio(self, audio: bytes | None) -> None:
-        """Placeholder for audio playback.
+    # Real speaker output is not implemented; playback is simulated by sleeping
+    # for an estimated duration so queue/interrupt sequencing can be exercised.
+    # Callers can check this flag instead of assuming audio is actually heard.
+    AUDIO_PLAYBACK_SUPPORTED: bool = False
+    _warned_no_playback: bool = False
 
-        Audio output is not currently supported in this version. For testing,
-        we simply sleep for a duration based on the audio length if provided.
+    async def _play_audio(self, audio: bytes | None) -> None:
+        """Simulate audio playback by sleeping for an estimated duration.
+
+        Real audio output is not supported (see ``AUDIO_PLAYBACK_SUPPORTED``).
+        The first time audio is "played" we warn so operators aren't misled into
+        thinking sound is actually being emitted.
         """
+        if audio and not AvatarAudioQueue._warned_no_playback:
+            AvatarAudioQueue._warned_no_playback = True
+            logger.warning(
+                "AvatarAudioQueue received audio but real playback is not "
+                "implemented; simulating duration only (no sound is emitted)."
+            )
         if audio:
             # Rough heuristic: 1000 bytes ~= 1 second
             await asyncio.sleep(max(len(audio) / 1000.0, 0))


### PR DESCRIPTION
Eighth per-subsystem cleanup PR from the codebase feature audit. Base \`claude2/determined-wilson-ac1380\`.

## Changes (cv-avatar-gui subsystem)
| Audit finding | Status | Fix |
|---|---|---|
| `with_thinking_state` decorator drops wrapped-fn metadata | 🟡→✅ | Added `@functools.wraps` |
| `AvatarAudioQueue._play_audio` silently simulates playback | 🟠→✅ | Added `AUDIO_PLAYBACK_SUPPORTED=False` flag + one-time "no sound emitted" warning |

Judgment calls from the plan, resolved by inspection:
- **Dead `cv/` adapter** — moot: the orchestrator already uses a labeled `DummyAdapter("computer_vision")`, not a broken import. Nothing to remove.
- **Avatar audio** — made the stub honest (flag + warning) rather than pulling in an audio dependency, as planned.

## Verification
- 92 avatar/thinking tests pass; syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)