### PR TITLE
🧹 Clean up suboptimal import in main entry point

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -32,10 +32,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 def main():
     """Entry point wrapper."""
-    # ruff: noqa: E402
-    import chatty_commander.main
+    from chatty_commander.main import main as main_func
 
-    main_func = chatty_commander.main.main
     return main_func()
 
 


### PR DESCRIPTION
🎯 **What:** Refactored the local import in `src/main.py` from `import chatty_commander.main` to `from chatty_commander.main import main as main_func`.
💡 **Why:** The previous import style was suboptimal and often flagged as "unused" by static analysis tools because the imported module was only accessed via its full name. The new style is cleaner, more explicit, and follows standard Python practices.
✅ **Verification:**
- Verified that `python3 src/main.py --help` still works correctly.
- Confirmed that `ruff check` passes without any warnings on the modified file.
- Ran relevant CLI unit tests (e.g., `tests/test_cli_main_coverage.py`) and confirmed they pass.
- Cleaned up all temporary testing scripts used during development.
✨ **Result:** Improved maintainability and readability of the application's primary entry point.

---
*PR created automatically by Jules for task [7589659911079732548](https://jules.google.com/task/7589659911079732548) started by @matthewhand*