### PR TITLE
Batch 10 — tools: atomic writes in fs_ops

### DIFF
--- a/src/chatty_commander/tools/fs_ops.py
+++ b/src/chatty_commander/tools/fs_ops.py
@@ -23,6 +23,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -34,19 +36,37 @@ def ensure_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
 
 
-def write_json(path: Path, data: dict[str, Any]) -> None:
-    """
-    Write a JSON file with pretty formatting.
+def _atomic_write(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` atomically (temp file in the same dir + replace).
+
+    A crash mid-write can't leave a truncated/corrupt file: readers see either
+    the old contents or the fully-written new contents.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    """
+    Write a JSON file with pretty formatting (atomically).
+    """
+    _atomic_write(path, json.dumps(data, indent=2))
 
 
 def write_text(path: Path, data: str) -> None:
     """
-    Write a text file.
+    Write a text file (atomically).
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        f.write(data)
+    _atomic_write(path, data)


### PR DESCRIPTION
Tenth (final) per-subsystem cleanup PR from the codebase feature audit. Base \`claude2/determined-wilson-ac1380\`.

## Changes (tools/utils/obs subsystem)
| Audit finding | Status | Fix |
|---|---|---|
| `fs_ops.write_json`/`write_text` non-atomic — crash mid-write corrupts file | 🟡→✅ | Shared `_atomic_write()` (temp + `os.replace()`); identical output, durable |

The rest of tools/utils/obs was assessed solid in the audit (security utils, metrics, logging, dograh client all well-tested).

## Verification
- 28 fs_ops/workflow/builder/docs tests pass
- Runtime check: write_json/write_text produce correct content, leave no temp files

🤖 Generated with [Claude Code](https://claude.com/claude-code)