### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2024-05-18 - Missing title/aria-labels on DaisyUI buttons
+**Learning:** Found several icon-only buttons or interactive elements (like modal close buttons, clear search, command buttons) lacking `aria-label` or `title` attributes in the React frontend components (`CommandsPage`, `DashboardPage`, `CommandAuthoringPage`). This makes the UI less accessible to screen readers and prevents tooltips from showing for sighted users who need clarification on icon-only actions.
+**Action:** Always verify that every `<button>` element has either descriptive visible text or an explicit `aria-label` attribute. For icon-only buttons, consider adding a `title` attribute to provide a native browser tooltip for sighted users.

--- a/webui/frontend/src/pages/CommandAuthoringPage.tsx
+++ b/webui/frontend/src/pages/CommandAuthoringPage.tsx
@@ -141,6 +141,7 @@ const ActionField: React.FC<{
           onClick={onRemove}
           className="btn btn-ghost btn-sm btn-circle text-error"
           aria-label="Remove action"
+          title="Remove action"
         >
           <Trash2 size={16} />
         </button>
@@ -481,7 +482,7 @@ export default function CommandAuthoringPage() {
           >
             <AlertCircle size={20} />
             <span>{error}</span>
-            <button onClick={() => setError(null)} className="btn btn-ghost btn-sm btn-circle" aria-label="Dismiss error">
+            <button onClick={() => setError(null)} className="btn btn-ghost btn-sm btn-circle" aria-label="Dismiss error" title="Dismiss error">
               <X size={16} />
             </button>
           </motion.div>

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -290,13 +290,13 @@ export default function CommandsPage() {
                       ariaLabel={`Options for ${name}`}
                     >
                       <li>
-                        <button aria-label={`Edit ${name}`}>
+                        <button aria-label={`Edit ${name}`} title="Edit Command">
                           <Edit3 size={16} className="text-primary" />
                           Edit Command
                         </button>
                       </li>
                       <li>
-                        <button className="text-error hover:bg-error/10 hover:text-error" aria-label={`Delete ${name}`} onClick={() => handleDeleteClick(name)}>
+                        <button className="text-error hover:bg-error/10 hover:text-error" aria-label={`Delete ${name}`} title="Delete Command" onClick={() => handleDeleteClick(name)}>
                           <Trash2 size={16} />
                           Delete Command
                         </button>
@@ -345,7 +345,7 @@ export default function CommandsPage() {
             <p className="text-base-content/50 mt-2 mb-6 max-w-md text-center">
               Try adjusting your search terms or clearing the search filter to see all commands.
             </p>
-            <button className="btn btn-outline" onClick={() => setSearchParams({})}>
+            <button className="btn btn-outline" aria-label="Clear Search" onClick={() => setSearchParams({})}>
               Clear Search
             </button>
           </div>
@@ -358,12 +358,12 @@ export default function CommandsPage() {
           <h3 className="font-bold text-lg">Confirm Deletion</h3>
           <p className="py-4">Are you sure you want to delete <strong>{pendingDeleteCommand}</strong>?</p>
           <div className="modal-action">
-            <button className="btn" onClick={handleDeleteCancel}>Cancel</button>
-            <button className="btn btn-error" onClick={handleDeleteConfirm}>Delete</button>
+            <button className="btn" aria-label="Cancel deletion" onClick={handleDeleteCancel}>Cancel</button>
+            <button className="btn btn-error" aria-label="Confirm deletion" onClick={handleDeleteConfirm}>Delete</button>
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button aria-label="Close dialog" onClick={handleDeleteCancel}>close</button>
         </form>
       </dialog>
     </div>

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -409,6 +409,7 @@ const DashboardPage = React.memo(() => {
             <button
               type="submit"
               className="btn btn-primary"
+              aria-label="Execute command"
               disabled={!commandInput.trim() || isSending || !isConnected}
             >
               {isSending ? <span className="loading loading-spinner"></span> : <Send size={18} />}


### PR DESCRIPTION
🎨 Palette: A11y improvements to icon-only buttons

💡 What: Added missing `aria-label` and `title` attributes to various icon-only buttons across the frontend pages.
🎯 Why: To ensure screen readers can announce the purpose of these interactive elements, and to provide native browser tooltips for sighted users.
♿ Accessibility: Improves compliance with WCAG 4.1.2 Name, Role, Value by providing accessible names for controls.

---
*PR created automatically by Jules for task [3003433961269229489](https://jules.google.com/task/3003433961269229489) started by @matthewhand*