### PR TITLE
Round 2 — backend hardening (critical-audit fixes, 8 subsystems)

### DIFF
--- a/src/chatty_commander/advisors/context.py
+++ b/src/chatty_commander/advisors/context.py
@@ -29,6 +29,8 @@ per application/tab context.
 """
 
 import json
+import os
+import tempfile
 import time
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -223,7 +225,7 @@ class ContextManager:
 
         context = self.contexts[context_key]
         context.persona_id = persona_id
-        context.system_prompt = self.personas[persona_id]["system_prompt"]
+        context.system_prompt = self.personas[persona_id].get("system_prompt", "")
         context.last_activity = time.time()
 
         if self.persistence_enabled:
@@ -329,15 +331,34 @@ class ContextManager:
             pass
 
     def _save_contexts(self) -> None:
-        """Save contexts to persistence file."""
+        """Save contexts to persistence file using an atomic write.
+
+        Writes to a temporary file in the same directory and then atomically
+        replaces the target via os.replace(). This prevents a corrupted or
+        partially written file if the process is interrupted mid-write or if
+        multiple saves race; the target file always reflects a complete state.
+        """
         self.persistence_path.parent.mkdir(parents=True, exist_ok=True)
 
         data = {}
         for context_key, context in self.contexts.items():
             data[context_key] = context.to_dict()
 
-        with open(self.persistence_path, "w") as f:
-            json.dump(data, f, indent=2)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.persistence_path.parent),
+            prefix=self.persistence_path.name,
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp_path, self.persistence_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def get_stats(self) -> dict[str, Any]:
         """Get statistics about current contexts."""

--- a/src/chatty_commander/advisors/service.py
+++ b/src/chatty_commander/advisors/service.py
@@ -169,7 +169,13 @@ class AdvisorsService:
             raise RuntimeError("Advisors are not enabled")
 
         # Get or create context for this identity
-        platform = PlatformType(message.platform.lower())
+        try:
+            platform = PlatformType(message.platform.lower())
+        except ValueError as e:
+            valid = ", ".join(p.value for p in PlatformType)
+            raise RuntimeError(
+                f"Unsupported platform '{message.platform}'; expected one of: {valid}"
+            ) from e
         context = self.context_manager.get_or_create_context(
             platform=platform,
             channel=message.channel,
@@ -251,28 +257,31 @@ class AdvisorsService:
                                     sm = StateManager()
                                     sm.change_state(target.strip())
                                     response = response.replace(
-                                        line, f"✓ Switched to {target.strip()} mode"
+                                        line, f"✓ Switched to {target.strip()} mode", 1
                                     )
                                 except Exception as e:
                                     response = response.replace(
-                                        line, f"✗ Mode switch failed: {e}"
+                                        line, f"✗ Mode switch failed: {e}", 1
                                     )
 
-                    # Record conversation for future context
-                    self.conversation_engine.record_conversation_turn(
-                        user_id=f"{message.platform}:{message.channel}:{message.user}",
-                        user_input=message.text,
-                        assistant_response=response,
-                        context={
-                            "persona_id": context.persona_id,
-                            "platform": message.platform,
-                        },
-                    )
                 except Exception as e:
                     # Fallback to echo if LLM fails
                     model_name = "error"
                     api_mode = "error"
                     response = f"[LLM Error] {message.text} ({str(e)})"
+
+                # Record conversation for future context. Done outside the
+                # try/except above so error responses are also recorded,
+                # keeping conversation history consistent for future turns.
+                self.conversation_engine.record_conversation_turn(
+                    user_id=f"{message.platform}:{message.channel}:{message.user}",
+                    user_input=message.text,
+                    assistant_response=response,
+                    context={
+                        "persona_id": context.persona_id,
+                        "platform": message.platform,
+                    },
+                )
 
                 # Update to responding state
                 thinking_manager.start_responding(agent_id, "Finalizing response...")
@@ -304,7 +313,15 @@ class AdvisorsService:
         """Handle the summarize command."""
         from .tools.browser_analyst import browser_analyst_tool
 
-        url = message.text[10:]  # Remove "summarize "
+        url = message.text[10:].strip()  # Remove "summarize " and surrounding whitespace
+        if not url:
+            return AdvisorReply(
+                reply="Usage: summarize <url>",
+                context_key="summarize",
+                persona_id="analyst",
+                model=self.provider.model,
+                api_mode=self.provider.api_mode,
+            )
         summary = browser_analyst_tool(url)
 
         return AdvisorReply(

--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -245,7 +245,31 @@ class Config:
             if new_config != self.config_data:
                 self.config_data = new_config
                 self.config = new_config
+                # Refresh top-level derived attributes that callers read directly;
+                # otherwise edits to these in the config file are silently ignored.
+                self.general_models_path = self.config_data.get(
+                    "general_models_path", "models-idle"
+                )
+                self.system_models_path = self.config_data.get(
+                    "system_models_path", "models-computer"
+                )
+                self.chat_models_path = self.config_data.get(
+                    "chat_models_path", "models-chatty"
+                )
+                self.state_models = self.config_data.get("state_models", {})
+                self.api_endpoints = self.config_data.get(
+                    "api_endpoints", self.api_endpoints
+                )
+                self.wakeword_state_map = self.config_data.get(
+                    "wakeword_state_map", {}
+                )
+                self.state_transitions = self.config_data.get("state_transitions", {})
+                self.commands = self.config_data.get("commands", self.commands)
                 self._validate_config()
+                # Re-apply env overrides + web server config so they keep
+                # precedence over freshly-loaded file values (matches __init__).
+                self._apply_env_overrides()
+                self._apply_web_server_config()
                 self._load_general_settings()  # Load general settings to update default_state
                 # Force re-load of other properties that depend on config_data
                 self.model_actions = self._build_model_actions()

--- a/src/chatty_commander/app/helpers.py
+++ b/src/chatty_commander/app/helpers.py
@@ -27,13 +27,27 @@ Utility functions for the ChattyCommander application. This module contains help
 across different components of the application to perform common tasks.
 """
 
