### PR TITLE
🛡️ Sentinel: [security improvement] Fix insecure CORS configuration

### DIFF
--- a/src/chatty_commander/web/auth.py
+++ b/src/chatty_commander/web/auth.py
@@ -85,7 +85,7 @@ def apply_cors(
     app.add_middleware(
         CORSMiddleware,
         allow_origins=allow_origins,
-        allow_credentials=True,
+        allow_credentials="*" not in allow_origins,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -563,10 +563,11 @@ class WebModeServer:
         app.add_middleware(ResponseTimeMiddleware)
 
         # CORS policy
+        allow_origins = ["*"] if self.no_auth else ["http://localhost:3000"]
         app.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"] if self.no_auth else ["http://localhost:3000"],
-            allow_credentials=True,
+            allow_origins=allow_origins,
+            allow_credentials="*" not in allow_origins,
             allow_methods=["*"],
             allow_headers=["*"],
         )


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an insecure CORS configuration where `allow_origins=["*"]` was paired with `allow_credentials=True`.
⚠️ **Risk:** This configuration allows any website to make authenticated requests to the API, potentially exposing sensitive user data or allowing unauthorized actions if session cookies or authentication headers are used. Modern browsers and the Starlette/FastAPI framework also flag this as an invalid configuration.
🛡️ **Solution:** Updated the CORS middleware configuration in both `src/chatty_commander/web/auth.py` and `src/chatty_commander/web/web_mode.py` to dynamically set `allow_credentials` based on the presence of a wildcard in `allow_origins`. Specifically, `allow_credentials` is now set to `False` if `"*"` is in `allow_origins`.

---
*PR created automatically by Jules for task [7386698154961057429](https://jules.google.com/task/7386698154961057429) started by @matthewhand*