### PR TITLE
🎨 Palette: Add ARIA label to hidden close button in modal backdrop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Explicit ID & Label Linking in Dynamic Components
 **Learning:** When building dynamic form lists in React (like mapping over an array of custom inputs), using implicit labels (`<label><input/></label>`) isn't always feasible, but simply placing `<label>` next to `<input>` with no mapping completely breaks screen reader association.
 **Action:** Always explicitly define uniquely generated IDs (e.g. ``id={`field-${index}`}``) and bind them directly using the `htmlFor` property on the label elements in dynamically generated components. Additionally, ensure bare `<textarea>` tags with placeholder text still have a proper `aria-label` or visually hidden label text to serve as the accessible name.
+
+## 2024-05-11 - Add ARIA label to DaisyUI's form method="dialog" backdrop
+**Learning:** DaisyUI uses `<form method="dialog">` for modal backdrops. The close button inside this form is visually hidden but still accessible to screen readers. If it simply contains the text "close", it lacks the necessary context for users utilizing screen readers to understand what exactly is being closed.
+**Action:** Always explicitly add a descriptive `aria-label` (e.g., `aria-label="Close dialog"`) to the `<button>` inside `<form method="dialog" className="modal-backdrop">` to provide screen reader users with the proper context.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -363,7 +363,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added `aria-label="Close dialog"` to the hidden close button inside the modal backdrop.
🎯 Why: DaisyUI uses a `<form method="dialog">` pattern where a visually hidden button is used to close the modal when clicking outside of it. However, if this button only contains the text "close", it lacks necessary context for screen reader users to understand what is being closed. Adding a descriptive `aria-label` provides this context.
♿ Accessibility: Improved screen reader experience by providing context for the modal close action.

---
*PR created automatically by Jules for task [7369040366360119293](https://jules.google.com/task/7369040366360119293) started by @matthewhand*