### PR TITLE
Batch 9 — frontend-components: ThemeProvider + authService logging hygiene

### DIFF
--- a/webui/frontend/src/components/ThemeProvider.tsx
+++ b/webui/frontend/src/components/ThemeProvider.tsx
@@ -24,7 +24,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
                         return data.ui.theme;
                     }
                 }
-            } catch { /* ignore */ }
+            } catch (e) {
+                // Non-fatal: fall back to the default theme, but don't fail silently.
+                console.debug('ThemeProvider: could not load theme from /api/v1/config, using default', e);
+            }
             return 'dark'; // Fallback
         },
         staleTime: Infinity, // Only fetch once on mount

--- a/webui/frontend/src/services/authService.ts
+++ b/webui/frontend/src/services/authService.ts
@@ -46,25 +46,16 @@ class AuthService {
       }
     }
 
-    // Check for no-auth mode by hitting the config endpoint
+    // Check for no-auth mode: if the config endpoint is reachable without a
+    // token, the backend is running with auth disabled and we grant a local
+    // admin session. A relative path works when same-origin or behind the proxy.
     try {
-      // In development/test, window.location might not match API location if proxied incorrectly.
-      // But usually relative path works if served by Vite proxy or same origin.
-
-      const configUrl = `${this.baseUrl}/config`;
-      console.log(`Checking no-auth mode at ${configUrl}`);
-
-      const confRes = await fetch(configUrl);
+      const confRes = await fetch(`${this.baseUrl}/config`);
       if (confRes.ok) {
-        console.log("No-auth mode detected via config endpoint");
         return { username: 'local_admin', roles: ['admin'], is_active: true, noAuth: true };
-      } else {
-         console.log("Config endpoint returned non-200", confRes.status);
-         // Fallback: If we get a 200 from ANY public endpoint, we might assume no-auth if auth endpoints fail?
-         // No, that's risky. But for this specific bug, maybe the URL is just missing the /api prefix or similar.
       }
     } catch (e) {
-      console.error("Failed to check no-auth mode", e);
+      console.debug("authService: no-auth probe failed", e);
     }
 
     throw new Error("Authentication required");


### PR DESCRIPTION
Ninth per-subsystem cleanup PR from the codebase feature audit. Base \`claude2/determined-wilson-ac1380\`.

## Changes (frontend-components subsystem)
| Audit finding | Status | Fix |
|---|---|---|
| ThemeProvider empty `catch {}` swallows config-fetch errors | 🟡→✅ | `console.debug` before default fallback (behavior unchanged) |
| authService verbose `console.log`/dead comments in prod code | 🟡→✅ | Trimmed to one `console.debug`; behavior unchanged |
| authService error-message vs unit-test mismatch | 🟡→deferred | Changes auth semantics; no unit-test runner wired — left for a dedicated auth PR |

## Verification
- `tsc --noEmit` clean; `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)