### PR TITLE
🧪 tests: verify DeprecationWarning in compat.py

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,88 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import warnings
+from unittest.mock import patch, MagicMock
+from chatty_commander import compat
+
+def test_load_with_alias():
+    """Test that compat.load triggers a DeprecationWarning for aliased modules."""
+    mock_aliases = {"old_mod": "new_mod"}
+    with patch("chatty_commander.compat.ALIASES", mock_aliases):
+        with patch("importlib.import_module") as mock_import:
+            mock_import.return_value = MagicMock()
+            with pytest.warns(DeprecationWarning, match="chatty_commander.old_mod is deprecated; use new_mod"):
+                compat.load("old_mod")
+            mock_import.assert_called_once_with("new_mod")
+
+def test_load_without_alias():
+    """Test that compat.load does not trigger a warning for non-aliased modules."""
+    mock_aliases = {"old_mod": "new_mod"}
+    with patch("chatty_commander.compat.ALIASES", mock_aliases):
+        with patch("importlib.import_module") as mock_import:
+            mock_import.return_value = MagicMock()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                compat.load("new_mod")
+                # Ensure no DeprecationWarning from chatty_commander was issued
+                for warning in w:
+                    if issubclass(warning.category, DeprecationWarning) and "chatty_commander" in str(warning.message):
+                        pytest.fail(f"Unexpected DeprecationWarning: {warning.message}")
+            mock_import.assert_called_once_with("new_mod")
+
+def test_expose_with_all():
+    """Test that compat.expose correctly populates the namespace using __all__."""
+    mock_module = MagicMock()
+    mock_module.attr1 = "val1"
+    mock_module.attr2 = "val2"
+    mock_module._private = "private"
+    mock_module.__all__ = ["attr1"]
+
+    namespace = {}
+    with patch("chatty_commander.compat.load") as mock_load:
+        mock_load.return_value = mock_module
+        compat.expose(namespace, "some_mod")
+
+        assert namespace["attr1"] == "val1"
+        assert "attr2" not in namespace
+        assert "_private" not in namespace
+        assert namespace["__all__"] == ["attr1"]
+
+def test_expose_without_all():
+    """Test compat.expose when __all__ is not defined."""
+    class MockModule:
+        def __init__(self):
+            self.attr1 = "val1"
+            self.attr2 = "val2"
+            self._private = "private"
+
+    mock_module = MockModule()
+    namespace = {}
+    with patch("chatty_commander.compat.load") as mock_load:
+        mock_load.return_value = mock_module
+        compat.expose(namespace, "some_mod")
+
+        assert namespace["attr1"] == "val1"
+        assert namespace["attr2"] == "val2"
+        assert "_private" not in namespace
+        assert set(namespace["__all__"]) == {"attr1", "attr2"}


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `src/chatty_commander/compat.py` module lacked automated tests to verify that its backward compatibility shim correctly warns users when deprecated module aliases are used.

### 📊 Coverage: What scenarios are now tested
- **`test_load_with_alias`**: Verifies that `compat.load` triggers a `DeprecationWarning` and returns the correctly aliased module.
- **`test_load_without_alias`**: Ensures no warning is issued for modules not in the `ALIASES` table.
- **`test_expose_with_all`**: Checks that `compat.expose` correctly populates a namespace using a module's `__all__` attribute.
- **`test_expose_without_all`**: Verifies that `compat.expose` handles modules without `__all__` by falling back to public attributes.

### ✨ Result: The improvement in test coverage
This addition provides a safety net for the compatibility layer, ensuring that future refactors maintain the expected warning behavior for legacy integrations.

---
*PR created automatically by Jules for task [5353545865193609272](https://jules.google.com/task/5353545865193609272) started by @matthewhand*