### PR TITLE
Round 4 — fix cli.main list/exec hang + models shell TypeError

### DIFF
--- a/src/chatty_commander/cli/main.py
+++ b/src/chatty_commander/cli/main.py
@@ -465,7 +465,14 @@ def run_interactive_shell(
                 print(f"Current state: {state_manager.current_state}")
                 continue
             if input_str.lower() == "models":
-                print("Loaded models: " + ", ".join(model_manager.get_models()))
+                # get_models(state) requires a state arg; list every loaded model
+                # across all states (mirrors the interactive shell in cli.py).
+                all_models = [
+                    name
+                    for state_models in model_manager.models.values()
+                    for name in state_models.keys()
+                ]
+                print("Loaded models: " + ", ".join(all_models))
                 continue
             if input_str.startswith("execute "):
                 command = input_str[8:].strip()
@@ -543,6 +550,15 @@ def main():
         register_dograh_subparser(subparsers)
         sub_args = sub_parser.parse_args()
         return handle_dograh(sub_args)
+
+    # `list` and `exec` are pure-utility subcommands fully implemented in
+    # cli.cli. Delegate to it so `python -m chatty_commander.cli.main list/exec`
+    # behaves like the console_script instead of falling through to mode startup
+    # (which loads the full ONNX pipeline and hangs in non-interactive use).
+    if len(sys.argv) > 1 and sys.argv[1] in ("list", "exec"):
+        from chatty_commander.cli.cli import cli_main
+
+        return cli_main()
 
     parser = create_parser()
     # Parse as the very first action and immediately return argparse exit code for help/usage


### PR DESCRIPTION
Fourth incomplete-feature sweep. **Honest result: diminishing returns** — most findings were already fixed in rounds 1–3 (Edit button, `create_metrics_router` type, `with_thinking_state` wraps, `is_available` caching) or are deliberately deferred (need a decision or external deps). Only **two genuinely-new, safely-completable bugs** were found, both in the secondary `python -m chatty_commander.cli.main` entrypoint:

| Bug | Fix |
|-----|-----|
| `cli.main list` / `exec` fell through to model-loading and **hung** instead of running the subcommand | Short-circuit delegates to `cli.cli.cli_main` (the working impl), mirroring the dograh short-circuit |
| Interactive-shell `models` command called `get_models()` with no arg → **runtime TypeError** (`get_models(state)` requires one) | Lists all loaded models across states, matching `cli.py` |

Both verified at runtime (`list` prints + exits 0; `exec --dry-run` works) and full pytest suite green (ran to 100%).

## Left for you (not auto-fixed)
Genuine but need a product/architecture decision: `intelligence_core` screenshot/lights/speech-event action hooks (log-only), MCP servers + persona handoffs, the recurring-prompt execution engine, and the long-dead `switch_mode` tool (complete-as-FunctionTool vs delete). Echo-cancellation / auto-gain need real DSP deps. I'd recommend **stopping the automated sweeps here** — the remaining incompleteness is intentional or needs your call, not more autonomous churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)