### PR TITLE
🎨 Palette: Add aria-label to DaisyUI modal backdrop close button

### DIFF
--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
**💡 What:** Added a descriptive `aria-label="Close dialog"` to the `<button>` inside the DaisyUI modal backdrop.
**🎯 Why:** DaisyUI's modal backdrop pattern uses a visually hidden button that spans the entire backdrop. While it contains the text 'close', adding an explicit and descriptive `aria-label` ensures that screen reader users understand exactly what action they are taking when interacting with the backdrop overlay.
**♿ Accessibility:** Improved screen reader context for the modal close action.

---
*PR created automatically by Jules for task [12833067003973914270](https://jules.google.com/task/12833067003973914270) started by @matthewhand*