### PR TITLE
Fix sys.path for root execution in CLI entry point

### DIFF
--- a/src/chatty_commander/cli/main.py
+++ b/src/chatty_commander/cli/main.py
@@ -35,9 +35,9 @@ import sys
 import sys as _sys
 import threading
 
-# Fix sys.path to include the project src root (one level up from this package directory)
+# Fix sys.path to include the project src root (two levels up from this package directory)
 _pkg_dir = _os.path.dirname(_os.path.abspath(__file__))
-_root_src = _os.path.abspath(_os.path.join(_pkg_dir, ".."))
+_root_src = _os.path.abspath(_os.path.join(_pkg_dir, "..", ".."))
 if _root_src not in _sys.path:
     _sys.path.insert(0, _root_src)
 


### PR DESCRIPTION
This PR fixes the sys.path initialization in `src/chatty_commander/cli/main.py`. 

When executing the application directly via this entry point, the previous logic incorrectly added `src/chatty_commander` to the Python path. This prevented absolute imports of the `chatty_commander` package from working as expected.

The fix updates the path calculation to go up two levels from the `cli` directory, correctly pointing to the `src/` root. The accompanying comment has also been updated to reflect this change.

Verification:
- Created a `verify_fix.py` script to simulate direct execution and confirm that `sys.path[0]` is correctly set to the `src/` directory and the `chatty_commander` package can be imported.
- Ran a subset of the existing test suite using `PYTHONPATH=src:. pytest --noconftest -c /dev/null` to avoid dependency issues in the restricted environment while still verifying core logic.

---
*PR created automatically by Jules for task [714773615703027342](https://jules.google.com/task/714773615703027342) started by @matthewhand*