### PR TITLE
Round 3 — complete incomplete features (9 wired/finished)

### DIFF
--- a/config.json
+++ b/config.json
@@ -148,5 +148,18 @@
     "telemetry_url": "",
     "external_url": "",
     "diagnostics_file": "logs/diagnostics.jsonl"
-  }
+  },
+  "general": {
+    "debug_mode": false,
+    "inference_framework": "custom",
+    "start_on_boot": true,
+    "check_for_updates": false
+  },
+  "web_server": {
+    "host": "0.0.0.0",
+    "port": 8100,
+    "auth_enabled": true,
+    "bridge_token": null
+  },
+  "voice_only": false
 }

--- a/config.json
+++ b/config.json
@@ -148,18 +148,5 @@
     "telemetry_url": "",
     "external_url": "",
     "diagnostics_file": "logs/diagnostics.jsonl"
-  },
-  "general": {
-    "debug_mode": false,
-    "inference_framework": "custom",
-    "start_on_boot": true,
-    "check_for_updates": false
-  },
-  "web_server": {
-    "host": "0.0.0.0",
-    "port": 8100,
-    "auth_enabled": true,
-    "bridge_token": null
-  },
-  "voice_only": false
+  }
 }

--- a/src/chatty_commander/advisors/service.py
+++ b/src/chatty_commander/advisors/service.py
@@ -304,10 +304,22 @@ class AdvisorsService:
                                     )
 
                 except Exception as e:
-                    # Fallback to echo if LLM fails
+                    # Fallback if the LLM fails. Use the intent/sentiment-aware
+                    # smart fallback for a more helpful message, but keep the
+                    # [LLM Error] marker that the API contract (and tests) rely on.
                     model_name = "error"
                     api_mode = "error"
-                    response = f"[LLM Error] {message.text} ({str(e)})"
+                    try:
+                        intent = self.conversation_engine.analyze_intent(message.text)
+                        sentiment = self.conversation_engine.analyze_sentiment(
+                            message.text
+                        )
+                        smart = self.conversation_engine.get_smart_fallback_response(
+                            message.text, intent, sentiment
+                        )
+                        response = f"[LLM Error] {smart} ({str(e)})"
+                    except Exception:
+                        response = f"[LLM Error] {message.text} ({str(e)})"
 
                 # Record conversation for future context. Done outside the
                 # try/except above so error responses are also recorded,
@@ -321,6 +333,32 @@ class AdvisorsService:
                         "platform": message.platform,
                     },
                 )
+
+                # Best-effort: learn lightweight user preferences from this turn.
+                # These feed get_conversation_context/build_enhanced_prompt on
+                # future turns. A failure here must never block the reply.
+                try:
+                    user_key = (
+                        f"{message.platform}:{message.channel}:{message.user}"
+                    )
+                    prev = self.conversation_engine.user_preferences.get(user_key, {})
+                    self.conversation_engine.update_user_preferences(
+                        user_key,
+                        {
+                            "last_intent": self.conversation_engine.analyze_intent(
+                                message.text
+                            ),
+                            "last_sentiment": self.conversation_engine.analyze_sentiment(
+                                message.text
+                            ),
+                            "preferred_persona": context.persona_id,
+                            "platform": message.platform,
+                            "interaction_count": int(prev.get("interaction_count", 0))
+                            + 1,
+                        },
+                    )
+                except Exception:
+                    pass
 
                 # Update to responding state
                 thinking_manager.start_responding(agent_id, "Finalizing response...")

--- a/src/chatty_commander/advisors/service.py
+++ b/src/chatty_commander/advisors/service.py
@@ -137,6 +137,45 @@ class AdvisorsService:
             }
         return persona_config
 
