### PR TITLE
🧹 Remove unused 'requests' import and clean up legacy shim

### DIFF
--- a/src/chatty_commander/app/command_executor.py
+++ b/src/chatty_commander/app/command_executor.py
@@ -54,13 +54,6 @@ except Exception:  # pragma: no cover - optional
 if _shim_pg is not None:  # pragma: no cover - optional
     pyautogui = _shim_pg
 
-try:  # pragma: no cover
-    from command_executor import requests as _shim_requests
-except Exception:  # pragma: no cover - optional
-    _shim_requests = None
-if _shim_requests is not None:  # pragma: no cover - optional
-    # Map legacy tests to our httpx var for test compatibility if needed
-    httpx = _shim_requests
 
 
 class CommandExecutor:

--- a/src/chatty_commander/command_executor.py
+++ b/src/chatty_commander/command_executor.py
@@ -32,12 +32,7 @@ try:  # pragma: no cover - best effort import
 except Exception:
     pyautogui = None  # type: ignore
 
-try:
-    import requests  # type: ignore
-except Exception:
-    requests = None  # type: ignore
-
-__all__ = ["pyautogui", "requests"]
+__all__ = ["pyautogui"]
 
 
 def __getattr__(name: str):  # type: ignore[override]
@@ -51,4 +46,4 @@ def __getattr__(name: str):  # type: ignore[override]
 
 
 # Make these names visible to patchers; CommandExecutor is provided lazily via __getattr__
-__all__ = ["pyautogui", "requests"]
+__all__ = ["pyautogui"]


### PR DESCRIPTION
🎯 **What:** Removed the unused `requests` import from the legacy compatibility shim `src/chatty_commander/command_executor.py` and cleaned up the corresponding redundant import logic in `src/chatty_commander/app/command_executor.py`.

💡 **Why:** Improving code maintainability by removing dead code and unnecessary dependencies. The project has migrated to `httpx` for HTTP requests.

✅ **Verification:**
- Ran `ruff check` on both modified files (all passed).
- Ran unit tests in `tests/test_command_executor.py` (all passed).
- Verified no other parts of the codebase were relying on the `requests` export from the shim.

✨ **Result:** A cleaner codebase with reduced technical debt and fewer unused imports.

---
*PR created automatically by Jules for task [5768218990692555735](https://jules.google.com/task/5768218990692555735) started by @matthewhand*