### PR TITLE
🔒 Tighten CORS policy and enable configuration retrieval

### DIFF
--- a/src/chatty_commander/web/auth.py
+++ b/src/chatty_commander/web/auth.py
@@ -72,7 +72,15 @@ def apply_cors(
     - Otherwise: restrict to provided origins, defaulting to localhost:3000.
     """
     if no_auth:
-        allow_origins = ["*"]
+        # Avoid wildcard for better security and to allow credentials in dev
+        allow_origins = [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "http://localhost:8100",
+            "http://127.0.0.1:3000",
+            "http://127.0.0.1:5173",
+            "http://127.0.0.1:8100",
+        ]
     else:
         allow_origins = (
             list(origins) if origins is not None else ["http://localhost:3000"]

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -607,7 +607,11 @@ class WebModeServer:
         # CORS policy — delegate to shared apply_cors() for consistency
         from chatty_commander.web.auth import apply_cors
 
-        apply_cors(app, no_auth=self.no_auth)
+        allowed_origins = None
+        if hasattr(self.config_manager, "web_server"):
+            allowed_origins = self.config_manager.web_server.get("allowed_origins")
+
+        apply_cors(app, no_auth=self.no_auth, origins=allowed_origins)
 
         # Core REST via extracted router (status/config/state/command)
         core = include_core_routes(


### PR DESCRIPTION
🎯 **What:** The CORS policy was overly permissive in development mode, using a wildcard origin (`"*"`) that could allow any website to make requests to the local server if authentication was disabled.

⚠️ **Risk:** Wildcard origins prevent the use of credentials and increase the attack surface of the local development environment. A malicious website could potentially interact with the ChattyCommander API if the user has the server running in `no_auth` mode.

🛡️ **Solution:** 
1. Replaced the `["*"]` wildcard with a specific whitelist of local origins (`localhost` and `127.0.0.1` on ports 3000, 5173, and 8100).
2. Enabled the application to respect the `allowed_origins` configuration in the `web_server` section of `config.json`, which was previously ignored.
3. Maintained support for cross-origin credentials by ensuring the specific origins are used instead of a wildcard.

---
*PR created automatically by Jules for task [17125916454985583574](https://jules.google.com/task/17125916454985583574) started by @matthewhand*