+    def get_personas(self) -> list[dict[str, Any]]:
+        """Return the configured personas in a UI-friendly shape.
+
+        Reads personas from the advisors config (either top-level ``personas``
+        or ``context.personas``) and normalises each into a dict with ``id``,
+        ``name``, ``is_default`` and ``system_prompt`` keys. Returns an empty
+        list when no personas are configured.
+        """
+        personas_dict = self.config.get("personas", {}) or self.config.get(
+            "context", {}
+        ).get("personas", {})
+        if not isinstance(personas_dict, dict) or not personas_dict:
+            return []
+
+        default_persona = self.config.get("default_persona") or self.config.get(
+            "context", {}
+        ).get("default_persona")
+
+        personas: list[dict[str, Any]] = []
+        for persona_id, raw in personas_dict.items():
+            if isinstance(raw, str):
+                name = persona_id
+                system_prompt = raw
+            elif isinstance(raw, dict):
+                name = raw.get("name", persona_id)
+                system_prompt = raw.get("system_prompt") or raw.get("prompt") or ""
+            else:
+                name = persona_id
+                system_prompt = ""
+            personas.append(
+                {
+                    "id": persona_id,
+                    "name": name,
+                    "is_default": persona_id == default_persona,
+                    "system_prompt": system_prompt,
+                }
+            )
+        return personas
+
     def _dispatch_special_command(self, message: AdvisorMessage, agent_id: str) -> AdvisorReply | None:
         """Dispatches special commands if identified in the message text.
 

--- a/src/chatty_commander/cli/cli.py
+++ b/src/chatty_commander/cli/cli.py
@@ -111,6 +111,27 @@ def run_cli_mode(config, model_manager, state_manager, command_executor, logger)
         sys.exit(0)
 
 
+def _detect_action_type(action) -> str:
+    """Classify a model action as 'shell', 'url', 'keypress', or 'unknown'.
+
+    Actions may be dicts (e.g. ``{"shell": {...}}`` or ``{"keypress": "ctrl+c"}``)
+    or plain strings. For dicts we inspect the keys; for strings we fall back to
+    a substring heuristic so legacy string actions still classify sensibly.
+    """
+    known = ("shell", "url", "keypress")
+    if isinstance(action, dict):
+        for key in known:
+            if key in action:
+                return key
+        return "unknown"
+    if isinstance(action, str):
+        for key in known:
+            if key in action:
+                return key
+        return "unknown"
+    return "unknown"
+
+
 def run_web_mode(
     config,
     model_manager,
@@ -182,7 +203,17 @@ def run_web_mode(
             port = int(env_port)
         except ValueError:
             logger.warning("Invalid CHATCOMM_PORT '%s'; using %s", env_port, port)
-    _log_level = os.getenv("CHATCOMM_LOG_LEVEL", "info")  # noqa: F841
+    env_log_level = os.getenv("CHATCOMM_LOG_LEVEL")
+    if env_log_level:
+        level = logging.getLevelName(env_log_level.strip().upper())
+        if isinstance(level, int):
+            logger.setLevel(level)
+            logging.getLogger().setLevel(level)
+        else:
+            logger.warning(
+                "Invalid CHATCOMM_LOG_LEVEL '%s'; keeping current level",
+                env_log_level,
+            )
 
     # Start the server
     try:
@@ -699,8 +730,7 @@ def cli_main():
             # Output as JSON array
             result = []
             for name, action in actions.items():
-                action_type = "shell" if "shell" in action else "url" if "url" in action else "unknown"
-                result.append({"name": name, "type": action_type})
+                result.append({"name": name, "type": _detect_action_type(action)})
             print(json_module.dumps(result, indent=2))
         else:
             # Output as text

--- a/src/chatty_commander/cli/main.py
+++ b/src/chatty_commander/cli/main.py
@@ -27,6 +27,7 @@ voice commands, and handles the execution of commands.
 """
 
 import argparse
+import logging
 
 # Ensure src/ is on sys.path so root execution finds package modules without PYTHONPATH
 import os as _os
