### PR TITLE
🎨 Palette: Add aria-label to modal backdrop close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2024-05-23 - Accessible Modal Backdrops
+**Learning:** DaisyUI modal backdrops use `<button>close</button>` which is visually hidden to provide click-to-close functionality. However, without an `aria-label`, screen readers will just read "close button", which may lack context.
+**Action:** Always add `aria-label="Close modal"` (or similar contextual label) to visually hidden modal backdrop buttons (`<form className="modal-backdrop"><button>close</button></form>`) to improve screen reader experience.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close modal">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
- Added `aria-label="Close modal"` to the delete confirmation modal backdrop button in `webui/frontend/src/pages/CommandsPage.tsx` to improve screen reader context.
- Added UX learning entry to `.Jules/palette.md` noting the importance of adding `aria-label`s to visually hidden DaisyUI modal backdrop triggers.

---
*PR created automatically by Jules for task [772016373713015857](https://jules.google.com/task/772016373713015857) started by @matthewhand*