### PR TITLE
docs: update documentation for rounds 1-5 (PRs #572-588)

### DIFF
--- a/docs/developer/CHANGELOG.md
+++ b/docs/developer/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## \[Unreleased\] - 2026-06-02
+
+Hardening, bug-fix, and feature-completion rounds (PRs #572–#588), grouped by area.
+
+### CLI
+
+- `--log-level {DEBUG,INFO,WARNING,ERROR}` is now actually applied to the logger (previously parsed and ignored).
+- `CHATCOMM_LOG_LEVEL` env var is now applied in web mode.
+- `exec <command> --timeout <seconds>` flag added and enforced (command runs in a worker thread, aborts with exit 1 on overrun).
+- `python -m chatty_commander.cli.main list` and `exec ...` now work (previously fell through to model-loading and hung); they delegate to the same implementation as the `chatty-commander` console script.
+- Interactive-shell `models` command fixed (previously raised `TypeError`).
+- `voice test` subcommand is now reachable (handler existed but was never dispatched).
+- `list --json` correctly classifies dict-form actions (keypress/url/shell) instead of reporting "unknown".
+
+### Configuration
+
+- `config.json` is now written **atomically** (temp file + `os.replace`) so a crash mid-write can't corrupt it; same for `fs_ops` `write_json`/`write_text`.
+- `set_start_on_boot` no longer silently no-ops; it logs that OS-level autostart isn't implemented yet (the preference is still persisted).
+- `Config.from_dict()` now sets `.config` and `system_models_path`/`chat_models_path` (previously missing, so a `ModelManager` built from a dict config couldn't find them).
+- `reload_config()` now refreshes all derived attributes (model paths, `state_models`, `api_endpoints`, `wakeword_state_map`, `state_transitions`), not just a couple.
+
+### Web API
+
+- Agent blueprint store (`agents.json`) is now lock-guarded and written atomically (concurrent create/update/delete can't corrupt it).
+- `GET /api/v1/advisors/personas` now reads personas from configuration (the hardcoded dev seed Jarvis/Friday/HAL was removed).
+- `POST /avatar/animation/choose` uses the LLM for classification when available, falling back to keyword hints.
+- `GET /api/system/info` no longer returns duplicate environment-variable entries.
+- Advisors memory endpoints validate `limit` (1–100) and reject empty platform/channel/user.
+- The server no longer runs `npm install`/`npm run build` at startup (frontend must be pre-built); the broken SPA 404 fallback was fixed; the bridge endpoint got `hasattr` and missing-token guards.
+- Rate-limit middleware now bounds its in-memory map under rotating-IP bursts.
+
+### Advisors
+
+- Memory load/save failures are now logged (were silently swallowed).
+- Invalid platform now raises a clear error listing valid platforms.
+- On LLM failure, an intent/sentiment-aware fallback message is returned (still marked `[LLM Error]`).
+- Lightweight user-preference learning is recorded each turn and feeds future-turn context.
+- Conversation context is saved atomically.
+- Intent detection now works for capitalized questions ("What is AI?").
+- `current_mode` is now read correctly from config (was always defaulting).
+
+### LLM
+
+- OpenAI availability probe is cached (no live API call on every check).
+- LLM JSON extraction is non-greedy; confidence parsing tolerates null/non-numeric values; fallback-backend errors are logged.
+
+### Voice
+
+- Whisper API and voice self-test temp WAV files are now cleaned up (were leaking).
+- Command matching uses word boundaries (no more "play" matching "replay"/"display").
+- VAD attribute init is guarded; voice-only no-match gives honest feedback.
+
+### Web UI (frontend)
+
+- Commands list "Edit" button now opens the authoring page **pre-filled** for editing.
+- A failed command delete now surfaces an error and keeps the dialog open (was silently closing and implying success).
+- JSON import validates each command's shape before overwriting config.
+- ThemeProvider/authService logging cleaned up; WebSocket frame guards added; `useAuth` retry timeout cleared on unmount.
+
+### Tools / Observability / Avatar / Tests
+
+- `fs_ops` writes are atomic; `create_metrics_router` return type corrected to `APIRouter | None`.
+- `with_thinking_state` decorator preserves wrapped-function metadata; avatar audio queue exposes an `AUDIO_PLAYBACK_SUPPORTED=False` flag (playback is simulated, no real audio output).
+- Transcription init tests mock whisper/openai so they no longer skip.
+
 ## \[0.1.1\] - 2025-08-20
 
 ## \[0.1.2\] - 2025-08-21

--- a/docs/developer/CONFIG_SCHEMA.md
+++ b/docs/developer/CONFIG_SCHEMA.md
@@ -76,5 +76,12 @@ ChattyCommander uses a JSON-based configuration file (`config.json`) with sensib
 | `LLM_BACKEND` | Preferred LLM backend (`openai`, `ollama`, `local`, `mock`) |
 | `PORT` | Server port (default `8100`) |
 | `NO_AUTH` | Set to `1` to disable authentication |
+| `CHATCOMM_LOG_LEVEL` | Logger level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) applied in web mode. The `--log-level` CLI flag takes precedence. |
 
 See `.env.example` for a template.
+
+## Config File Writes
+
+`config.json` is written **atomically** (written to a temp file, then `os.replace`d into place), so a crash mid-write cannot leave a corrupt or partially-written config on disk.
+
+> **Note:** `set_start_on_boot` persists the preference but does not yet implement OS-level autostart; it logs that the platform integration is not implemented.

--- a/docs/developer/PRODUCTION_READINESS_ROADMAP.md
+++ b/docs/developer/PRODUCTION_READINESS_ROADMAP.md
@@ -67,7 +67,7 @@ This document outlines the work required to achieve production readiness.
   - Database connections
   - Redis connections
 - [ ] **Implement graceful degradation**
-  - Fallback responses when LLM unavailable
+  - [x] Fallback responses when LLM unavailable — advisors now return an intent/sentiment-aware fallback message (marked `[LLM Error]`) on LLM failure; LLM JSON extraction and confidence parsing tolerate malformed/null output
   - Cache-first strategy for config
 
 ### 2.2 Database & Persistence
@@ -84,7 +84,7 @@ This document outlines the work required to achieve production readiness.
 ### 2.3 Observability
 - [ ] **Structured logging**
   - JSON log format for production
-  - Log levels per environment
+  - [x] Log levels per environment — `--log-level {DEBUG,INFO,WARNING,ERROR}` is now actually applied to the logger (was parsed and ignored) and `CHATCOMM_LOG_LEVEL` is honored in web mode
   - Request ID tracing
 - [ ] **Distributed tracing** (OpenTelemetry)
   - Trace requests across services
@@ -234,7 +234,7 @@ This document outlines the work required to achieve production readiness.
 
 ### 7.2 User Experience
 - [ ] **WebUI polish**
-  - Error states
+  - [x] Error states (commands flow) — a failed command delete now surfaces an error and keeps the dialog open instead of silently implying success; JSON import validates each command's shape before overwriting config; the "Edit" button opens the authoring page pre-filled
   - Loading states
   - Offline support
 - [ ] **Desktop app**

--- a/docs/developer/WEBUI_ISSUES.md
+++ b/docs/developer/WEBUI_ISSUES.md
@@ -73,6 +73,17 @@ For ONNX model management:
 - `GET /api/models/download/{filename}` - Download ONNX model file
 - `DELETE /api/models/files/{filename}` - Delete ONNX model file
 
+## Frontend Fixes Applied
+
+The following frontend (Web UI) issues have been resolved:
+
+| Area | Fix | Status |
+|------|-----|--------|
+| Commands list "Edit" button | Now opens the authoring page **pre-filled** for editing (previously did not). | ✅ Fixed |
+| Command delete | A failed delete now surfaces an error and keeps the dialog open instead of silently closing and implying success. | ✅ Fixed |
+| JSON import | Each command's shape is now validated before overwriting config. | ✅ Fixed |
+| ThemeProvider / authService | Logging cleaned up; WebSocket frame guards added; `useAuth` retry timeout cleared on unmount. | ✅ Fixed |
+
 ## Frontend Pages Status
 
 | Page | Status | Issues |

--- a/docs/user-guide/01_INSTALLATION.md
+++ b/docs/user-guide/01_INSTALLATION.md
@@ -20,3 +20,19 @@ Welcome to ChattyCommander!
    ```bash
    uv run chatty-commander
    ```
+
+## Logging
+
+You can control the logging verbosity with the `--log-level` flag, which accepts
+`DEBUG`, `INFO`, `WARNING`, or `ERROR`:
+
+```bash
+uv run chatty-commander --log-level DEBUG
+```
+
+When running in web mode, the `CHATCOMM_LOG_LEVEL` environment variable is also
+honoured:
+
+```bash
+CHATCOMM_LOG_LEVEL=DEBUG uv run chatty-commander
+```

--- a/docs/user-guide/02_CONFIGURATION.md
+++ b/docs/user-guide/02_CONFIGURATION.md
@@ -18,6 +18,12 @@ You can view sample configurations in `config/`:
 - `full-assistant-example.json`
 - `voice-only-example.json`
 
+Saved changes to `config.json` are written atomically (via a temporary file that is then swapped into place), so an interrupted save or crash will not corrupt your configuration.
+
+### Logging Level
+
+Set the `CHATCOMM_LOG_LEVEL` environment variable (`DEBUG`, `INFO`, `WARNING`, or `ERROR`) to control log verbosity when running in web mode. On the command line, the `--log-level` flag takes precedence over this variable.
+
 ## Web Dashboard Configuration
 
 Once running, you can modify configuration in real-time using the **Web Dashboard Component**.

--- a/docs/user-guide/03_DASHBOARD_AND_WEBUI.md
+++ b/docs/user-guide/03_DASHBOARD_AND_WEBUI.md
@@ -5,6 +5,11 @@ ChattyCommander includes a rich WebUI built with React and Vite.
 ## Accessing the Dashboard
 By default, the dashboard is served at `http://localhost:8100/` when the application is running.
 
+> **Note:** The server no longer builds the frontend automatically at startup. The
+> WebUI must be pre-built before the dashboard can be served. See the
+> [Documentation Maintenance](#documentation-maintenance) section and the
+> developer docs for building the `webui/frontend` assets.
+
 ## Features
 - **Real-time Metrics**: View CPU usage, Memory Usage, and total API Commands Executed on the home page.
 - **WebSocket Streaming**: All AI generated logs, state transitions, and system errors are streamed directly to the UI.

--- a/docs/user-guide/04_VOICE_MODES_AND_COMMANDS.md
+++ b/docs/user-guide/04_VOICE_MODES_AND_COMMANDS.md
@@ -13,3 +13,38 @@ You can configure the exact model and threshold passing in `config.json`.
 
 ## Custom Voice Commands
 You can map specific voice triggers to CLI commands or internal Python functions by modifying the JSON profiles within the backend configs.
+
+## Listing and Running Commands from the CLI
+
+You can inspect and execute configured commands directly from the terminal:
+
+```bash
+# List all configured commands
+chatty-commander list
+
+# Machine-readable output (keypress/url/shell actions are classified by type)
+chatty-commander list --json
+
+# Run a command by name
+chatty-commander exec <command>
+
+# Abort the command if it runs longer than N seconds (exits with code 1 on overrun)
+chatty-commander exec <command> --timeout <seconds>
+```
+
+These subcommands are also reachable through the module entry point, which behaves
+identically to the `chatty-commander` console script:
+
+```bash
+python -m chatty_commander.cli.main list
+python -m chatty_commander.cli.main exec <command>
+```
+
+## Testing the Voice Pipeline
+
+Use the `voice test` subcommand to exercise the voice pipeline without going through
+the full wake-word flow:
+
+```bash
+chatty-commander voice test
+```


### PR DESCRIPTION
Docs were stale (code changed across 5 rounds, .md files not updated). Fanned out 6 base-corrected doc agents working only from a factual change-summary; reviewed the full diff for accuracy. Updates: CHANGELOG (new Unreleased section), PRODUCTION_READINESS_ROADMAP (ticked delivered items), WEBUI_ISSUES (frontend fixes table), user-guide 01-04 + CONFIG_SCHEMA (--log-level/CHATCOMM_LOG_LEVEL, atomic writes, list/exec --timeout/voice test, pre-build note). API.md and dograh ROADMAP.md correctly left untouched. Markdown-only, 8 files, +148/-3, reviewed line-by-line.