+import logging
 import os
 
+logger = logging.getLogger(__name__)
 
-def ensure_directory_exists(path: str) -> None:
-    """Ensure that a directory exists, and if not, create it."""
-    if not os.path.exists(path):
-        os.makedirs(path)
+
+def ensure_directory_exists(path: str) -> bool:
+    """Ensure that a directory exists, creating it if necessary.
+
+    Returns True if the directory exists (or was created), False if creation
+    failed due to a permission or concurrent-creation issue. Those failures are
+    logged rather than raised so non-critical callers are not interrupted (e.g.
+    when another process created the directory first). Other errors, such as an
+    invalid empty path, still propagate.
+    """
+    try:
+        os.makedirs(path, exist_ok=True)
+        return True
+    except (PermissionError, FileExistsError) as e:
+        logger.warning("Failed to ensure directory %r exists: %s", path, e)
+        return False
 
 
 def format_command_output(cmd_output: str) -> str:
@@ -47,7 +61,13 @@ def parse_model_keybindings(keybindings_str: str) -> dict[str, str]:
     if keybindings_str:
         pairs = keybindings_str.split(",")
         for pair in pairs:
-            model, keys = pair.split("=", 1)
+            if not pair.strip():
+                continue
+            try:
+                model, keys = pair.split("=", 1)
+            except ValueError:
+                logger.warning("Skipping malformed keybinding entry: %r", pair)
+                continue
             keybindings[model.strip()] = keys.strip()
     return keybindings
 

--- a/src/chatty_commander/app/orchestrator.py
+++ b/src/chatty_commander/app/orchestrator.py
@@ -22,9 +22,12 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
 
 try:
     from chatty_commander.voice.wakeword import MockWakeWordDetector, WakeWordDetector
@@ -244,6 +247,11 @@ class ModeOrchestrator:
             # If no specific wake word command, try a generic wake command
             try:
                 self._dispatch_command("wake")
-            except Exception:
-                # If no wake command, log the detection
-                pass  # Could add logging here if needed
+            except Exception as e:
+                # No matching command for this wake word; surface for diagnosis.
+                logger.warning(
+                    "Failed to dispatch wake word %r (confidence=%.3f): %s",
+                    wake_word,
+                    confidence,
+                    e,
+                )

--- a/src/chatty_commander/avatars/thinking_state.py
+++ b/src/chatty_commander/avatars/thinking_state.py
@@ -31,6 +31,7 @@ import asyncio
 import functools
 import inspect
 import logging
+import threading
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
@@ -93,20 +94,25 @@ class ThinkingStateManager:
         self.agent_states: dict[str, AgentStateInfo] = {}
         self.avatar_mappings: dict[str, str] = {}  # agent_id -> avatar_id
         self.broadcast_callbacks: set[Callable[[dict[str, Any]], None] | Callable[[dict[str, Any]], Awaitable[None]]] = set()
+        # Reentrant lock guarding the shared dicts/set above. Held only around
+        # the in-memory mutations and snapshots, never while invoking broadcast
+        # callbacks, so a callback may safely re-enter the manager.
+        self._lock = threading.RLock()
 
     def register_agent(
         self, agent_id: str, persona_id: str, avatar_id: str | None = None
     ) -> None:
         """Register a new agent with optional avatar mapping."""
-        self.agent_states[agent_id] = AgentStateInfo(
-            agent_id=agent_id,
-            avatar_id=avatar_id,
-            persona_id=persona_id,
-            state=ThinkingState.IDLE,
-        )
+        with self._lock:
+            self.agent_states[agent_id] = AgentStateInfo(
+                agent_id=agent_id,
+                avatar_id=avatar_id,
+                persona_id=persona_id,
+                state=ThinkingState.IDLE,
+            )
 
-        if avatar_id:
-            self.avatar_mappings[agent_id] = avatar_id
+            if avatar_id:
+                self.avatar_mappings[agent_id] = avatar_id
 
         self._broadcast_state_change(agent_id)
 
@@ -122,28 +128,34 @@ class ThinkingStateManager:
             logger.warning(f"Agent {agent_id} not registered, creating default entry")
             self.register_agent(agent_id, "default")
 
-        agent_info = self.agent_states[agent_id]
-        agent_info.state = state
-        agent_info.message = message
-        agent_info.progress = progress
-        agent_info.timestamp = time.time()
+        with self._lock:
+            agent_info = self.agent_states[agent_id]
+            agent_info.state = state
+            agent_info.message = message
+            agent_info.progress = progress
+            agent_info.timestamp = time.time()
 
         self._broadcast_state_change(agent_id)
 
     def get_agent_state(self, agent_id: str) -> AgentStateInfo | None:
         """Get current state of an agent."""
