### PR TITLE
🔒 Fix Insecure CORS Policy (Wildcard Origin with Credentials)

### DIFF
--- a/src/chatty_commander/web/auth.py
+++ b/src/chatty_commander/web/auth.py
@@ -72,10 +72,12 @@ def apply_cors(
     """
     if no_auth:
         allow_origins = ["*"]
+        allow_credentials = False
     else:
         allow_origins = (
             list(origins) if origins is not None else ["http://localhost:3000"]
         )
+        allow_credentials = True
 
     # Remove existing CORS middleware if already present to avoid duplicates.
     app.user_middleware = [
@@ -85,7 +87,7 @@ def apply_cors(
     app.add_middleware(
         CORSMiddleware,
         allow_origins=allow_origins,
-        allow_credentials=True,
+        allow_credentials=allow_credentials,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -566,7 +566,7 @@ class WebModeServer:
         app.add_middleware(
             CORSMiddleware,
             allow_origins=["*"] if self.no_auth else ["http://localhost:3000"],
-            allow_credentials=True,
+            allow_credentials=not self.no_auth,
             allow_methods=["*"],
             allow_headers=["*"],
         )


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an insecure CORS policy where wildcard origins (`*`) were allowed alongside credentials (`allow_credentials=True`).
⚠️ **Risk:** FastAPI/Starlette prohibits this combination because it allows any website to make credentialed requests to the API, potentially leading to CSRF or other cross-origin attacks if cookies or other credentials were used.
🛡️ **Solution:** The fix ensures that `allow_credentials` is set to `False` whenever wildcard origins are used (specifically in `no_auth` mode). This aligns with security best practices and prevents middleware initialization errors.

---
*PR created automatically by Jules for task [14783782880110622503](https://jules.google.com/task/14783782880110622503) started by @matthewhand*