### PR TITLE
Round 5 — fix 5 genuine correctness bugs (adversarial hunt)

### DIFF
--- a/src/chatty_commander/advisors/conversation_engine.py
+++ b/src/chatty_commander/advisors/conversation_engine.py
@@ -58,7 +58,7 @@ class ConversationEngine:
                 return "mode_switch"
 
         # Question intents
-        if text.startswith(("what", "how", "why", "when", "where", "who")):
+        if text_lower.startswith(("what", "how", "why", "when", "where", "who")):
             return "question"
 
         # Task intents

--- a/src/chatty_commander/advisors/service.py
+++ b/src/chatty_commander/advisors/service.py
@@ -260,7 +260,7 @@ class AdvisorsService:
                         user_input=combined_user_text,
                         user_id=f"{message.platform}:{message.channel}:{message.user}",
                         persona_config=persona_config,
-                        current_mode=getattr(self.config, "current_mode", "chatty"),
+                        current_mode=self.config.get("current_mode", "chatty"),
                     )
 
                     # Use LLMManager to generate response

--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -597,11 +597,21 @@ class Config:
         instance = cls.__new__(cls)
         instance.config_file = config_file
         instance.config_data = data.copy()
+        # Mirror __init__: web handlers/tests expect `.config` as the raw dict.
+        instance.config = instance.config_data
 
         # Set basic attributes first
         instance.default_state = instance.config_data.get("default_state", "idle")
         instance.general_models_path = instance.config_data.get("general", {}).get(
             "models_path", "models"
+        )
+        # system/chat model paths were omitted here (only general was set), so
+        # ModelManager built from a from_dict() Config couldn't find them.
+        instance.system_models_path = instance.config_data.get(
+            "system_models_path", "models-computer"
+        )
+        instance.chat_models_path = instance.config_data.get(
+            "chat_models_path", "models-chatty"
         )
         instance.state_models = instance.config_data.get("state_models", {})
         instance.api_endpoints = instance.config_data.get("api_endpoints", {})

--- a/src/chatty_commander/voice/self_test.py
+++ b/src/chatty_commander/voice/self_test.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import tempfile
 import time
 from typing import Any
@@ -142,8 +143,10 @@ class VoiceSelfTester:
             logger.warning("TTS engine not available")
             return None
 
+        tmp_path: str | None = None
         try:
             with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
+                tmp_path = tmp_file.name
                 self._tts_engine.save_to_file(text, tmp_file.name)
                 self._tts_engine.runAndWait()
 
@@ -156,6 +159,13 @@ class VoiceSelfTester:
         except Exception as e:
             logger.error(f"TTS generation failed for '{text}': {e}")
             return None
+        finally:
+            # Always remove the temp WAV so repeated self-tests don't leak files.
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
     def test_transcription_accuracy(self, text: str) -> tuple[str, float]:
         """Test transcription accuracy for a given text."""

--- a/src/chatty_commander/web/routes/system.py
+++ b/src/chatty_commander/web/routes/system.py
@@ -103,8 +103,12 @@ def include_system_routes(
             )
             for name, (desc, default, required) in _ENV_VAR_CATALOG.items()
         ] + [
+            # Only include description-only vars that aren't already in the
+            # catalog, otherwise the response carries duplicate entries (every
+            # _ENV_VAR_DESCRIPTIONS key currently also lives in the catalog).
             EnvVarInfo(name=name, set=(name in os.environ), description=desc, default=None, required=False)
             for name, desc in _ENV_VAR_DESCRIPTIONS.items()
+            if name not in _ENV_VAR_CATALOG
         ]
 
         info = SystemInfo(


### PR DESCRIPTION
Pivoted to a correctness bug-hunt (incomplete-feature lens was exhausted). 15 high-confidence hits, but ~half were stale re-flags of my own earlier fixes (greedy regex #584, Whisper temp #578, persona .get #584, cli action detection #586). Five were **genuine and verified present**:

| Bug | Effect | Fix |
|-----|--------|-----|
| `service.py` `getattr(dict, 'current_mode')` | dict key never read → mode always 'chatty' | `.get()` |
| `conversation_engine.py` `text.startswith` vs `text_lower` | 'What is AI?' misclassified, not a question | use `text_lower` |
| `system.py` env list | 6 duplicate env entries in `/api/system/info` | skip catalog-dupes |
| `self_test.py` | temp `.wav` leak per TTS self-test | `finally` cleanup |
| `config.py from_dict` | missing `.config`, system/chat model paths | set all three |

Verified: full pytest green (ran to 100%); runtime-confirmed the intent + from_dict fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)