-        return self.agent_states.get(agent_id)
+        with self._lock:
+            return self.agent_states.get(agent_id)
 
     def get_all_states(self) -> dict[str, AgentStateInfo]:
         """Get all agent states."""
-        return self.agent_states.copy()
+        with self._lock:
+            return self.agent_states.copy()
 
     def map_agent_to_avatar(self, agent_id: str, avatar_id: str) -> None:
         """Map an agent to a specific avatar for visual correlation."""
-        self.avatar_mappings[agent_id] = avatar_id
+        with self._lock:
+            self.avatar_mappings[agent_id] = avatar_id
+            mapped = agent_id in self.agent_states
+            if mapped:
+                self.agent_states[agent_id].avatar_id = avatar_id
 
-        if agent_id in self.agent_states:
-            self.agent_states[agent_id].avatar_id = avatar_id
+        if mapped:
             self._broadcast_state_change(agent_id)
 
     def add_broadcast_callback(
@@ -154,7 +166,8 @@ class ThinkingStateManager:
         ),
     ) -> None:
         """Add a callback to receive state change broadcasts."""
-        self.broadcast_callbacks.add(callback)
+        with self._lock:
+            self.broadcast_callbacks.add(callback)
 
     def remove_broadcast_callback(
         self,
@@ -164,10 +177,14 @@ class ThinkingStateManager:
         ),
     ) -> None:
         """Remove a broadcast callback."""
-        self.broadcast_callbacks.discard(callback)
+        with self._lock:
+            self.broadcast_callbacks.discard(callback)
 
     def _broadcast(self, message: dict[str, Any]) -> None:
-        callbacks = list(self.broadcast_callbacks.copy())
+        # Snapshot callbacks under the lock, then invoke them outside it so a
+        # callback may safely re-enter the manager without deadlocking.
+        with self._lock:
+            callbacks = list(self.broadcast_callbacks)
         for callback in callbacks:
             try:
                 if inspect.iscoroutinefunction(callback):
@@ -184,14 +201,15 @@ class ThinkingStateManager:
 
     def _broadcast_state_change(self, agent_id: str) -> None:
         """Broadcast state change to all registered callbacks."""
-        agent_info = self.agent_states.get(agent_id)
-        if not agent_info:
-            return
-        message = {
-            "type": "agent_state_change",
-            "data": agent_info.to_dict(),
-            "timestamp": time.time(),
-        }
+        with self._lock:
+            agent_info = self.agent_states.get(agent_id)
+            if not agent_info:
+                return
+            message = {
+                "type": "agent_state_change",
+                "data": agent_info.to_dict(),
+                "timestamp": time.time(),
+            }
         self._broadcast(message)
 
     # Tool calling lifecycle events
@@ -239,8 +257,9 @@ class ThinkingStateManager:
 
     def handoff_complete(self, agent_id: str, new_persona_id: str) -> None:
         # Update persona mapping and return to idle
