### PR TITLE
Salvage 5 genuine improvements from triaged main PRs

### DIFF
--- a/src/chatty_commander/app/config.py
+++ b/src/chatty_commander/app/config.py
@@ -31,6 +31,14 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Default command set used when no `commands` are present in the config file.
+DEFAULT_COMMANDS: dict[str, Any] = {
+    "hello": {"action": "custom_message", "message": "Hello from ChattyCommander!"},
+    "take_screenshot": {"action": "keypress", "keys": "take_screenshot"},
+    "paste": {"action": "keypress", "keys": "paste"},
+    "submit": {"action": "keypress", "keys": "submit"},
+}
+
 
 class Config:
     def __init__(self, config_file: str = "config.json") -> None:
@@ -66,16 +74,7 @@ class Config:
             "state_transitions", {}
         )
         self.commands: dict[str, Any] = self.config_data.get(
-            "commands",
-            {
-                "hello": {
-                    "action": "custom_message",
-                    "message": "Hello from ChattyCommander!",
-                },
-                "take_screenshot": {"action": "keypress", "keys": "take_screenshot"},
-                "paste": {"action": "keypress", "keys": "paste"},
-                "submit": {"action": "keypress", "keys": "submit"},
-            },
+            "commands", dict(DEFAULT_COMMANDS)
         )
 
         # Advisors configuration
@@ -112,19 +111,6 @@ class Config:
             self.config_data.get("general", {}).get("inference_framework", "onnx")
         )
 
