### PR TITLE
feat(ui): replace text character with lucide icon for clear search button

### DIFF
--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -12,7 +12,8 @@ import {
   RefreshCw,
   Search,
   Download,
-  Upload
+  Upload,
+  X
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
@@ -240,7 +241,7 @@ export default function CommandsPage() {
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
             >
-              ×
+              <X size={14} />
             </button>
           )}
         </div>


### PR DESCRIPTION
Replaces the generic '×' text character in the 'Clear search' button
on the CommandsPage with the vector `X` icon from lucide-react. This
ensures visual consistency and alignment with the rest of the application
using DaisyUI and vector icons.

Added UX learning about standardizing close/clear icons to palette journal.

---
*PR created automatically by Jules for task [7588170836896709725](https://jules.google.com/task/7588170836896709725) started by @matthewhand*