### PR TITLE
🧹 remove unused re-export of CommandExecutor

### DIFF
--- a/src/chatty_commander/app/__init__.py
+++ b/src/chatty_commander/app/__init__.py
@@ -20,6 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .command_executor import CommandExecutor
-
-__all__ = ["CommandExecutor"]
+# Empty file to indicate that the directory is a Python package.

--- a/tests/test_advisors_memory_api.py
+++ b/tests/test_advisors_memory_api.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.web_mode import WebModeServer

--- a/tests/test_advisors_memory_disabled.py
+++ b/tests/test_advisors_memory_disabled.py
@@ -22,7 +22,7 @@
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.web_mode import WebModeServer

--- a/tests/test_agents_api_create_from_description.py
+++ b/tests/test_agents_api_create_from_description.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.web_mode import WebModeServer

--- a/tests/test_agents_api_crud_happy_path.py
+++ b/tests/test_agents_api_crud_happy_path.py
@@ -22,7 +22,7 @@
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.routes.agents import AgentBlueprintModel

--- a/tests/test_agents_api_errors.py
+++ b/tests/test_agents_api_errors.py
@@ -22,7 +22,7 @@
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.web_mode import WebModeServer

--- a/tests/test_agents_api_list_empty.py
+++ b/tests/test_agents_api_list_empty.py
@@ -22,7 +22,7 @@
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.web_mode import WebModeServer

--- a/tests/test_avatar_api_list_success.py
+++ b/tests/test_avatar_api_list_success.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.web_mode import WebModeServer

--- a/tests/test_openapi_endpoints.py
+++ b/tests/test_openapi_endpoints.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.config import Config
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager

--- a/tests/test_web_advisors_api.py
+++ b/tests/test_web_advisors_api.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.config import Config
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager

--- a/tests/test_web_bridge_api.py
+++ b/tests/test_web_bridge_api.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
-from chatty_commander.app import CommandExecutor
+from chatty_commander.app.command_executor import CommandExecutor
 from chatty_commander.app.model_manager import ModelManager
 from chatty_commander.app.state_manager import StateManager
 from chatty_commander.web.web_mode import WebModeServer


### PR DESCRIPTION
🎯 **What:** Removed the re-export of `CommandExecutor` from `src/chatty_commander/app/__init__.py`.
💡 **Why:** This improves consistency with other components in the `app` package and resolves a linter-identified "unused import" while maintaining a clean submodule-based import pattern.
✅ **Verification:** Updated 10 test files to use the explicit import path. Ran 40 core tests and confirmed all passed. Verified no remaining package-level imports for `CommandExecutor` exist in `src/` or `tests/`.
✨ **Result:** A cleaner and more consistent package API for `chatty_commander.app`.

---
*PR created automatically by Jules for task [2884449524885693436](https://jules.google.com/task/2884449524885693436) started by @matthewhand*