### PR TITLE
🎨 Palette: Replace raw text close icon with vector X icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2024-05-24 - Consistent Vector Icons over Raw Text
+**Learning:** Using raw text characters like "X" or "×" for close/clear buttons often results in poor visual alignment and inconsistent appearance across platforms, detracting from visual polish.
+**Action:** Always use proper vector icons (e.g., `X` from `lucide-react`) for UI actions like clearing input or closing modals instead of raw text characters.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -12,7 +12,8 @@ import {
   RefreshCw,
   Search,
   Download,
-  Upload
+  Upload,
+  X
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
@@ -240,7 +241,7 @@ export default function CommandsPage() {
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
             >
-              ×
+              <X size={14} />
             </button>
           )}
         </div>


### PR DESCRIPTION
💡 **What**: Replaced the raw text character "×" in `CommandsPage.tsx` with the `<X />` vector icon from `lucide-react`.

🎯 **Why**: Using raw text characters for UI icons like "close" or "clear" frequently leads to inconsistent sizing and visual alignment issues across different platforms and browsers. Proper vector icons ensure a polished, consistent user experience.

♿ **Accessibility**: Maintained the existing `aria-label="Clear search"` attribute to ensure screen readers continue to properly identify the button's action.

📔 **Learning**: Added a new entry to the `.Jules/palette.md` UX journal documenting this pattern for future consistency.

---
*PR created automatically by Jules for task [10311415524465103429](https://jules.google.com/task/10311415524465103429) started by @matthewhand*