### PR TITLE
🧹 Code Health: Extract default commands into shared constant in App Config

### DIFF
--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -31,6 +31,16 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_COMMANDS = {
+    "hello": {
+        "action": "custom_message",
+        "message": "Hello from ChattyCommander!",
+    },
+    "take_screenshot": {"action": "keypress", "keys": "take_screenshot"},
+    "paste": {"action": "keypress", "keys": "paste"},
+    "submit": {"action": "keypress", "keys": "submit"},
+}
+
 
 class Config:
     def __init__(self, config_file: str = "config.json") -> None:
@@ -65,18 +75,7 @@ class Config:
         self.state_transitions: dict[str, dict[str, str]] = self.config_data.get(
             "state_transitions", {}
         )
-        self.commands: dict[str, Any] = self.config_data.get(
-            "commands",
-            {
-                "hello": {
-                    "action": "custom_message",
-                    "message": "Hello from ChattyCommander!",
-                },
-                "take_screenshot": {"action": "keypress", "keys": "take_screenshot"},
-                "paste": {"action": "keypress", "keys": "paste"},
-                "submit": {"action": "keypress", "keys": "submit"},
-            },
-        )
+        self.commands: dict[str, Any] = self.config_data.get("commands", DEFAULT_COMMANDS)
 
         # Advisors configuration
         advisors_cfg = self.config_data.get("advisors", {})
@@ -112,19 +111,6 @@ class Config:
             self.config_data.get("general", {}).get("inference_framework", "onnx")
         )
 
-        # Commands for model actions
-        default_commands = {}
-        if not self.config_file or "commands" not in self.config_data:  # Use defaults if file missing or commands missing
-            default_commands = {
-                "hello": {
-                    "action": "custom_message",
-                    "message": "Hello from ChattyCommander!",
-                },
-                "take_screenshot": {"action": "keypress", "keys": "take_screenshot"},
-                "paste": {"action": "keypress", "keys": "paste"},
-                "submit": {"action": "keypress", "keys": "submit"},
-            }
-        self.commands: dict[str, Any] = self.config_data.get("commands", default_commands)  # type: ignore[no-redef]
 
         # Start on boot setting
         self.start_on_boot: bool = bool(


### PR DESCRIPTION
## Summary
Extracted duplicated dictionary structures in `src/chatty_commander/app/config.py` into a shared `DEFAULT_COMMANDS` constant and simplified the `Config.__init__` method to remove redundant initialization logic.

## Changes
- Defined `DEFAULT_COMMANDS` at the module level in `src/chatty_commander/app/config.py`.
- Updated `Config.__init__` to use `DEFAULT_COMMANDS` in the initial `self.commands` assignment.
- Removed the second redundant block in `Config.__init__` that re-initialized `self.commands` with the same hardcoded values.

## Verification
- Successfully ran configuration-related tests using `PYTHONPATH=src:. pytest --noconftest -c /dev/null tests/test_config.py tests/test_default_config_generator.py`.
- Verified the code structure using `read_file` and `grep`.
- Reverted accidental modifications to `config.json` that occurred during test execution.

---
*PR created automatically by Jules for task [10368962619994272434](https://jules.google.com/task/10368962619994272434) started by @matthewhand*