### PR TITLE
🎨 Palette: Add aria-label to modal backdrop close button

### DIFF
--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -391,7 +391,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
💡 What: Added `aria-label="Close dialog"` to the visually hidden `<button>` inside `<form method="dialog" className="modal-backdrop">`.
🎯 Why: Better context for screen reader users on what exactly is being closed by the backdrop layer.
♿ Accessibility: Improves semantics by making screen readers announce the exact intention of the background dismiss overlay instead of just "close button".

---
*PR created automatically by Jules for task [1584922024983678891](https://jules.google.com/task/1584922024983678891) started by @matthewhand*