### PR TITLE
UI/UX: command card identity, visible gradient headings, cleaner dograh offline card

### DIFF
--- a/webui/frontend/src/components/DograhStatusCard.tsx
+++ b/webui/frontend/src/components/DograhStatusCard.tsx
@@ -76,8 +76,11 @@ const DograhStatusCard = React.memo(() => {
           </div>
           <div className="stat-title">Dograh</div>
           <div className="stat-value text-2xl text-base-content/50">Offline</div>
-          <div className="stat-desc text-xs truncate" title={status?.reason ?? ""}>
-            {status?.reason ?? "not configured"}
+          <div
+            className="stat-desc text-xs whitespace-normal leading-snug max-w-[16rem]"
+            title={status?.reason ?? ""}
+          >
+            Optional voice-call integration — not configured.
           </div>
         </div>
       </div>

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -79,23 +79,26 @@ textarea {
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
   }
 
-  /* Gradient text utilities */
+  /* Gradient text utilities.
+     DaisyUI 4 stores theme colors as oklch COMPONENTS (e.g. --p: 0.65 0.24 280),
+     so hsl(var(--p)) is invalid and made these headings render transparent.
+     Use oklch(var(--x)) to match how Tailwind/DaisyUI consume the same vars. */
   .text-gradient-primary {
-    background: linear-gradient(135deg, hsl(var(--p)) 0%, hsl(var(--s)) 100%);
+    background: linear-gradient(135deg, oklch(var(--p)) 0%, oklch(var(--s)) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
 
   .text-gradient-accent {
-    background: linear-gradient(135deg, hsl(var(--a)) 0%, hsl(var(--p)) 100%);
+    background: linear-gradient(135deg, oklch(var(--a)) 0%, oklch(var(--p)) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
 
   .text-gradient-warm {
-    background: linear-gradient(135deg, hsl(var(--wa)) 0%, hsl(var(--er)) 100%);
+    background: linear-gradient(135deg, oklch(var(--wa)) 0%, oklch(var(--er)) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;

--- a/webui/frontend/src/pages/CommandsPage.test.tsx
+++ b/webui/frontend/src/pages/CommandsPage.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+import CommandsPage from "./CommandsPage";
+import { apiService } from "../services/apiService";
+
+vi.mock("../services/apiService", () => ({
+  apiService: { getCommands: vi.fn() },
+}));
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CommandsPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  (apiService.getCommands as ReturnType<typeof vi.fn>).mockResolvedValue({
+    take_screenshot: { action: "keypress", keys: "alt+print_screen" },
+    open_docs: { action: "url", url: "https://example.com/docs" },
+  });
+});
+
+test("each command card shows its name", async () => {
+  renderPage();
+  // The command name is the card title (previously the card was anonymous).
+  expect(await screen.findByText("take_screenshot")).toBeInTheDocument();
+  expect(await screen.findByText("open_docs")).toBeInTheDocument();
+});
+
+test("each card describes the command's actual action", async () => {
+  renderPage();
+  // keypress command shows the keys it presses
+  expect(await screen.findByText("Presses keys")).toBeInTheDocument();
+  expect(await screen.findByText("alt+print_screen")).toBeInTheDocument();
+  // url command shows the URL it opens
+  expect(await screen.findByText("Opens URL")).toBeInTheDocument();
+  expect(
+    await screen.findByText("https://example.com/docs")
+  ).toBeInTheDocument();
+});

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -27,6 +27,16 @@ interface CommandConfig {
   message?: string;
 }
 
+// Human-readable summary of what a command actually does, for the card.
+function describeAction(config: CommandConfig): { label: string; detail: string } {
+  if (config.url) return { label: 'Opens URL', detail: config.url };
+  if (config.keys) return { label: 'Presses keys', detail: config.keys };
+  if (config.cmd) return { label: 'Runs command', detail: config.cmd };
+  if (config.message) return { label: 'Sends message', detail: config.message };
+  if (config.action) return { label: 'Action', detail: config.action };
+  return { label: 'No action', detail: 'Not configured' };
+}
+
 export default function CommandsPage() {
   useEffect(() => {
     document.title = "Commands | ChattyCommander";
@@ -303,8 +313,12 @@ export default function CommandsPage() {
               <div className="border-gradient"></div>
               <div className="card-body p-0">
                 {/* Command Header */}
-                <div className="p-6 bg-base-200/50 border-b border-base-content/10 flex justify-between items-start">
-                  <div className="flex gap-1">
+                <div className="p-6 bg-base-200/50 border-b border-base-content/10 flex justify-between items-start gap-3">
+                  <div className="min-w-0 flex items-center gap-3">
+                    <TerminalSquare size={20} className="text-primary shrink-0" />
+                    <h3 className="text-lg font-bold truncate" title={name}>{name}</h3>
+                  </div>
+                  <div className="flex gap-1 shrink-0">
                     <DynamicDropdown
                       buttonContent={
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
@@ -330,13 +344,19 @@ export default function CommandsPage() {
                   </div>
                 </div>
 
-                {/* Triggers Section */}
+                {/* Action + Triggers Section */}
                 <div className="p-6 space-y-4">
-                  <h3 className="text-sm font-semibold uppercase tracking-wider text-base-content/50 flex items-center gap-2">
-                    <Settings2 size={14} /> Activation Triggers
-                  </h3>
+                  {/* What this command does */}
+                  <div>
+                    <h4 className="text-sm font-semibold uppercase tracking-wider text-base-content/50 flex items-center gap-2 mb-2">
+                      <Settings2 size={14} /> {describeAction(config).label}
+                    </h4>
+                    <p className="text-sm text-base-content/80 font-mono break-all bg-base-200/40 rounded-lg px-3 py-2">
+                      {describeAction(config).detail}
+                    </p>
+                  </div>
 
-                  {/* REST API Badge */}
+                  {/* How it's triggered */}
                   <div className="flex items-center gap-3 p-3 rounded-lg border border-success/30 bg-success/5">
                     <Globe className="text-success" size={20} />
                     <div className="flex-1">


### PR DESCRIPTION
Reviewed the running web UI and fixed the three clearest problems.

| # | Problem | Fix |
|---|---|---|
| 1 | Command cards were **anonymous** — header showed only the ⋮ menu, and every card repeated an identical generic 'REST API Trigger' block | Card now titles the **command name** and describes its **actual action** (Opens URL / Presses keys / Runs command / Sends message) with the target |
| 2 | Page headings (`.text-gradient-*`) rendered **invisible** — used `hsl(var(--p))` but DaisyUI 4 stores oklch components | Switched to `oklch(var(--x))`; 'Commands & Triggers' etc. now render |
| 3 | Dograh offline card printed the raw backend reason **truncated mid-word** ('DOGRAH_BASE_URL and DOGRAH_…') | Clean wrapped 'Optional voice-call integration — not configured.' |

Before/after screenshots attached in the conversation. vitest 63/63 (2 new), build + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)