-        # Commands for model actions
-        default_commands = {}
-        if not self.config_file or "commands" not in self.config_data:  # Use defaults if file missing or commands missing
-            default_commands = {
-                "hello": {
-                    "action": "custom_message",
-                    "message": "Hello from ChattyCommander!",
-                },
-                "take_screenshot": {"action": "keypress", "keys": "take_screenshot"},
-                "paste": {"action": "keypress", "keys": "paste"},
-                "submit": {"action": "keypress", "keys": "submit"},
-            }
-        self.commands: dict[str, Any] = self.config_data.get("commands", default_commands)  # type: ignore[no-redef]
 
         # Start on boot setting
         self.start_on_boot: bool = bool(

--- a/src/chatty_commander/cli/main.py
+++ b/src/chatty_commander/cli/main.py
@@ -36,9 +36,9 @@ import sys
 import sys as _sys
 import threading
 
-# Fix sys.path to include the project src root (one level up from this package directory)
+# Fix sys.path to include the project src root (two levels up from this package directory)
 _pkg_dir = _os.path.dirname(_os.path.abspath(__file__))
-_root_src = _os.path.abspath(_os.path.join(_pkg_dir, ".."))
+_root_src = _os.path.abspath(_os.path.join(_pkg_dir, "..", ".."))
 if _root_src not in _sys.path:
     _sys.path.insert(0, _root_src)
 

--- a/src/chatty_commander/web/routes/agents.py
+++ b/src/chatty_commander/web/routes/agents.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -214,7 +215,11 @@ async def create_blueprint(
             and "description" in payload
             and len(payload.keys()) == 1
         ):
-            model = parse_blueprint_from_text(str(payload.get("description", "")))
+            # Offload the blocking (synchronous LLM I/O) parse off the event
+            # loop so concurrent blueprint creations don't serialize behind it.
+            model = await asyncio.to_thread(
+                parse_blueprint_from_text, str(payload.get("description", ""))
+            )
         else:
             # Try to parse as structured blueprint
             model = AgentBlueprintModel(**payload)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,88 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import warnings
+from unittest.mock import patch, MagicMock
+from chatty_commander import compat
+
+def test_load_with_alias():
+    """Test that compat.load triggers a DeprecationWarning for aliased modules."""
+    mock_aliases = {"old_mod": "new_mod"}
+    with patch("chatty_commander.compat.ALIASES", mock_aliases):
+        with patch("importlib.import_module") as mock_import:
+            mock_import.return_value = MagicMock()
+            with pytest.warns(DeprecationWarning, match="chatty_commander.old_mod is deprecated; use new_mod"):
+                compat.load("old_mod")
+            mock_import.assert_called_once_with("new_mod")
+
+def test_load_without_alias():
+    """Test that compat.load does not trigger a warning for non-aliased modules."""
+    mock_aliases = {"old_mod": "new_mod"}
+    with patch("chatty_commander.compat.ALIASES", mock_aliases):
+        with patch("importlib.import_module") as mock_import:
+            mock_import.return_value = MagicMock()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                compat.load("new_mod")
+                # Ensure no DeprecationWarning from chatty_commander was issued
+                for warning in w:
+                    if issubclass(warning.category, DeprecationWarning) and "chatty_commander" in str(warning.message):
+                        pytest.fail(f"Unexpected DeprecationWarning: {warning.message}")
+            mock_import.assert_called_once_with("new_mod")
+
+def test_expose_with_all():
+    """Test that compat.expose correctly populates the namespace using __all__."""
+    mock_module = MagicMock()
+    mock_module.attr1 = "val1"
+    mock_module.attr2 = "val2"
+    mock_module._private = "private"
+    mock_module.__all__ = ["attr1"]
+
+    namespace = {}
+    with patch("chatty_commander.compat.load") as mock_load:
+        mock_load.return_value = mock_module
+        compat.expose(namespace, "some_mod")
+
+        assert namespace["attr1"] == "val1"
+        assert "attr2" not in namespace
+        assert "_private" not in namespace
+        assert namespace["__all__"] == ["attr1"]
+
+def test_expose_without_all():
+    """Test compat.expose when __all__ is not defined."""
+    class MockModule:
+        def __init__(self):
+            self.attr1 = "val1"
+            self.attr2 = "val2"
+            self._private = "private"
+
+    mock_module = MockModule()
+    namespace = {}
+    with patch("chatty_commander.compat.load") as mock_load:
+        mock_load.return_value = mock_module
+        compat.expose(namespace, "some_mod")
+
+        assert namespace["attr1"] == "val1"
+        assert namespace["attr2"] == "val2"
+        assert "_private" not in namespace
+        assert set(namespace["__all__"]) == {"attr1", "attr2"}

--- a/tests/test_tools_fs_ops.py
+++ b/tests/test_tools_fs_ops.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+from chatty_commander.tools.fs_ops import ensure_dir, write_json, write_text
+
+def test_ensure_dir(tmp_path: Path):
+    """Test that ensure_dir creates a directory and handles existing ones."""
+    test_path = tmp_path / "new_dir"
+    assert not test_path.exists()
+
+    # Test creation
+    ensure_dir(test_path)
+    assert test_path.is_dir()
+
+    # Test existing (should not raise error)
+    ensure_dir(test_path)
+    assert test_path.is_dir()
+
+    # Test nested creation
+    nested_path = tmp_path / "nested" / "dir"
+    assert not nested_path.exists()
+    ensure_dir(nested_path)
+    assert nested_path.is_dir()
+
+
+def test_write_json(tmp_path: Path):
+    """Test that write_json writes data and creates parent directories."""
+    json_path = tmp_path / "subdir" / "test.json"
+    data = {"key": "value", "number": 42}
+
+    assert not json_path.parent.exists()
+
+    write_json(json_path, data)
+
+    assert json_path.exists()
+    assert json_path.parent.is_dir()
+
+    with json_path.open("r", encoding="utf-8") as f:
+        loaded_data = json.load(f)
+
+    assert loaded_data == data
+
+    # Verify pretty formatting (indent=2)
+    content = json_path.read_text(encoding="utf-8")
+    assert '{\n  "key": "value",\n  "number": 42\n}' in content
+
+
+def test_write_text(tmp_path: Path):
+    """Test that write_text writes data and creates parent directories."""
+    text_path = tmp_path / "subdir2" / "test.txt"
+    content = "Hello, world!\nLine 2"
+
+    assert not text_path.parent.exists()
+
+    write_text(text_path, content)
+
+    assert text_path.exists()
+    assert text_path.parent.is_dir()
+
+    assert text_path.read_text(encoding="utf-8") == content


### PR DESCRIPTION
Triaged 18 bot PRs that targeted broken `main`. Salvaged the 5 genuinely-valuable-and-absent ones onto the baseline: DEFAULT_COMMANDS dedup (#593), async-offload of blocking LLM call in create_blueprint (#594), root-execution sys.path fix (#595), and fs_ops + compat test coverage (#601/#603). Full pytest green (100%). The other 13 PRs are closed (superseded/redundant/harmful/obsolete) — see their comments.