-        if agent_id in self.agent_states:
-            self.agent_states[agent_id].persona_id = new_persona_id
+        with self._lock:
+            if agent_id in self.agent_states:
+                self.agent_states[agent_id].persona_id = new_persona_id
         self.set_agent_state(agent_id, ThinkingState.IDLE)
         self._broadcast(
             {

--- a/src/chatty_commander/cli/cli.py
+++ b/src/chatty_commander/cli/cli.py
@@ -69,22 +69,32 @@ def run_cli_mode(config, model_manager, state_manager, command_executor, logger)
 
     try:
         while not shutdown_flag["stop"]:
-            # Listen for voice input
-            command = model_manager.listen_for_commands()
-            if not command:
+            try:
+                # Listen for voice input
+                command = model_manager.listen_for_commands()
+                if not command:
+                    continue
+
+                logger.info(f"Command detected: {command}")
+
+                # Update system state based on command
+                new_state = state_manager.update_state(command)
+                if new_state:
+                    logger.info(f"Transitioning to new state: {new_state}")
+                    model_manager.reload_models(new_state)
+
+                # Execute the detected command if it's actionable
+                if command in config.model_actions:
+                    command_executor.execute_command(command)
+            except KeyboardInterrupt:
+                # Propagate to outer handler for graceful shutdown
+                raise
+            except Exception as e:
+                # Keep the loop alive on transient errors (listen, state
+                # transition, model reload, or command execution failures)
+                # so a single bad iteration does not crash the process.
+                logger.error(f"Error while processing command loop: {e}")
                 continue
-
-            logger.info(f"Command detected: {command}")
-
-            # Update system state based on command
-            new_state = state_manager.update_state(command)
-            if new_state:
-                logger.info(f"Transitioning to new state: {new_state}")
-                model_manager.reload_models(new_state)
-
-            # Execute the detected command if it's actionable
-            if command in config.model_actions:
-                command_executor.execute_command(command)
 
     except KeyboardInterrupt:
         logger.info("KeyboardInterrupt received; shutting down")
@@ -491,8 +501,11 @@ def run_interactive_shell(
             if input_str.startswith("execute "):
                 command = input_str[8:].strip()
                 if command in config.model_actions:
-                    command_executor.execute_command(command)
-                    print(f"Executed: {command}")
+                    try:
+                        command_executor.execute_command(command)
+                        print(f"Executed: {command}")
+                    except Exception as e:
+                        print(f"Error executing '{command}': {e}")
                 else:
                     print(f"Unknown command: {command}")
                 continue
@@ -503,7 +516,10 @@ def run_interactive_shell(
                 logger.info(f"Transitioning to new state: {new_state}")
                 model_manager.reload_models(new_state)
             if input_str in config.model_actions:
-                command_executor.execute_command(input_str)
+                try:
+                    command_executor.execute_command(input_str)
+                except Exception as e:
+                    print(f"Error executing '{input_str}': {e}")
         except EOFError:
             break
     logger.info("Exiting interactive shell")
@@ -624,8 +640,11 @@ def cli_main():
         config.web_server = web_cfg
         try:
             config.config["web_server"] = web_cfg
-        except Exception:
-            pass
+        except (AttributeError, KeyError, TypeError) as e:
+            # config may not expose a mutable `.config` mapping; the
+            # web_server attribute above is the source of truth, so this
+            # is best-effort only.
+            logger.debug(f"Could not persist web_server into config.config: {e}")
     # Apply runtime advisors enable if requested
     if getattr(args, "advisors", False):
         try:
@@ -698,6 +717,10 @@ def cli_main():
         command_name = getattr(args, "command_name", None)
         dry_run = getattr(args, "dry_run", False)
         actions = getattr(config, "model_actions", {}) or {}
+
+        if not command_name:
+            print("No command name provided.", file=sys.stderr)
+            raise SystemExit(1)
 
         if command_name not in actions:
             print(f"Unknown command: {command_name}", file=sys.stderr)

--- a/src/chatty_commander/gui/pyqt5_avatar.py
+++ b/src/chatty_commander/gui/pyqt5_avatar.py
@@ -136,18 +136,29 @@ class TransparentBrowser(QMainWindow):
 
         self.setCentralWidget(central_widget)
 
-        # Load the avatar page
-        url = self.config.get(
-            "url", "file:///src/chatty_commander/webui/avatar/index.html"
-        )
+        # Load the avatar page. The default points at the bundled avatar UI
+        # resolved relative to this installation rather than an absolute
+        # "/src/..." path, which is not portable across installations.
+        base_path = Path(__file__).resolve().parent.parent.parent.parent
+        default_index = base_path / "src" / "chatty_commander" / "webui" / "avatar" / "index.html"
+        url = self.config.get("url", default_index.as_uri())
         if url.startswith("file://") and not url.startswith("file:///"):
             # Convert relative file paths to absolute
             file_path = url[7:]  # Remove 'file://'
             if not file_path.startswith("/"):
-                # Relative path, make it absolute
-                base_path = Path(__file__).parent.parent.parent.parent
-                file_path = str(base_path / file_path)
-            url = f"file:///{file_path}"
+                # Relative path, resolve it against the installation directory
+                # and reject any traversal that escapes that base.
+                resolved = (base_path / file_path).resolve()
+                try:
+                    resolved.relative_to(base_path)
+                except ValueError:
+                    logger.error(
+                        f"Refusing to load avatar URL outside installation root: {url}"
+                    )
+                    resolved = default_index.resolve()
+                url = resolved.as_uri()
+            else:
+                url = f"file:///{file_path.lstrip('/')}"
 
         logger.info(f"Loading avatar URL: {url}")
         self.web_view.load(QUrl(url))  # type: ignore[attr-defined]
@@ -313,9 +324,18 @@ def _load_settings() -> dict[str, Any]:
     except Exception as e:
         logger.warning(f"Failed to load configuration: {e}")
 
-    # Default settings
+    # Default settings. Resolve the bundled avatar UI relative to this
+    # installation rather than an absolute "/src/..." path.
+    default_index = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "src"
+        / "chatty_commander"
+        / "webui"
+        / "avatar"
+        / "index.html"
+    )
     return {
-        "url": "file:///src/chatty_commander/webui/avatar/index.html",
+        "url": default_index.as_uri(),
         "width": 400,
         "height": 600,
         "x": 100,

--- a/src/chatty_commander/gui/tray_popup.py
+++ b/src/chatty_commander/gui/tray_popup.py
@@ -157,15 +157,29 @@ def run_tray_popup(config: Any, logger) -> int:
 
     icon_img = _icon_image()
 
+    # Track the single webview worker thread so we can avoid spawning a second
+    # window while one is open and join it on shutdown instead of leaking it.
+    window_thread: dict[str, threading.Thread | None] = {"t": None}
+
     def on_open(_icon, _item):
         # open window on a background thread to avoid blocking the tray loop
+        existing = window_thread["t"]
+        if existing is not None and existing.is_alive():
+            logger.info("Avatar popup window already open; ignoring open request")
+            return
         settings = _load_settings(config)
-        threading.Thread(
+        t = threading.Thread(
             target=_open_window, args=(settings, logger), daemon=True
-        ).start()
+        )
+        window_thread["t"] = t
+        t.start()
 
     def on_quit(_icon, _item):
         _icon.stop()
+        # Best-effort graceful shutdown of the webview worker thread.
+        t = window_thread["t"]
+        if t is not None and t.is_alive():
+            t.join(timeout=2.0)
 
     menu = Menu(
         MenuItem("Open", on_open, default=True),

--- a/src/chatty_commander/llm/manager.py
+++ b/src/chatty_commander/llm/manager.py
@@ -166,7 +166,14 @@ class LLMManager:
             # Try to fallback to next available backend
             if self._try_fallback():
                 logger.info(f"Falling back to {self.get_active_backend_name()}")
-                return self.active_backend.generate_response(prompt, **kwargs)
+                try:
+                    return self.active_backend.generate_response(prompt, **kwargs)
+                except Exception as fallback_error:
+                    logger.error(
+                        f"Generation failed with fallback backend "
+                        f"{self.get_active_backend_name()}: {fallback_error}"
+                    )
+                    raise
             else:
                 raise
 

--- a/src/chatty_commander/llm/processor.py
+++ b/src/chatty_commander/llm/processor.py
@@ -38,6 +38,23 @@ from .manager import LLMManager
 logger = logging.getLogger(__name__)
 
 
+def _safe_confidence(value: Any) -> float:
+    """Coerce an LLM-supplied confidence into a float, defaulting to 0.0.
+
+    LLMs may return ``null``, non-numeric strings ("high"), or other invalid
+    values for the confidence field; rather than raising we treat any value we
+    cannot interpret as a number as zero confidence.
+    """
+    try:
+        confidence = float(value)
+    except (ValueError, TypeError):
+        return 0.0
+    # Guard against NaN/inf which would survive float() but break clamping.
+    if confidence != confidence or confidence in (float("inf"), float("-inf")):
+        return 0.0
+    return confidence
+
+
 class CommandProcessor:
     """Processes natural language commands using LLM."""
 
@@ -200,16 +217,27 @@ Response:"""
     ) -> tuple[str | None, float, str]:
         """Parse LLM response to extract command information."""
         try:
-            # Try to extract JSON from response
-            json_match = re.search(r"\{.*\}", response, re.DOTALL)
-            if not json_match:
+            # Try to extract JSON from response. Use a non-greedy match so a
+            # response containing multiple JSON objects does not produce an
+            # invalid span (e.g. '{"a":1} and {"b":2}'). If the first match
+            # fails to decode, fall back to a greedy match for objects that
+            # legitimately contain nested braces.
+            data = None
+            for pattern in (r"\{.*?\}", r"\{.*\}"):
+                match = re.search(pattern, response, re.DOTALL)
+                if not match:
+                    continue
+                try:
+                    data = json.loads(match.group())
+                    break
+                except json.JSONDecodeError:
+                    continue
+
+            if data is None:
                 return None, 0.0, "No JSON found in LLM response"
 
-            json_str = json_match.group()
-            data = json.loads(json_str)
-
             command = data.get("command")
-            confidence = float(data.get("confidence", 0.0))
+            confidence = _safe_confidence(data.get("confidence", 0.0))
             reasoning = data.get("reasoning", "LLM interpretation")
 
             # Validate command exists

--- a/src/chatty_commander/tools/browser_analyst.py
+++ b/src/chatty_commander/tools/browser_analyst.py
@@ -61,6 +61,9 @@ def summarize_url(request: AnalystRequest) -> AnalystResult:
     config_data = Config().config_data
     allowlist = config_data.get("advisors", {}).get("browser_analyst", {}).get("allowlist", None)
     timeout = config_data.get("advisors", {}).get("browser_analyst", {}).get("timeout", 10.0)
+    # Validate timeout: fall back to default if not a positive number
+    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or timeout <= 0:
+        timeout = 10.0
 
     parsed_url = urlparse(request.url)
     if parsed_url.scheme not in ("http", "https"):

--- a/src/chatty_commander/utils/url_validator.py
+++ b/src/chatty_commander/utils/url_validator.py
@@ -1,6 +1,9 @@
 import ipaddress
+import logging
 import socket
 from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 _ALLOWED_SCHEMES = {"http", "https"}
 
@@ -37,7 +40,7 @@ def is_safe_url(url: str) -> bool:
         # Resolve all addresses (IPv4 + IPv6)
         try:
             addr_infos = socket.getaddrinfo(hostname, None)
-        except socket.gaierror:
+        except (socket.gaierror, socket.timeout):
             return False
 
         if not addr_infos:
@@ -51,5 +54,9 @@ def is_safe_url(url: str) -> bool:
                 return False
 
         return True
-    except Exception:
+    except Exception as e:
+        # Fail closed (treat as unsafe), but surface unexpected errors so an
+        # operator can notice resolver/parsing problems rather than silently
+        # rejecting (or, worse, masking) URLs.
+        logger.warning("URL safety check failed unexpectedly for %r: %s", url, e)
         return False

--- a/src/chatty_commander/voice/pipeline.py
+++ b/src/chatty_commander/voice/pipeline.py
@@ -33,6 +33,7 @@ Provides a complete voice interface:
 from __future__ import annotations
 
 import logging
+import re
 import threading
 from collections.abc import Callable
 from typing import Any
@@ -163,8 +164,8 @@ class VoicePipeline:
             if self.state_manager:
                 try:
                     self.state_manager.change_state("voice_recording")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Could not update state to voice_recording: {e}")
 
             # Record and transcribe
             logger.info("Recording voice command...")
@@ -180,8 +181,8 @@ class VoicePipeline:
             if self.state_manager:
                 try:
                     self.state_manager.change_state("voice_processing")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Could not update state to voice_processing: {e}")
 
             # Process command
             command_name = self._match_command(transcription)
@@ -205,7 +206,10 @@ class VoicePipeline:
                 # Still notify callbacks with empty command name
                 self._notify_callbacks("", transcription)
                 if self.voice_only and self.tts.is_available():
-                    self.tts.speak(transcription)
+                    # Give clear no-match feedback rather than echoing the
+                    # (possibly mis-transcribed) text back at the user. The raw
+                    # transcription is logged above for operator debugging.
+                    self.tts.speak("Sorry, I didn't understand that")
 
         except Exception as e:
             logger.error(f"Error processing voice command: {e}")
@@ -215,8 +219,8 @@ class VoicePipeline:
             if self.state_manager:
                 try:
                     self.state_manager.change_state("voice_listening")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Could not update state to voice_listening: {e}")
 
     def _match_command(self, transcription: str) -> str | None:
         """Match transcription to available commands."""
@@ -231,12 +235,35 @@ class VoicePipeline:
                 logger.debug("No model actions available")
                 return None
 
-            # Simple keyword matching (can be enhanced with fuzzy matching, NLP, etc.)
+            # Keyword matching with word-boundary awareness. Substring matching is
+            # avoided because a command named "play" would otherwise match words
+            # like "replay", "display" or "player" and misdispatch commands.
             transcription_lower = transcription.lower()
+            tokens = re.findall(r"[a-z0-9']+", transcription_lower)
+            token_set = set(tokens)
 
-            # Direct name match first
+            def _matches_phrase(phrase: str) -> bool:
+                """Return True if ``phrase`` appears as a whole word/phrase."""
+                phrase = phrase.lower().strip()
+                if not phrase:
+                    return False
+                phrase_tokens = re.findall(r"[a-z0-9']+", phrase)
+                if not phrase_tokens:
+                    return False
+                # Single-word commands: require an exact token match.
+                if len(phrase_tokens) == 1:
+                    return phrase_tokens[0] in token_set
+                # Multi-word commands: require the token sequence to appear
+                # contiguously within the transcription tokens.
+                n = len(phrase_tokens)
+                for i in range(len(tokens) - n + 1):
+                    if tokens[i : i + n] == phrase_tokens:
+                        return True
+                return False
+
+            # Direct name match first (whole-word, not substring)
             for command_name in model_actions.keys():
-                if command_name.lower() in transcription_lower:
+                if _matches_phrase(str(command_name)):
                     return str(command_name)  # type: ignore[no-any-return]
 
             # Keyword-based matching
@@ -252,7 +279,7 @@ class VoicePipeline:
             for command_name, keywords in command_keywords.items():
                 if command_name in model_actions:
                     for keyword in keywords:
-                        if keyword in transcription_lower:
+                        if _matches_phrase(keyword):
                             return command_name
 
             return None
@@ -304,8 +331,9 @@ class VoicePipeline:
             if self.voice_only and self.tts.is_available():
                 self.tts.speak(f"Failed to execute {command_name}")
         else:
+            logger.info(f"No matching command found for: '{text}'")
             if self.voice_only and self.tts.is_available():
-                self.tts.speak(text)
+                self.tts.speak("Sorry, I didn't understand that")
         return None
 
     def get_status(self) -> dict[str, Any]:

--- a/src/chatty_commander/voice/transcription.py
+++ b/src/chatty_commander/voice/transcription.py
@@ -215,6 +215,7 @@ class VoiceTranscriber:
         channels: int = 1,
         record_timeout: float = 5.0,
         silence_timeout: float = 1.0,
+        silence_threshold: float = 500.0,
         **backend_kwargs,
     ):
         if not AUDIO_DEPS_AVAILABLE:
@@ -225,6 +226,11 @@ class VoiceTranscriber:
         self.channels = channels
         self.record_timeout = record_timeout
         self.silence_timeout = silence_timeout
+        # RMS energy (root-mean-square of int16 samples) below which a chunk is
+        # considered silence. The scale is environment-dependent: quieter rooms
+        # may want a lower value, noisier ones a higher value. Exposed here so it
+        # can be tuned via config rather than being hardcoded in the record loop.
+        self.silence_threshold = silence_threshold
 
         self._backend = self._create_backend(backend, **backend_kwargs)
         self._audio = None
@@ -295,7 +301,7 @@ class VoiceTranscriber:
                     audio_array = np.frombuffer(data, dtype=np.int16).astype(np.float32)
                     volume = np.sqrt(np.dot(audio_array, audio_array) / len(audio_array))
 
-                    if volume < 500:  # Silence threshold
+                    if volume < self.silence_threshold:  # RMS silence threshold
                         if silence_start is None:
                             silence_start = time.time()
                         elif time.time() - silence_start > self.silence_timeout:

--- a/src/chatty_commander/web/routes/avatar_ws.py
+++ b/src/chatty_commander/web/routes/avatar_ws.py
@@ -60,12 +60,12 @@ class AvatarWSConnectionManager:
                     self._registered_manager.remove_broadcast_callback(
                         self.broadcast_state_change
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"Failed to remove broadcast callback: {e}")
             try:
                 mgr.add_broadcast_callback(self.broadcast_state_change)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"Failed to register broadcast callback: {e}")
             self._registered_manager = mgr
         return mgr
 
@@ -81,8 +81,8 @@ class AvatarWSConnectionManager:
             if self.theme_resolver and d.get("persona_id"):
                 try:
                     d["theme"] = self.theme_resolver(d["persona_id"])  # type: ignore[arg-type]
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Theme resolver failed for snapshot: {e}")
             data[agent_id] = d
         snapshot = {"type": "agent_states_snapshot", "data": data}
         try:
@@ -219,7 +219,14 @@ class AvatarAudioQueue:
                 self._current_play_task = None
                 self.queue.task_done()
 
+        # Mark this processor as finished. Re-check the queue afterwards to
+        # close the race window where a message is enqueued between the final
+        # ``empty()`` check above and this assignment: ``_ensure_processor``
+        # would otherwise see a not-yet-finished task and decline to re-arm,
+        # leaving the new message stranded.
         self._processor_task = None
+        if not self.queue.empty():
+            self._ensure_processor()
 
     def _ensure_processor(self) -> None:
         if self._processor_task is None or self._processor_task.done():
@@ -304,3 +311,10 @@ async def avatar_ws_endpoint(websocket: WebSocket):
     except Exception as e:
         logger.error(f"Avatar WS error: {e}")
         manager.disconnect(websocket)
+        # Best-effort explicit close so the socket/file descriptor is not
+        # leaked on non-disconnect error paths (WebSocketDisconnect already
+        # implies the socket is closed).
+        try:
+            await websocket.close()
+        except Exception:
+            pass

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -49,7 +49,7 @@ except ImportError:
 
 from collections import defaultdict
 
-from fastapi import FastAPI, Header, HTTPException, Request, WebSocket
+from fastapi import FastAPI, Header, HTTPException, Query, Request, WebSocket
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
@@ -313,8 +313,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         current_time = time.time()
 
         # Periodic global cleanup: evict stale IP entries to prevent
-        # memory exhaustion from many unique IPs
-        if current_time - self._last_cleanup > 60:
+        # memory exhaustion from many unique IPs. A secondary size-based
+        # trigger guards against bursts of rotating IPs between the
+        # periodic sweeps (e.g. a DDoS) accumulating unbounded entries.
+        if current_time - self._last_cleanup > 60 or len(self.requests) > 10000:
             self._last_cleanup = current_time
             for ip in list(self.requests):
                 self.requests[ip] = [
@@ -692,32 +694,18 @@ class WebModeServer:
         self._register_bridge_routes(app)
 
         # Serve static web UI (optional)
+        # The frontend must be pre-built at deployment time (CI/CD responsibility).
+        # We never run npm at server startup: that would block app init, require
+        # Node.js in production, and could fail silently.
         frontend_path = Path("webui/frontend/dist")
         if not frontend_path.exists():
             frontend_path = Path("webui/frontend/build")
         if not frontend_path.exists():
-            logger.info("Frontend build not found. Automagically building the frontend UI...")
-            try:
-                import subprocess
-                import sys
-
-                # Check if npm is available
-                subprocess.run(["npm", "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
-
-                logger.info("Installing frontend dependencies...")
-                subprocess.run(["npm", "install", "--no-audit", "--no-fund", "--legacy-peer-deps"], cwd="webui/frontend", stdout=sys.stdout, stderr=sys.stderr, check=True)
-
-                logger.info("Building frontend assets...")
-                subprocess.run(["npm", "run", "build"], cwd="webui/frontend", stdout=sys.stdout, stderr=sys.stderr, check=True)
-
-                if Path("webui/frontend/dist").exists():
-                    frontend_path = Path("webui/frontend/dist")
-                elif Path("webui/frontend/build").exists():
-                    frontend_path = Path("webui/frontend/build")
-            except FileNotFoundError:
-                logger.error("Could not find 'npm' executable. Please install Node.js and run 'npm run build' manually in webui/frontend/.")
-            except Exception as e:
-                logger.error(f"Automagic frontend build failed: {e}. Please run 'npm run build' manually in webui/frontend/.")
+            logger.warning(
+                "Frontend build not found at webui/frontend/dist or "
+                "webui/frontend/build. Serving a fallback page. Run "
+                "'npm run build' in webui/frontend/ as part of deployment."
+            )
 
         if frontend_path.exists():
             static_assets = frontend_path / "assets"
@@ -751,7 +739,8 @@ class WebModeServer:
                 # If API or static file request fails, let it 404.
                 # Otherwise, serve index.html for SPA routing.
                 if request.url.path.startswith("/api") or request.url.path.startswith("/assets"):
-                     return await app.exception_handler_default(request, exc) if hasattr(app, "exception_handler_default") else HTMLResponse("Not Found", status_code=404)
+                    # Genuine 404 for API/static paths — do not serve the SPA shell.
+                    return HTMLResponse("Not Found", status_code=404)
 
                 index_file = frontend_path / "index.html"
                 if index_file.exists():
@@ -876,7 +865,10 @@ class WebModeServer:
 
         @app.get("/api/v1/advisors/memory")
         async def advisors_memory(
-            platform: str, channel: str, user: str, limit: int = 20
+            platform: str,
+            channel: str,
+            user: str,
+            limit: int = Query(default=20, ge=1, le=100),
         ):
             svc = self.advisors_service
             if not svc or not getattr(svc, "enabled", False):
@@ -912,11 +904,17 @@ class WebModeServer:
             event: dict[str, Any],
             x_bridge_token: str | None = Header(None, alias="X-Bridge-Token"),
         ):
-            # Check for bridge token in header
-            expected_token = self.config_manager.web_server.get("bridge_token")
+            # Check for bridge token in header. Guard against a config_manager
+            # that lacks the web_server attribute (e.g. minimal/stub configs).
+            expected_token = None
+            if hasattr(self.config_manager, "web_server"):
+                expected_token = self.config_manager.web_server.get("bridge_token")
             if not expected_token:
                 logger.warning("Bridge token not configured; rejecting request")
                 raise HTTPException(status_code=401, detail="Bridge not configured")
+
+            if not x_bridge_token:
+                raise HTTPException(status_code=401, detail="Missing bridge token")
 
             if not constant_time_compare(x_bridge_token, expected_token):
                 raise HTTPException(status_code=401, detail="Invalid bridge token")
@@ -952,21 +950,40 @@ class WebModeServer:
         self.last_state_change = datetime.now()
         try:
             loop = asyncio.get_event_loop()
+            loop.create_task(
+                self._broadcast_message(
+                    WebSocketMessage(
+                        type="state_change",
+                        data={
+                            "old_state": old_state,
+                            "new_state": new_state,
+                            "timestamp": self.last_state_change.isoformat(),
+                        },
+                    )
+                )
+            )
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        loop.create_task(
-            self._broadcast_message(
-                WebSocketMessage(
-                    type="state_change",
-                    data={
-                        "old_state": old_state,
-                        "new_state": new_state,
-                        "timestamp": self.last_state_change.isoformat(),
-                    },
+            try:
+                loop.create_task(
+                    self._broadcast_message(
+                        WebSocketMessage(
+                            type="state_change",
+                            data={
+                                "old_state": old_state,
+                                "new_state": new_state,
+                                "timestamp": self.last_state_change.isoformat(),
+                            },
+                        )
+                    )
                 )
-            )
-        )
+            except Exception as e:  # noqa: BLE001
+                logger.debug("state_change broadcast scheduling failed: %s", e)
+        except Exception as e:  # noqa: BLE001
+            # e.g. the event loop is closed — fail gracefully rather than
+            # propagating into the state manager callback chain.
+            logger.debug("state_change broadcast scheduling failed: %s", e)
 
     # Optional convenience callbacks (exposed for tests)
     def on_command_detected(self, command: str, confidence: float) -> None:

--- a/webui/frontend/package-lock.json
+++ b/webui/frontend/package-lock.json
@@ -3196,6 +3196,70 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3243,6 +3307,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5106,6 +5178,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -8143,6 +8226,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/webui/frontend/package-lock.json
+++ b/webui/frontend/package-lock.json
@@ -3196,70 +3196,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@testing-library/dom/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3307,14 +3243,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5178,17 +5106,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -8226,17 +8143,6 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {


### PR DESCRIPTION
Second improvement round from a critical re-assessment of the baseline. Fixers fanned out per subsystem (worktree-isolated, verify-then-fix), then I integrated + verified centrally. **Full pytest suite green (ran to 100%).**

Each fixer skipped gaps that were false positives or already fixed in round 1 (atomic writes, agent-store lock, Whisper temp cleanup, `--log-level`, etc.).

## Fixes by subsystem
- **web-api** (`web_mode.py`): removed the npm auto-build-on-startup block (no shelling out to npm at boot); fixed the broken SPA 404 fallback (called a nonexistent method); `hasattr` guard + None-token check on the bridge endpoint; bounded `RateLimitMiddleware` memory under rotating-IP bursts; `Query(ge=1,le=100)` on advisors memory `limit`; wrapped the state-change task scheduling so a closed loop fails gracefully.
- **advisors** (`service.py`, `context.py`): validate `PlatformType` (clear error vs raw `ValueError`); record error/fallback responses to conversation history; `count=1` on SWITCH_MODE replace; usage hint on empty `summarize`; `.get('system_prompt','')`; **atomic** `_save_contexts()` write.
- **llm-ai** (`processor.py`, `manager.py`): non-greedy JSON extraction; `_safe_confidence()` handles null/non-numeric/NaN; fallback-backend generation errors logged + consistent.
- **voice** (`pipeline.py`, `transcription.py`): **word-boundary** command matching (no more `play`↔`replay` false positives); honest voice-only no-match feedback; config-driven silence threshold.
- **app-core** (`config.py`, `helpers.py`, `orchestrator.py`, `url_validator.py`): `reload_config()` refreshes all derived attrs; helpers input validation + permission handling; wake-word handler logs instead of bare `pass`; **SSRF validator fails closed** on DNS errors.
- **cli-entry** (`cli.py`): exception handling around the listen loop + `execute_command` call sites; defensive guards.
- **avatar-gui** (`avatar_ws.py`, `thinking_state.py`, `pyqt5_avatar.py`, `tray_popup.py`): `try/finally` socket close on the avatar WS; log broadcast-callback registration failures; safer GUI path/config handling.
- **tools** (`browser_analyst.py`): validate config `timeout` is a positive number before use.

## Verification
- Full `pytest` suite: green, ran to 100%, no failures.
- All changed files parse; integrated cleanly onto the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)