### PR TITLE
🔒 restrict CORS origins in no_auth mode

### DIFF
--- a/src/chatty_commander/web/auth.py
+++ b/src/chatty_commander/web/auth.py
@@ -74,7 +74,6 @@ def enable_no_auth_docs(app: FastAPI, *, no_auth: bool) -> None:
 
 
 def apply_cors(
-    """apply cors."""
     app: FastAPI, *, no_auth: bool, origins: Iterable[str] | None = None
 ) -> None:
     """
@@ -84,7 +83,16 @@ def apply_cors(
     - Otherwise: restrict to provided origins, defaulting to localhost:3000.
     """
     if no_auth:
-        allow_origins = ["*"]
+        # Restrict to local development origins even in no_auth mode to prevent
+        # cross-origin attacks from malicious websites.
+        allow_origins = [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+            "http://localhost:8100",
+            "http://127.0.0.1:8100",
+        ]
     else:
         allow_origins = (
             # Logic flow


### PR DESCRIPTION
🎯 **What:** The CORS policy in `src/chatty_commander/web/auth.py` was overly permissive, using a wildcard `"*"` when `no_auth` was enabled.
⚠️ **Risk:** A wildcard CORS policy allows any website to make requests to the API from a user's browser, which could be exploited for Cross-Site Request Forgery (CSRF) or other cross-origin attacks if the user is running the application locally.
🛡️ **Solution:** Restricted the `allow_origins` to a specific list of local development origins (`localhost` and `127.0.0.1` on ports `3000`, `5173`, and `8100`) when `no_auth` is enabled. Additionally, fixed a `SyntaxError` in the `apply_cors` function signature where a docstring was incorrectly placed.

---
*PR created automatically by Jules for task [11094061661783006095](https://jules.google.com/task/11094061661783006095) started by @matthewhand*