### PR TITLE
🎨 Palette: Add explicit label-input linking to login form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2024-05-23 - Accessibility & Micro-UX Additions
 **Learning:** Icon-only buttons (like error dismissals and model deletions) frequently lack `aria-label`s, preventing screen readers from understanding their purpose. Also, async operations (like deletions) bound to lists without granular loading states can leave users wondering if their action registered.
 **Action:** Always add `aria-label`s to icon-only buttons. Consider conditionally rendering a small spinner component in place of an icon for actions bound to `useMutation` that take noticeable time.
+
+## 2026-03-17 - Explicit Label Linking with DaisyUI wrappers
+**Learning:** DaisyUI `form-control` wrappers still require explicit `htmlFor`/`id` linking for inputs and labels, as they do not automatically handle this critical accessibility requirement.
+**Action:** Always manually link labels and inputs using `htmlFor` and `id` when authoring forms, even when utilizing styled wrappers.

--- a/webui/frontend/src/pages/LoginPage.tsx
+++ b/webui/frontend/src/pages/LoginPage.tsx
@@ -36,10 +36,11 @@ const LoginPage: React.FC = () => {
 
           <form onSubmit={handleSubmit} className="w-full space-y-4">
             <div className="form-control w-full">
-              <label className="label">
+              <label htmlFor="username" className="label">
                 <span className="label-text">Username</span>
               </label>
               <input
+                id="username"
                 type="text"
                 placeholder="Enter username"
                 className="input input-bordered w-full input-primary"
@@ -51,10 +52,11 @@ const LoginPage: React.FC = () => {
             </div>
 
             <div className="form-control w-full">
-              <label className="label">
+              <label htmlFor="password" className="label">
                 <span className="label-text">Password</span>
               </label>
               <input
+                id="password"
                 type="password"
                 placeholder="Enter password"
                 className="input input-bordered w-full input-primary"


### PR DESCRIPTION
💡 **What:** Added `id` and `htmlFor` attributes to the username and password fields on the login page to explicitly link labels with inputs.
🎯 **Why:** DaisyUI `form-control` wrappers do not automatically handle label-input linking. Without this, screen readers cannot properly associate the label text with the input field, and users cannot click the label text to focus the input.
♿ **Accessibility:** This directly addresses a critical WCAG requirement for form accessibility.

---
*PR created automatically by Jules for task [13720388106203149952](https://jules.google.com/task/13720388106203149952) started by @matthewhand*