### PR TITLE
🎨 Palette: UX Improvement - Clear Search Icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+## 2026-03-31 - Better Icons for Better UX
+**Learning:** Raw text characters like 'x' or '×' shouldn't be used for icons as they lack the visual consistency of proper SVG icons, might not center correctly, and can vary based on the system font.
+**Action:** When implementing close or clear buttons, use proper vector icons (e.g., `X` from `lucide-react`) instead of raw text characters.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -12,7 +12,8 @@ import {
   RefreshCw,
   Search,
   Download,
-  Upload
+  Upload,
+  X
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
@@ -240,7 +241,7 @@ export default function CommandsPage() {
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
             >
-              ×
+              <X size={14} />
             </button>
           )}
         </div>


### PR DESCRIPTION
🎨 Palette: UX Improvement - Clear Search Icon

💡 **What:** Replaced the raw text character '×' with the `<X />` vector icon from `lucide-react` in the "Clear search" button on the Commands page. Added a new entry to the `.Jules/palette.md` UX journal.
🎯 **Why:** Using plain text characters like 'x' or '×' for icons often results in poor visual alignment and inconsistency, as they depend on the user's system font. Using a proper vector icon ensures it looks correct across all devices and matches the styling of other icons (like the Search icon) on the page.
♿ **Accessibility:** Maintained the existing `aria-label="Clear search"` on the button, ensuring the action remains fully accessible to screen readers while the visual presentation is improved.

---
*PR created automatically by Jules for task [9714921821174941344](https://jules.google.com/task/9714921821174941344) started by @matthewhand*