### PR TITLE
Salvage a11y + CORS-safety test from stale main PRs (#552/#563)

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -86,6 +86,20 @@ class TestSecurity:
         # CORS should be properly configured
         assert server.no_auth is True
 
+    def test_apply_cors_wildcard_safety(self):
+        """apply_cors must never combine credentials with a wildcard origin (RFC 6454)."""
+        from fastapi import FastAPI
+        from fastapi.middleware.cors import CORSMiddleware
+
+        from chatty_commander.web.auth import apply_cors
+
+        app = FastAPI()
+        apply_cors(app, no_auth=False, origins=["*"])
+        cors = next(m for m in app.user_middleware if m.cls is CORSMiddleware)
+        assert cors.kwargs["allow_origins"] == ["*"]
+        # Credentials must be disabled whenever the wildcard origin is in effect.
+        assert cors.kwargs["allow_credentials"] is False
+
 
 class TestClientIPSecurity:
     """Tests for secure client IP extraction to prevent IP spoofing attacks."""

--- a/webui/frontend/src/pages/ConfigurationPage.tsx
+++ b/webui/frontend/src/pages/ConfigurationPage.tsx
@@ -364,6 +364,7 @@ const ConfigurationPage: React.FC = () => {
                       className="btn btn-xs btn-outline btn-primary"
                       onClick={handleTestMic}
                       disabled={isTestingMic || !inputDevice}
+                      aria-label={isTestingMic ? "Testing microphone device" : "Test microphone device"}
                     >
                       {isTestingMic ? "Testing..." : "Test"}
                     </button>
@@ -411,6 +412,7 @@ const ConfigurationPage: React.FC = () => {
                       className="btn btn-xs btn-outline btn-secondary"
                       onClick={handleTestOutput}
                       disabled={isTestingOutput || !outputDevice}
+                      aria-label={isTestingOutput ? "Playing output device" : "Test output device"}
                     >
                       {isTestingOutput ? "Playing..." : "Test"}
                     </button>


### PR DESCRIPTION
Brings the genuinely-valuable, still-absent parts of the old main-targeted PRs onto the baseline: audio test-button aria-labels (#563) and the apply_cors wildcard-credentials invariant test (#552, adapted to the current Starlette API). Verified: CORS test passes, frontend tsc+build clean.