@@ -181,7 +182,17 @@ def run_web_mode(
             port = int(env_port)
         except ValueError:
             logger.warning("Invalid CHATCOMM_PORT '%s'; using %s", env_port, port)
-    _log_level = os.getenv("CHATCOMM_LOG_LEVEL", "info")  # noqa: F841
+    env_log_level = os.getenv("CHATCOMM_LOG_LEVEL")
+    if env_log_level:
+        level = logging.getLevelName(env_log_level.strip().upper())
+        if isinstance(level, int):
+            logger.setLevel(level)
+            logging.getLogger().setLevel(level)
+        else:
+            logger.warning(
+                "Invalid CHATCOMM_LOG_LEVEL '%s'; keeping current level",
+                env_log_level,
+            )
 
     # Start the server
     try:

--- a/src/chatty_commander/obs/metrics.py
+++ b/src/chatty_commander/obs/metrics.py
@@ -320,8 +320,11 @@ class RequestMetricsMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
         return response  # type: ignore[no-any-return]
 
 
-def create_metrics_router(registry: MetricsRegistry | None = None) -> APIRouter:  # type: ignore[misc]
+def create_metrics_router(registry: MetricsRegistry | None = None) -> APIRouter | None:  # type: ignore[misc]
     """Return a FastAPI router exposing metrics in JSON and Prometheus text format.
+
+    Returns ``None`` when FastAPI is not installed (``APIRouter`` unavailable);
+    callers must guard against this before mounting the router.
 
     Endpoints:
     - GET /metrics/json

--- a/src/chatty_commander/voice/cli.py
+++ b/src/chatty_commander/voice/cli.py
@@ -116,6 +116,8 @@ def handle_voice_command(
         print("No voice command specified. Use --help for available commands.")
         return
 
+    elif args.voice_command == "test":
+        _handle_voice_test(args, config_manager, command_executor, state_manager)
     elif args.voice_command == "status":
         _handle_voice_status(args)
     elif args.voice_command == "transcribe":

--- a/src/chatty_commander/voice/enhanced_processor.py
+++ b/src/chatty_commander/voice/enhanced_processor.py
@@ -73,6 +73,7 @@ class EnhancedVoiceProcessor:
 
         # Voice activity detection state
         self.vad_enabled = config.voice_activity_detection
+        self.vad: Any = None
         self.silence_counter = 0
         self.speech_detected = False
 
@@ -141,6 +142,12 @@ class EnhancedVoiceProcessor:
             # Fallback to energy-based VAD
             self.vad = self._energy_based_vad
             self.logger.info("Energy-based VAD enabled")
+        except Exception as e:
+            # Never leave self.vad in an undefined state; fall back safely
+            self.vad = self._energy_based_vad
+            self.logger.warning(
+                f"VAD initialization failed ({e}); using energy-based VAD"
+            )
 
     def _initialize_transcription(self):
         """Initialize speech-to-text transcription."""
@@ -287,7 +294,7 @@ class EnhancedVoiceProcessor:
                     )
 
             # Voice activity detection
-            if self.vad_enabled:
+            if self.vad_enabled and self.vad is not None:
                 if callable(self.vad):
                     speech_detected = self.vad(audio_chunk)
                 else:

--- a/src/chatty_commander/web/routes/avatar_selector.py
+++ b/src/chatty_commander/web/routes/avatar_selector.py
@@ -22,10 +22,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -58,23 +61,97 @@ _HINTS = {
 }
 
 
+_ALL_LABELS = set(_HINTS.keys()) | {"neutral"}
+
+
+def _hint_classify(text: str, allowed) -> AnimationChooseResponse:
+    """Deterministic keyword-hint classifier used as the reliable fallback."""
+    for label, keywords in _HINTS.items():
+        if not allowed(label):
+            continue
+        if any(k in text for k in keywords):
+            return AnimationChooseResponse(
+                label=label,
+                confidence=0.8,
+                rationale="keyword-hint match",
+            )
+    return AnimationChooseResponse(
+        label="neutral", confidence=0.5, rationale="no keyword match (default)"
+    )
+
+
+def _llm_classify(text: str, allowed_labels: set[str]) -> str | None:
+    """Attempt an LLM-backed classification.
+
+    Returns a single normalized label string if the active LLM backend produced
+    a recognisable label, otherwise ``None`` so the caller can fall back to the
+    deterministic hint classifier. Any failure (missing backend, network error,
+    unparseable output) is swallowed and reported as ``None`` — the endpoint must
+    never crash just because an optional LLM is unavailable.
+    """
+    try:
+        from ...llm.manager import get_global_llm_manager
+    except Exception:  # pragma: no cover - import guard
+        return None
+
+    try:
+        manager = get_global_llm_manager()
+        if not manager.is_available():
+            return None
+        options = ", ".join(sorted(allowed_labels))
+        prompt = (
+            "Classify the emotional/animation intent of the following assistant "
+            "text into exactly one of these labels: "
+            f"{options}.\n"
+            "Respond with ONLY the single label word, nothing else.\n\n"
+            f"Text: {text!r}\nLabel:"
+        )
+        raw = manager.generate_response(prompt)
+    except Exception as exc:  # noqa: BLE001 - optional dependency, degrade gracefully
+        logger.debug("LLM animation classification unavailable: %s", exc)
+        return None
+
+    if not isinstance(raw, str):
+        return None
+    # Be tolerant of extra whitespace/punctuation around the label, but require
+    # an exact label token match so prose responses (e.g. the mock backend) fall
+    # back to the deterministic classifier rather than producing garbage.
+    candidates = {
+        tok.strip(" \t\r\n.,:;!\"'`").lower()
+        for tok in raw.replace("\n", " ").split(" ")
+    }
+    candidates.add(raw.strip(" \t\r\n.,:;!\"'`").lower())
+    for label in allowed_labels:
+        if label in candidates:
+            return label
+    return None
+
+
 @router.post("/avatar/animation/choose", response_model=AnimationChooseResponse)
 async def choose_animation(req: AnimationChooseRequest) -> Any:
     try:
         text = (req.text or "").lower()
         labels = set(req.candidate_labels or [])
         if labels:
-            labels &= set(_HINTS.keys()) | {"neutral"}
+            labels &= _ALL_LABELS
 
         def allowed(label: str) -> bool:
             return (not labels) or (label in labels)
 
-        # Hint-based deterministic classifier (placeholder for LLM)
-        for label, keywords in _HINTS.items():
-            if not allowed(label):
-                continue
-            if any(k in text for k in keywords):
-                return AnimationChooseResponse(label=label, confidence=0.8)
-        return AnimationChooseResponse(label="neutral", confidence=0.5)
+        allowed_labels = labels or _ALL_LABELS
+
+        # Prefer an LLM-backed classification when a backend is available; the
+        # helper returns None (and we fall back to hints) on any failure or when
+        # the output is not a recognisable label.
+        llm_label = _llm_classify(text, allowed_labels)
+        if llm_label is not None and allowed(llm_label):
+            return AnimationChooseResponse(
+                label=llm_label,
+                confidence=0.9,
+                rationale="llm classification",
+            )
+
+        # Deterministic keyword-hint fallback (also used when no LLM is present).
+        return _hint_classify(text, allowed)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -775,18 +775,20 @@ class WebModeServer:
 
         @app.get("/api/v1/advisors/personas")
         async def advisor_personas():
-            # Return seed data for testing
-            if self.no_auth:
-                return {"personas": [
-                    {"id": "jarvis", "name": "Jarvis", "is_default": True, "system_prompt": "You are a helpful AI assistant named Jarvis."},
-                    {"id": "friday", "name": "Friday", "is_default": False, "system_prompt": "You are a witty AI named Friday."},
-                    {"id": "hal", "name": "HAL 9000", "is_default": False, "system_prompt": "You are a calm, ominous AI."},
-                ]}
-            # Production: use advisors_service if available
+            # Consult the advisors service consistently in every mode. Personas
+            # come from configuration via AdvisorsService.get_personas(); when no
+            # advisors service is wired up we return an empty list rather than
+            # fabricating seed data.
             svc = self.advisors_service
             if not svc:
                 return {"personas": []}
-            return {"personas": getattr(svc, "get_personas", lambda: [])()}
+            get_personas = getattr(svc, "get_personas", None)
+            if not callable(get_personas):
+                return {"personas": []}
+            try:
+                return {"personas": get_personas()}
+            except Exception:  # noqa: BLE001 - never fail the listing endpoint
+                return {"personas": []}
 
         @app.post("/api/v1/advisors/message", response_model=AdvisorOutbound)
         async def advisor_message(


### PR DESCRIPTION
Third round, from an **incomplete-feature sweep** (54 findings: 20 safe / 17 need-decision / 17 need-external). I completed only the **safely-finishable** ones (all pieces present, low regression risk) and left stubs that genuinely need hardware/external services/product decisions. **Full pytest suite green (ran to 100%).**

## Completed
- **advisors** (`service.py`): two fully-implemented-but-never-called methods are now wired into `handle_message` — `update_user_preferences` (learns last intent/sentiment/persona/interaction-count each turn, feeding future-turn context) and `get_smart_fallback_response` (intent/sentiment-aware message on LLM failure, keeping the `[LLM Error]` marker tests rely on). *(Re-applied by hand — the fan-out fixer's commit silently dropped.)*
- **web-api / personas** (`web_mode.py` + `service.py`): removed the hardcoded dev seed (Jarvis/Friday/HAL); added `AdvisorsService.get_personas()` reading real personas from config; endpoint now consistent across modes.
- **web-api / avatar animation** (`avatar_selector.py`): the "placeholder for LLM" classifier now uses the LLM when available (constrained single-label prompt, strict parse) and **falls back to the existing keyword hints** on any failure — no new deps, existing tests still pass.
- **voice** (`cli.py`): `voice test` subcommand was registered with a full handler that was never reachable — added the missing dispatch branch. (`enhanced_processor.py`): VAD attribute was never initialized → guarded init + access so a non-ImportError failure can't leave it undefined.
- **cli-entry** (`cli.py`, `main.py`): `CHATCOMM_LOG_LEVEL` was read then discarded — now applied to the logger; `list --json` action-type detection now handles dict actions (`keypress` no longer misreported as `unknown`).
- **tools** (`metrics.py`): `create_metrics_router` return type corrected to `APIRouter | None`.

## Left incomplete (by design — flagged, not faked)
System-info `/proc` fallback (a test asserts `None` when psutil is absent); avatar **audio playback**, voice **start/stop** pipeline, MCP servers, persona handoffs, streaming — these need external deps/hardware or a product decision. The bridge-event handler and a few half-wired public APIs (avatar queue, `summarize_url`) need a routing decision.

## Verification
- Full `pytest` suite: green, ran to 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)