### PR TITLE
🎨 Palette: Add aria-label to DaisyUI modal backdrop

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@ This journal records critical UX and accessibility learnings for the Chatty Comm
 ## 2026-03-28 - Actionable Empty States and Custom Component A11y
 **Learning:** Bare text for empty states or zero-results states is unhelpful. Users benefit from clear visual indicators (icons) and actionable next steps. Also, custom reusable components like dropdown triggers often forget `ariaLabel` props, making them inaccessible when they wrap icon-only buttons.
 **Action:** Always replace bare text empty states with an illustrative icon (e.g., from `lucide-react`), explanatory text, and a primary call-to-action button, utilizing existing DaisyUI utility classes (`bg-base-200/50`, `rounded-box`). Ensure custom UI components with icon-only triggers accept an optional `ariaLabel` prop with sensible default fallbacks.
+
+## 2026-06-05 - DaisyUI Modal Backdrop A11y
+**Learning:** DaisyUI modal backdrops (`<form method="dialog" className="modal-backdrop">`) use a visually hidden `<button>close</button>` element which requires an explicit `aria-label` (e.g., `aria-label="Close modal"`) to ensure screen readers announce it with appropriate context instead of just reading the raw "close" text.
+**Action:** Always add an explicit `aria-label` to the hidden close buttons within DaisyUI modal backdrops to improve screen reader context.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -391,7 +391,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close modal">close</button>
         </form>
       </dialog>
     </div>


### PR DESCRIPTION
# 🎨 Palette: DaisyUI Modal Backdrop A11y

💡 **What:** Added an explicit `aria-label="Close modal"` to the visually hidden close button within the DaisyUI modal backdrop on the Commands page. Also recorded this learning in the Palette journal.
🎯 **Why:** DaisyUI's `<form method="dialog" className="modal-backdrop">` creates a full-screen clickable area to dismiss the modal, but under the hood, it uses a visually hidden `<button>close</button>`. Without an `aria-label`, screen readers might simply announce "close" without sufficient context about *what* is being closed, or why clicking the "backdrop" triggers that action. The explicit label provides better context for non-visual users.
♿ **Accessibility:** Improves screen reader experience for the modal backdrop dismissal interaction.

---
*PR created automatically by Jules for task [9062123169460093103](https://jules.google.com/task/9062123169460093103) started by @matthewhand*