### PR TITLE
Batch 3: raise coverage on ws.py, llm/manager.py, wakeword.py, lifecycle.py

### DIFF
--- a/tests/test_llm_manager_coverage.py
+++ b/tests/test_llm_manager_coverage.py
@@ -1,0 +1,420 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction.
+
+"""Coverage-focused tests for ``chatty_commander.llm.manager.LLMManager``.
+
+All real backends (OpenAI / Ollama / local transformers) are replaced with
+fakes so the tests are fully hermetic: no network calls, no model downloads,
+no API keys required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import chatty_commander.llm.manager as manager_mod
+from chatty_commander.llm.manager import (
+    LLMManager,
+    get_default_llm_manager,
+    get_global_llm_manager,
+)
+
+
+class FakeBackend:
+    """A controllable stand-in for any LLMBackend."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        available: bool = True,
+        response: str = "ok",
+        raise_on_generate: Exception | None = None,
+    ) -> None:
+        self.name = name
+        self._available = available
+        self._response = response
+        self._raise_on_generate = raise_on_generate
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def generate_response(self, prompt: str, **kwargs: Any) -> str:
+        self.calls.append((prompt, kwargs))
+        if self._raise_on_generate is not None:
+            raise self._raise_on_generate
+        return self._response
+
+    def get_backend_info(self) -> dict[str, Any]:
+        return {"backend": self.name, "available": self._available}
+
+
+@pytest.fixture
+def patch_backends(monkeypatch):
+    """Patch the backend constructors used inside ``_initialize_backends``.
+
+    Returns a dict you mutate to control which backends are created and how
+    they behave. By default every constructor yields an *available* fake.
+    """
+
+    registry: dict[str, FakeBackend] = {}
+
+    def make_factory(key: str):
+        def factory(*args: Any, **kwargs: Any) -> FakeBackend:
+            backend = registry.get(key)
+            if backend is None:
+                backend = FakeBackend(key)
+                registry[key] = backend
+            if isinstance(backend, Exception):  # pragma: no cover - defensive
+                raise backend
+            return backend
+
+        return factory
+
+    # Mock backend is constructed with MockLLMBackend(); give it its own fake.
+    def mock_factory(*args: Any, **kwargs: Any) -> FakeBackend:
+        backend = registry.get("mock")
+        if backend is None:
+            backend = FakeBackend("mock")
+            registry["mock"] = backend
+        return backend
+
+    monkeypatch.setattr(manager_mod, "MockLLMBackend", mock_factory)
+    monkeypatch.setattr(manager_mod, "OpenAIBackend", make_factory("openai"))
+    monkeypatch.setattr(manager_mod, "OllamaBackend", make_factory("ollama"))
+    monkeypatch.setattr(manager_mod, "LocalTransformersBackend", make_factory("local"))
+
+    return registry
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    """Ensure ambient env vars don't influence backend selection."""
+    monkeypatch.delenv("LLM_BACKEND", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# Construction / backend selection
+# --------------------------------------------------------------------------- #
+
+
+def test_use_mock_only_initializes_mock(patch_backends):
+    mgr = LLMManager(use_mock=True)
+    assert set(mgr.backends.keys()) == {"mock"}
+    assert mgr.get_active_backend_name() == "mock"
+    assert mgr.is_available() is True
+
+
+def test_priority_order_selects_openai_first(patch_backends):
+    # All available -> openai wins by priority order.
+    mgr = LLMManager()
+    assert mgr.get_active_backend_name() == "openai"
+
+
+def test_falls_through_to_ollama_when_openai_unavailable(patch_backends):
+    patch_backends["openai"] = FakeBackend("openai", available=False)
+    mgr = LLMManager()
+    assert mgr.get_active_backend_name() == "ollama"
+
+
+def test_falls_through_to_mock_when_all_real_unavailable(patch_backends):
+    patch_backends["openai"] = FakeBackend("openai", available=False)
+    patch_backends["ollama"] = FakeBackend("ollama", available=False)
+    patch_backends["local"] = FakeBackend("local", available=False)
+    mgr = LLMManager()
+    assert mgr.get_active_backend_name() == "mock"
+
+
+def test_preferred_backend_used_when_available(patch_backends):
+    mgr = LLMManager(preferred_backend="ollama")
+    assert mgr.get_active_backend_name() == "ollama"
+
+
+def test_preferred_backend_falls_back_when_unavailable(patch_backends):
+    patch_backends["ollama"] = FakeBackend("ollama", available=False)
+    mgr = LLMManager(preferred_backend="ollama")
+    # ollama not available -> falls to priority order -> openai
+    assert mgr.get_active_backend_name() == "openai"
+
+
+def test_preferred_backend_unknown_name_ignored(patch_backends):
+    mgr = LLMManager(preferred_backend="does-not-exist")
+    # Unknown name not in backends -> normal priority order
+    assert mgr.get_active_backend_name() == "openai"
+
+
+def test_preferred_backend_from_env(monkeypatch, patch_backends):
+    monkeypatch.setenv("LLM_BACKEND", "local")
+    mgr = LLMManager()
+    assert mgr.preferred_backend == "local"
+    assert mgr.get_active_backend_name() == "local"
+
+
+def test_backend_init_exception_is_swallowed(monkeypatch, patch_backends):
+    def boom(*args: Any, **kwargs: Any):
+        raise RuntimeError("cannot init openai")
+
+    monkeypatch.setattr(manager_mod, "OpenAIBackend", boom)
+    mgr = LLMManager()
+    # openai never registered; next priority backend selected
+    assert "openai" not in mgr.backends
+    assert mgr.get_active_backend_name() == "ollama"
+
+
+def test_ollama_and_local_init_exceptions_swallowed(monkeypatch, patch_backends):
+    def boom(*args: Any, **kwargs: Any):
+        raise RuntimeError("init failure")
+
+    monkeypatch.setattr(manager_mod, "OllamaBackend", boom)
+    monkeypatch.setattr(manager_mod, "LocalTransformersBackend", boom)
+    mgr = LLMManager()
+    # Both failed to register; openai is still available and selected.
+    assert "ollama" not in mgr.backends
+    assert "local" not in mgr.backends
+    assert mgr.get_active_backend_name() == "openai"
+
+
+# --------------------------------------------------------------------------- #
+# generate_response + fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_generate_response_uses_active_backend(patch_backends):
+    patch_backends["openai"] = FakeBackend("openai", response="hello-openai")
+    mgr = LLMManager()
+    out = mgr.generate_response("hi", max_tokens=5)
+    assert out == "hello-openai"
+    assert mgr.backends["openai"].calls == [("hi", {"max_tokens": 5})]
+
+
+def test_generate_response_no_backend_raises():
+    mgr = LLMManager(use_mock=True)
+    mgr.active_backend = None
+    with pytest.raises(RuntimeError, match="No LLM backend available"):
+        mgr.generate_response("hi")
+
+
+def test_generate_response_falls_back_on_error(patch_backends):
+    patch_backends["openai"] = FakeBackend(
+        "openai", raise_on_generate=RuntimeError("rate limited")
+    )
+    patch_backends["ollama"] = FakeBackend("ollama", response="from-ollama")
+    mgr = LLMManager()
+    assert mgr.get_active_backend_name() == "openai"
+    out = mgr.generate_response("hi")
+    assert out == "from-ollama"
+    assert mgr.get_active_backend_name() == "ollama"
+
+
+def test_generate_response_fallback_also_fails_reraises(patch_backends):
+    patch_backends["openai"] = FakeBackend(
+        "openai", raise_on_generate=RuntimeError("primary fail")
+    )
+    patch_backends["ollama"] = FakeBackend(
+        "ollama", raise_on_generate=ValueError("fallback fail")
+    )
+    patch_backends["local"] = FakeBackend("local", available=False)
+    # mock is available but comes after; fallback picks ollama which fails.
+    mgr = LLMManager()
+    with pytest.raises(ValueError, match="fallback fail"):
+        mgr.generate_response("hi")
+
+
+def test_generate_response_no_fallback_available_reraises(patch_backends):
+    # Only mock backend; it raises and there's nothing after it.
+    err = RuntimeError("mock fail")
+    patch_backends["mock"] = FakeBackend("mock", raise_on_generate=err)
+    mgr = LLMManager(use_mock=True)
+    with pytest.raises(RuntimeError, match="mock fail"):
+        mgr.generate_response("hi")
+
+
+# --------------------------------------------------------------------------- #
+# _try_fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_try_fallback_returns_false_when_none_available(patch_backends):
+    patch_backends["ollama"] = FakeBackend("ollama", available=False)
+    patch_backends["local"] = FakeBackend("local", available=False)
+    patch_backends["mock"] = FakeBackend("mock", available=False)
+    mgr = LLMManager()
+    # active is openai; everything after is unavailable.
+    assert mgr.get_active_backend_name() == "openai"
+    assert mgr._try_fallback() is False
+
+
+def test_try_fallback_from_unknown_current_scans_all(patch_backends):
+    mgr = LLMManager(use_mock=True)
+    # Force an active backend whose name isn't in fallback_order list path.
+    mgr.active_backend = FakeBackend("ghost")
+    assert mgr.get_active_backend_name() == "unknown"
+    # candidates = full order; mock is available.
+    assert mgr._try_fallback() is True
+    assert mgr.get_active_backend_name() == "mock"
+
+
+# --------------------------------------------------------------------------- #
+# get_active_backend_name / info helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_get_active_backend_name_none():
+    mgr = LLMManager(use_mock=True)
+    mgr.active_backend = None
+    assert mgr.get_active_backend_name() == "none"
+
+
+def test_get_active_backend_name_unknown(patch_backends):
+    mgr = LLMManager()
+    mgr.active_backend = FakeBackend("stranger")
+    assert mgr.get_active_backend_name() == "unknown"
+
+
+def test_get_backend_info_named_existing(patch_backends):
+    mgr = LLMManager()
+    info = mgr.get_backend_info("ollama")
+    assert info["backend"] == "ollama"
+
+
+def test_get_backend_info_named_missing(patch_backends):
+    mgr = LLMManager()
+    info = mgr.get_backend_info("nope")
+    assert info == {"error": "Backend nope not found"}
+
+
+def test_get_backend_info_active(patch_backends):
+    mgr = LLMManager()
+    info = mgr.get_backend_info()
+    assert info["backend"] == "openai"
+
+
+def test_get_backend_info_no_active(patch_backends):
+    mgr = LLMManager()
+    mgr.active_backend = None
+    assert mgr.get_backend_info() == {"error": "No active backend"}
+
+
+def test_get_all_backends_info_includes_active_and_errors(patch_backends):
+    # Make one backend raise during get_backend_info.
+    bad = FakeBackend("local")
+
+    def boom() -> dict[str, Any]:
+        raise RuntimeError("info boom")
+
+    bad.get_backend_info = boom  # type: ignore[method-assign]
+    patch_backends["local"] = bad
+
+    mgr = LLMManager()
+    info = mgr.get_all_backends_info()
+    assert info["active"] == "openai"
+    assert info["local"] == {"error": "info boom"}
+    assert info["openai"]["backend"] == "openai"
+
+
+# --------------------------------------------------------------------------- #
+# switch_backend
+# --------------------------------------------------------------------------- #
+
+
+def test_switch_backend_success(patch_backends):
+    mgr = LLMManager()
+    assert mgr.switch_backend("ollama") is True
+    assert mgr.get_active_backend_name() == "ollama"
+
+
+def test_switch_backend_unknown(patch_backends):
+    mgr = LLMManager()
+    assert mgr.switch_backend("nope") is False
+
+
+def test_switch_backend_unavailable(patch_backends):
+    patch_backends["ollama"] = FakeBackend("ollama", available=False)
+    mgr = LLMManager()
+    assert mgr.switch_backend("ollama") is False
+    # active unchanged
+    assert mgr.get_active_backend_name() == "openai"
+
+
+# --------------------------------------------------------------------------- #
+# refresh_backends
+# --------------------------------------------------------------------------- #
+
+
+def test_refresh_backends_resets_available_cache_attr(patch_backends):
+    mgr = LLMManager()
+    # Give a backend the cache attribute that refresh resets.
+    target = mgr.backends["openai"]
+    target._available = True  # type: ignore[attr-defined]
+    mgr.refresh_backends()
+    assert target._available is None  # type: ignore[attr-defined]
+    # Reselection still yields a valid backend.
+    assert mgr.is_available() is True
+
+
+# --------------------------------------------------------------------------- #
+# test_backend
+# --------------------------------------------------------------------------- #
+
+
+def test_test_backend_unknown(patch_backends):
+    mgr = LLMManager()
+    assert mgr.test_backend("nope") == {"error": "Backend nope not found"}
+
+
+def test_test_backend_unavailable(patch_backends):
+    patch_backends["ollama"] = FakeBackend("ollama", available=False)
+    mgr = LLMManager()
+    result = mgr.test_backend("ollama")
+    assert result == {"error": "Backend ollama not available"}
+
+
+def test_test_backend_success(patch_backends):
+    patch_backends["openai"] = FakeBackend("openai", response="pong")
+    mgr = LLMManager()
+    result = mgr.test_backend("openai", test_prompt="ping")
+    assert result["success"] is True
+    assert result["response"] == "pong"
+    assert "response_time" in result
+    assert result["backend_info"]["backend"] == "openai"
+    # max_tokens=20 passed through
+    assert mgr.backends["openai"].calls[-1] == ("ping", {"max_tokens": 20})
+
+
+def test_test_backend_generation_error(patch_backends):
+    patch_backends["openai"] = FakeBackend(
+        "openai", raise_on_generate=RuntimeError("gen boom")
+    )
+    mgr = LLMManager()
+    result = mgr.test_backend("openai")
+    assert result["error"] == "gen boom"
+    assert result["backend_info"]["backend"] == "openai"
+
+
+# --------------------------------------------------------------------------- #
+# Module-level convenience functions
+# --------------------------------------------------------------------------- #
+
+
+def test_get_default_llm_manager(patch_backends):
+    mgr = get_default_llm_manager(use_mock=True)
+    assert isinstance(mgr, LLMManager)
+    assert mgr.get_active_backend_name() == "mock"
+
+
+def test_get_global_llm_manager_is_cached(patch_backends):
+    # Reset module global to avoid cross-test contamination.
+    manager_mod._default_manager = None
+    first = get_global_llm_manager(use_mock=True)
+    second = get_global_llm_manager(use_mock=True)
+    assert first is second
+    manager_mod._default_manager = None

--- a/tests/test_wakeword_coverage.py
+++ b/tests/test_wakeword_coverage.py
@@ -1,0 +1,531 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction.
+
+"""Coverage tests for ``chatty_commander.voice.wakeword``.
+
+The runtime voice dependencies (``openwakeword``, ``pyaudio``, ``numpy``) are
+not installed in the CI/test environment, so these tests patch the import
+boundary -- the module-level globals ``VOICE_DEPS_AVAILABLE``, ``openwakeword``,
+``pyaudio`` and ``np`` -- with fakes. This lets us exercise the real detector
+code paths (model init, listen loop, scoring, lifecycle) without any audio
+hardware or real ONNX models.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from chatty_commander.voice import wakeword
+from chatty_commander.voice.wakeword import MockWakeWordDetector, WakeWordDetector
+
+# ---------------------------------------------------------------------------
+# Fakes for the import-guarded dependencies
+# ---------------------------------------------------------------------------
+
+
+class _FakeModel:
+    """Stand-in for ``openwakeword.Model``."""
+
+    def __init__(self, *args, **kwargs):
+        self.models = {"hey_jarvis": object(), "alexa": object()}
+        self.predictions = {}
+
+    def predict(self, audio_array):
+        return self.predictions
+
+
+class _FakeOpenWakeWord:
+    Model = _FakeModel
+
+
+class _FakeNumpy:
+    int16 = "int16"
+
+    @staticmethod
+    def frombuffer(data, dtype=None):
+        # Return a recognizable sentinel; the fake model ignores it.
+        return list(data) if data else []
+
+
+@contextmanager
+def patched_deps(
+    monkeypatch,
+    *,
+    available: bool = True,
+    oww=None,
+    pyaudio_mod=None,
+    numpy_mod=None,
+):
+    """Patch the import-guarded module globals so real branches run."""
+    monkeypatch.setattr(wakeword, "VOICE_DEPS_AVAILABLE", available)
+    monkeypatch.setattr(
+        wakeword, "openwakeword", oww if oww is not None else _FakeOpenWakeWord
+    )
+    monkeypatch.setattr(
+        wakeword,
+        "pyaudio",
+        pyaudio_mod if pyaudio_mod is not None else MagicMock(),
+    )
+    monkeypatch.setattr(
+        wakeword, "np", numpy_mod if numpy_mod is not None else _FakeNumpy
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Dependency-unavailable branch
+# ---------------------------------------------------------------------------
+
+
+def test_init_raises_when_deps_unavailable(monkeypatch):
+    monkeypatch.setattr(wakeword, "VOICE_DEPS_AVAILABLE", False)
+    with pytest.raises(ImportError) as exc:
+        WakeWordDetector()
+    assert "Voice dependencies not available" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Init / defaults
+# ---------------------------------------------------------------------------
+
+
+def test_init_defaults(monkeypatch):
+    with patched_deps(monkeypatch):
+        det = WakeWordDetector()
+    assert det.wake_words == ["hey_jarvis", "alexa"]
+    assert det.threshold == 0.5
+    assert det.chunk_size == 1280
+    assert det.sample_rate == 16000
+    assert det.channels == 1
+    assert isinstance(det._model, _FakeModel)
+    assert det._running is False
+    assert det._callbacks == []
+
+
+def test_init_custom_args(monkeypatch):
+    with patched_deps(monkeypatch):
+        det = WakeWordDetector(
+            wake_words=["computer"],
+            threshold=0.8,
+            chunk_size=640,
+            sample_rate=8000,
+            channels=2,
+        )
+    assert det.wake_words == ["computer"]
+    assert det.threshold == 0.8
+    assert det.chunk_size == 640
+    assert det.sample_rate == 8000
+    assert det.channels == 2
+
+
+def test_init_model_failure_falls_back_to_mock(monkeypatch):
+    """If model construction raises, detector flips to mock mode."""
+
+    class BoomOWW:
+        class Model:
+            def __init__(self, *a, **k):
+                raise RuntimeError("no onnx for you")
+
+    with patched_deps(monkeypatch, oww=BoomOWW):
+        det = WakeWordDetector()
+    assert det._model is None
+    assert det._is_mock is True
+
+
+# ---------------------------------------------------------------------------
+# Callback management
+# ---------------------------------------------------------------------------
+
+
+def test_add_and_remove_callback(monkeypatch):
+    with patched_deps(monkeypatch):
+        det = WakeWordDetector()
+
+    def cb(word, conf):
+        pass
+
+    det.add_callback(cb)
+    assert cb in det._callbacks
+    det.remove_callback(cb)
+    assert cb not in det._callbacks
+    # Removing again is a no-op (does not raise)
+    det.remove_callback(cb)
+
+
+def test_notify_callbacks_invokes_all(monkeypatch):
+    with patched_deps(monkeypatch):
+        det = WakeWordDetector()
+    received = []
+    det.add_callback(lambda w, c: received.append((w, c)))
+    det.add_callback(lambda w, c: received.append(("second", c)))
+    det._notify_callbacks("alexa", 0.77)
+    assert ("alexa", 0.77) in received
+    assert ("second", 0.77) in received
+
+
+def test_notify_callbacks_swallows_exceptions(monkeypatch):
+    with patched_deps(monkeypatch):
+        det = WakeWordDetector()
+    good = []
+
+    def boom(w, c):
+        raise ValueError("boom")
+
+    det.add_callback(boom)
+    det.add_callback(lambda w, c: good.append((w, c)))
+    # Should not propagate the exception from the first callback.
+    det._notify_callbacks("hey_jarvis", 0.9)
+    assert good == [("hey_jarvis", 0.9)]
+
+
+# ---------------------------------------------------------------------------
+# Mock-mode lifecycle (model failed to load)
+# ---------------------------------------------------------------------------
+
+
+def _mock_mode_detector(monkeypatch):
+    class BoomOWW:
+        class Model:
+            def __init__(self, *a, **k):
+                raise RuntimeError("boom")
+
+    with patched_deps(monkeypatch, oww=BoomOWW):
+        return WakeWordDetector()
+
+
+def test_mock_mode_start_listening(monkeypatch):
+    det = _mock_mode_detector(monkeypatch)
+    det.start_listening()
+    assert det._running is True
+    # No thread is started in mock mode.
+    assert det._thread is None
+
+
+def test_mock_mode_get_available_models(monkeypatch):
+    det = _mock_mode_detector(monkeypatch)
+    assert det.get_available_models() == ["hey_jarvis", "alexa", "hey_google"]
+
+
+def test_start_listening_noop_when_already_running(monkeypatch):
+    det = _mock_mode_detector(monkeypatch)
+    det._running = True
+    det.start_listening()  # Early return; should remain running.
+    assert det._running is True
+    assert det._thread is None
+
+
+# ---------------------------------------------------------------------------
+# Real-detector lifecycle with a fake PyAudio stream
+# ---------------------------------------------------------------------------
+
+
+def _real_detector_with_stream(monkeypatch, predictions=None):
+    fake_stream = MagicMock()
+    fake_stream.read.return_value = b"\x00\x01" * 10
+    fake_audio = MagicMock()
+    fake_audio.open.return_value = fake_stream
+
+    fake_pyaudio = MagicMock()
+    fake_pyaudio.PyAudio.return_value = fake_audio
+    fake_pyaudio.paInt16 = 8
+
+    with patched_deps(monkeypatch, pyaudio_mod=fake_pyaudio):
+        det = WakeWordDetector(wake_words=["hey_jarvis"], threshold=0.5)
+    if predictions is not None:
+        det._model.predictions = predictions
+    return det, fake_audio, fake_stream
+
+
+def test_start_and_stop_listening_lifecycle(monkeypatch):
+    det, fake_audio, fake_stream = _real_detector_with_stream(monkeypatch)
+    det.start_listening()
+    assert det._running is True
+    assert det._thread is not None
+    # is_listening reflects the live thread.
+    assert det.is_listening() is True
+    fake_audio.open.assert_called_once()
+
+    det.stop_listening()
+    assert det._running is False
+    fake_stream.stop_stream.assert_called_once()
+    fake_stream.close.assert_called_once()
+    fake_audio.terminate.assert_called_once()
+    assert det._stream is None
+    assert det._audio is None
+    assert det.is_listening() is False
+
+
+def test_start_listening_failure_calls_stop_and_raises(monkeypatch):
+    fake_audio = MagicMock()
+    fake_audio.open.side_effect = OSError("device busy")
+    fake_pyaudio = MagicMock()
+    fake_pyaudio.PyAudio.return_value = fake_audio
+    fake_pyaudio.paInt16 = 8
+
+    with patched_deps(monkeypatch, pyaudio_mod=fake_pyaudio):
+        det = WakeWordDetector()
+    with pytest.raises(OSError):
+        det.start_listening()
+    # stop_listening was invoked during cleanup.
+    assert det._running is False
+    assert det._audio is None
+
+
+def test_stop_listening_handles_stream_close_errors(monkeypatch):
+    det, _, fake_stream = _real_detector_with_stream(monkeypatch)
+    det._stream = fake_stream
+    det._audio = MagicMock()
+    fake_stream.stop_stream.side_effect = RuntimeError("close fail")
+    det._audio.terminate.side_effect = RuntimeError("term fail")
+    # Errors are swallowed; resources still cleared.
+    det.stop_listening()
+    assert det._stream is None
+    assert det._audio is None
+
+
+# ---------------------------------------------------------------------------
+# Detection / scoring path (_listen_loop body via direct stepping)
+# ---------------------------------------------------------------------------
+
+
+def _run_one_loop_iteration(det, fake_stream):
+    """Run a single iteration of the listen loop body, then stop.
+
+    The real ``start_listening`` is what assigns ``_stream``; we drive the
+    loop directly, so wire the fake stream in by hand and have the model's
+    ``predict`` flip ``_running`` off so the ``while`` loop exits after one
+    pass (the model is the last call in the loop body).
+    """
+    det._stream = fake_stream
+    preds = det._model.predictions
+
+    def stop_after(*_a, **_k):
+        det._running = False
+        return preds
+
+    # Patch the model predict to also stop the loop after one call.
+    det._model.predict = stop_after
+    det._running = True
+    det._listen_loop()
+
+
+def test_listen_loop_detects_above_threshold(monkeypatch):
+    det, _, stream = _real_detector_with_stream(
+        monkeypatch, predictions={"hey_jarvis": 0.9}
+    )
+    hits = []
+    det.add_callback(lambda w, c: hits.append((w, c)))
+    _run_one_loop_iteration(det, stream)
+    assert hits == [("hey_jarvis", 0.9)]
+
+
+def test_listen_loop_ignores_below_threshold(monkeypatch):
+    det, _, stream = _real_detector_with_stream(
+        monkeypatch, predictions={"hey_jarvis": 0.2}
+    )
+    hits = []
+    det.add_callback(lambda w, c: hits.append((w, c)))
+    _run_one_loop_iteration(det, stream)
+    assert hits == []
+
+
+def test_listen_loop_at_exact_threshold_detects(monkeypatch):
+    # confidence >= threshold, boundary inclusive.
+    det, _, stream = _real_detector_with_stream(
+        monkeypatch, predictions={"hey_jarvis": 0.5}
+    )
+    hits = []
+    det.add_callback(lambda w, c: hits.append((w, c)))
+    _run_one_loop_iteration(det, stream)
+    assert hits == [("hey_jarvis", 0.5)]
+
+
+def test_listen_loop_ignores_unconfigured_wake_word(monkeypatch):
+    # Model reports a word the detector is not configured to listen for.
+    det, _, stream = _real_detector_with_stream(
+        monkeypatch, predictions={"alexa": 0.99}
+    )
+    hits = []
+    det.add_callback(lambda w, c: hits.append((w, c)))
+    _run_one_loop_iteration(det, stream)
+    assert hits == []
+
+
+def test_listen_loop_handles_read_exception(monkeypatch):
+    det, _, fake_stream = _real_detector_with_stream(monkeypatch)
+    det._stream = fake_stream
+    # First read raises; loop logs, sleeps briefly, then we stop it.
+    calls = {"n": 0}
+
+    def read_raises(*_a, **_k):
+        calls["n"] += 1
+        # Stay running so the loop's ``if self._running`` error branch
+        # (log + brief sleep) executes; the patched sleep below stops us.
+        raise OSError("overflow")
+
+    fake_stream.read = read_raises
+
+    sleeps = {"n": 0}
+
+    def fake_sleep(_secs):
+        # Loop hit the error path and is pausing before retry; stop it now.
+        sleeps["n"] += 1
+        det._running = False
+
+    monkeypatch.setattr(wakeword.time, "sleep", fake_sleep)
+    det._running = True
+    det._listen_loop()  # Should not raise.
+    assert calls["n"] == 1
+    assert sleeps["n"] == 1  # the error-branch sleep ran
+
+
+def test_listen_loop_read_exception_while_stopped_is_silent(monkeypatch):
+    """If a read fails after we've already stopped, no retry-sleep happens."""
+    det, _, fake_stream = _real_detector_with_stream(monkeypatch)
+    det._stream = fake_stream
+
+    def read_then_stop(*_a, **_k):
+        det._running = False  # simulate stop racing with the read
+        raise OSError("overflow")
+
+    fake_stream.read = read_then_stop
+    slept = {"n": 0}
+    monkeypatch.setattr(
+        wakeword.time, "sleep", lambda *_: slept.__setitem__("n", slept["n"] + 1)
+    )
+    det._running = True
+    det._listen_loop()
+    # _running was False inside the except, so the error branch is skipped.
+    assert slept["n"] == 0
+
+
+def test_listen_loop_mock_mode_sleeps_and_continues(monkeypatch):
+    det = _mock_mode_detector(monkeypatch)
+    sleeps = {"n": 0}
+
+    def fake_sleep(_secs):
+        sleeps["n"] += 1
+        det._running = False  # break out after first sleep
+
+    monkeypatch.setattr(wakeword.time, "sleep", fake_sleep)
+    det._running = True
+    det._listen_loop()
+    assert sleeps["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_available_models / is_listening on real detector
+# ---------------------------------------------------------------------------
+
+
+def test_get_available_models_from_model(monkeypatch):
+    det, _, _ = _real_detector_with_stream(monkeypatch)
+    models = det.get_available_models()
+    assert set(models) == {"hey_jarvis", "alexa"}
+
+
+def test_get_available_models_no_model_returns_empty(monkeypatch):
+    det, _, _ = _real_detector_with_stream(monkeypatch)
+    det._model = None
+    assert det.get_available_models() == []
+
+
+def test_get_available_models_handles_error(monkeypatch):
+    det, _, _ = _real_detector_with_stream(monkeypatch)
+
+    class BadModel:
+        @property
+        def models(self):
+            raise RuntimeError("kaboom")
+
+    det._model = BadModel()
+    assert det.get_available_models() == []
+
+
+def test_is_listening_false_without_thread(monkeypatch):
+    det, _, _ = _real_detector_with_stream(monkeypatch)
+    assert det.is_listening() is False
+    det._running = True
+    # Still no live thread.
+    assert det.is_listening() is False
+
+
+# ---------------------------------------------------------------------------
+# MockWakeWordDetector
+# ---------------------------------------------------------------------------
+
+
+def test_mock_detector_full_flow():
+    det = MockWakeWordDetector("ignored", foo="bar")
+    assert det.is_listening() is False
+    assert det.get_available_models() == ["hey_jarvis", "alexa", "hey_google"]
+
+    hits = []
+    cb = lambda w, c: hits.append((w, c))  # noqa: E731
+    det.add_callback(cb)
+
+    # Triggering before start does nothing.
+    det.trigger_wake_word()
+    assert hits == []
+
+    det.start_listening()
+    assert det.is_listening() is True
+    det.trigger_wake_word("alexa", 0.42)
+    assert hits == [("alexa", 0.42)]
+
+    det.remove_callback(cb)
+    assert cb not in det._callbacks
+    det.remove_callback(cb)  # no-op
+
+    det.stop_listening()
+    assert det.is_listening() is False
+
+
+def test_mock_detector_trigger_default_args():
+    det = MockWakeWordDetector()
+    hits = []
+    det.add_callback(lambda w, c: hits.append((w, c)))
+    det.start_listening()
+    det.trigger_wake_word()
+    assert hits == [("hey_jarvis", 0.9)]
+
+
+def test_mock_detector_trigger_swallows_callback_errors():
+    det = MockWakeWordDetector()
+
+    def boom(w, c):
+        raise ValueError("boom")
+
+    det.add_callback(boom)
+    det.start_listening()
+    # Should not raise even though the callback throws.
+    det.trigger_wake_word()
+
+
+# ---------------------------------------------------------------------------
+# Threaded integration: start, detect via real loop, stop
+# ---------------------------------------------------------------------------
+
+
+def test_threaded_detection_end_to_end(monkeypatch):
+    det, _, fake_stream = _real_detector_with_stream(
+        monkeypatch, predictions={"hey_jarvis": 0.95}
+    )
+    event = threading.Event()
+    det.add_callback(lambda w, c: event.set())
+    # Keep numpy.frombuffer cheap; default fake handles it.
+    det.start_listening()
+    try:
+        assert event.wait(timeout=2.0), "callback was not invoked"
+    finally:
+        det.stop_listening()
+    assert det._running is False

--- a/tests/test_web_lifecycle_coverage.py
+++ b/tests/test_web_lifecycle_coverage.py
@@ -1,0 +1,224 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Tests for src/chatty_commander/web/lifecycle.py
+
+from __future__ import annotations
+
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from chatty_commander.web import lifecycle
+
+# ---------------------------------------------------------------------------
+# Module-level handler functions
+# ---------------------------------------------------------------------------
+
+
+def test_handle_shutdown_signal_logs_and_reraises():
+    """_handle_shutdown_signal logs structured info, restores default handler, re-raises."""
+    with (
+        patch.object(lifecycle.signal, "signal") as mock_signal,
+        patch.object(lifecycle.signal, "raise_signal") as mock_raise,
+        patch.object(lifecycle.logger, "info") as mock_info,
+    ):
+        lifecycle._handle_shutdown_signal(signal.SIGTERM, None)
+
+    # Restores default handler for the received signal, then re-raises it.
+    mock_signal.assert_called_once_with(signal.SIGTERM, signal.SIG_DFL)
+    mock_raise.assert_called_once_with(signal.SIGTERM)
+
+    # Two info log lines: signal-received and shutting-down.
+    assert mock_info.call_count == 2
+    first_call = mock_info.call_args_list[0]
+    # The signal name 'SIGTERM' is one of the positional log args.
+    assert "SIGTERM" in first_call.args
+
+
+def test_handle_shutdown_signal_sigint():
+    """SIGINT path resolves the signal name correctly."""
+    with (
+        patch.object(lifecycle.signal, "signal"),
+        patch.object(lifecycle.signal, "raise_signal") as mock_raise,
+        patch.object(lifecycle.logger, "info") as mock_info,
+    ):
+        lifecycle._handle_shutdown_signal(signal.SIGINT, None)
+
+    mock_raise.assert_called_once_with(signal.SIGINT)
+    assert "SIGINT" in mock_info.call_args_list[0].args
+
+
+def test_atexit_handler_logs_completion():
+    with patch.object(lifecycle.logger, "info") as mock_info:
+        lifecycle._atexit_handler()
+    assert mock_info.call_count == 1
+    assert "Shutdown complete" in mock_info.call_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# register_lifecycle - registration wiring
+# ---------------------------------------------------------------------------
+
+
+def _find_handler(app: FastAPI, event_type: str):
+    """Return the registered async handler for 'startup'/'shutdown'."""
+    handlers = app.router.on_startup if event_type == "startup" else app.router.on_shutdown
+    assert handlers, f"no {event_type} handlers registered"
+    return handlers[-1]
+
+
+def test_register_lifecycle_registers_both_events():
+    app = FastAPI()
+    before_startup = len(app.router.on_startup)
+    before_shutdown = len(app.router.on_shutdown)
+
+    lifecycle.register_lifecycle(app, get_state_manager=lambda: object())
+
+    assert len(app.router.on_startup) == before_startup + 1
+    assert len(app.router.on_shutdown) == before_shutdown + 1
+
+
+# ---------------------------------------------------------------------------
+# Startup handler behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_registers_signals_and_atexit_no_callback():
+    app = FastAPI()
+    lifecycle.register_lifecycle(app, get_state_manager=lambda: object())
+    startup = _find_handler(app, "startup")
+
+    with (
+        patch.object(lifecycle.signal, "signal") as mock_signal,
+        patch.object(lifecycle.atexit, "register") as mock_atexit,
+    ):
+        await startup()
+
+    # SIGTERM and SIGINT handlers installed.
+    installed = {c.args[0] for c in mock_signal.call_args_list}
+    assert signal.SIGTERM in installed
+    assert signal.SIGINT in installed
+    mock_atexit.assert_called_once_with(lifecycle._atexit_handler)
+
+
+@pytest.mark.asyncio
+async def test_startup_invokes_on_startup_callback():
+    app = FastAPI()
+    cb = MagicMock()
+    lifecycle.register_lifecycle(
+        app, get_state_manager=lambda: object(), on_startup=cb
+    )
+    startup = _find_handler(app, "startup")
+
+    with (
+        patch.object(lifecycle.signal, "signal"),
+        patch.object(lifecycle.atexit, "register"),
+    ):
+        await startup()
+
+    cb.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_startup_swallows_on_startup_exception():
+    app = FastAPI()
+    cb = MagicMock(side_effect=RuntimeError("boom"))
+    lifecycle.register_lifecycle(
+        app, get_state_manager=lambda: object(), on_startup=cb
+    )
+    startup = _find_handler(app, "startup")
+
+    with (
+        patch.object(lifecycle.signal, "signal"),
+        patch.object(lifecycle.atexit, "register"),
+    ):
+        # Must not raise despite the callback raising.
+        await startup()
+
+    cb.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Shutdown handler behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shutdown_logs_without_callback():
+    app = FastAPI()
+    lifecycle.register_lifecycle(app, get_state_manager=lambda: object())
+    shutdown = _find_handler(app, "shutdown")
+
+    with patch.object(lifecycle.logger, "info") as mock_info:
+        await shutdown()
+
+    messages = [c.args[0] for c in mock_info.call_args_list]
+    assert any("Shutting down gracefully" in m for m in messages)
+    assert any("Shutdown complete" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_invokes_on_shutdown_callback():
+    app = FastAPI()
+    cb = MagicMock()
+    lifecycle.register_lifecycle(
+        app, get_state_manager=lambda: object(), on_shutdown=cb
+    )
+    shutdown = _find_handler(app, "shutdown")
+
+    await shutdown()
+    cb.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_swallows_on_shutdown_exception():
+    app = FastAPI()
+    cb = MagicMock(side_effect=ValueError("nope"))
+    lifecycle.register_lifecycle(
+        app, get_state_manager=lambda: object(), on_shutdown=cb
+    )
+    shutdown = _find_handler(app, "shutdown")
+
+    with patch.object(lifecycle.logger, "info") as mock_info:
+        # Must not raise despite callback raising.
+        await shutdown()
+
+    cb.assert_called_once_with()
+    # Completion still logged after a swallowed callback error.
+    messages = [c.args[0] for c in mock_info.call_args_list]
+    assert any("Shutdown complete" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via TestClient lifespan (drives startup + shutdown together)
+# ---------------------------------------------------------------------------
+
+
+def test_lifespan_end_to_end_via_testclient():
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    startup_cb = MagicMock()
+    shutdown_cb = MagicMock()
+    lifecycle.register_lifecycle(
+        app,
+        get_state_manager=lambda: object(),
+        on_startup=startup_cb,
+        on_shutdown=shutdown_cb,
+    )
+
+    with (
+        patch.object(lifecycle.signal, "signal"),
+        patch.object(lifecycle.atexit, "register"),
+    ):
+        with TestClient(app):
+            # Inside the context, startup has fired.
+            startup_cb.assert_called_once_with()
+            shutdown_cb.assert_not_called()
+        # On exit, shutdown has fired.
+        shutdown_cb.assert_called_once_with()

--- a/tests/test_ws_routes_coverage.py
+++ b/tests/test_ws_routes_coverage.py
@@ -1,0 +1,336 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Coverage tests for the generic /ws router (``include_ws_routes``).
+
+Exercises the full WebSocket lifecycle wired by
+``chatty_commander.web.routes.ws.include_ws_routes``:
+
+  * client connect -> ``accept`` + connection registration + initial snapshot
+  * inbound JSON dispatch through the ``on_message`` callback
+  * non-JSON frames being wrapped as ``{"type": "raw", ...}``
+  * ping -> pong symmetry
+  * the heartbeat (``TimeoutError``) branch via a tiny ``heartbeat_seconds``
+  * broadcast to multiple connected clients (shared connection set)
+  * disconnect cleanup (connection removed from the shared set)
+
+The router is mounted on a minimal ``FastAPI`` app via the public factory so the
+real ASGI WebSocket lifecycle runs under starlette's ``TestClient``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+
+from chatty_commander.web.routes.ws import include_ws_routes
+
+
+class _Harness:
+    """Owns the shared connection set + state snapshot for a mounted /ws router."""
+
+    def __init__(self, snapshot: dict | None = None, heartbeat_seconds: float = 30.0):
+        self.connections: set[WebSocket] = set()
+        self.snapshot = snapshot if snapshot is not None else {"current_state": "idle"}
+        self.received: list[dict] = []
+        self.app = FastAPI()
+        self.app.include_router(
+            include_ws_routes(
+                get_connections=lambda: self.connections,
+                set_connections=self._set_connections,
+                get_state_snapshot=lambda: self.snapshot,
+                on_message=self.received.append,
+                heartbeat_seconds=heartbeat_seconds,
+            )
+        )
+
+    def _set_connections(self, conns: set[WebSocket]) -> None:
+        self.connections = conns
+
+    def client(self) -> TestClient:
+        return TestClient(self.app)
+
+
+@pytest.fixture
+def harness() -> _Harness:
+    return _Harness()
+
+
+def test_connect_sends_initial_snapshot(harness: _Harness):
+    with harness.client().websocket_connect("/ws") as ws:
+        msg = ws.receive_json()
+    assert msg["type"] == "connection_established"
+    assert msg["data"] == {"current_state": "idle"}
+    # timestamp present and ISO-ish (datetime.now().isoformat())
+    assert isinstance(msg["timestamp"], str)
+    assert "T" in msg["timestamp"]
+
+
+def test_connect_registers_then_cleans_up_connection(harness: _Harness):
+    # During the session the connection set holds exactly one socket.
+    with harness.client().websocket_connect("/ws") as ws:
+        ws.receive_json()  # drain snapshot
+        assert len(harness.connections) == 1
+    # After the context exits (client disconnect) the finally-block discards it.
+    assert harness.connections == set()
+
+
+def test_inbound_json_message_dispatched_to_on_message(harness: _Harness):
+    with harness.client().websocket_connect("/ws") as ws:
+        ws.receive_json()  # snapshot
+        ws.send_text(json.dumps({"type": "command", "data": {"name": "go"}}))
+        # Round-trip a ping afterwards to be sure the prior frame was processed.
+        ws.send_text(json.dumps({"type": "ping"}))
+        pong = ws.receive_json()
+    assert pong["type"] == "pong"
+    assert {"type": "command", "data": {"name": "go"}} in harness.received
+
+
+def test_non_json_frame_wrapped_as_raw(harness: _Harness):
+    with harness.client().websocket_connect("/ws") as ws:
+        ws.receive_json()  # snapshot
+        ws.send_text("this is not json{")
+        # Force synchronization with a ping/pong.
+        ws.send_text(json.dumps({"type": "ping"}))
+        ws.receive_json()
+    raw_msgs = [m for m in harness.received if m.get("type") == "raw"]
+    assert raw_msgs and raw_msgs[0]["data"] == "this is not json{"
+
+
+def test_ping_yields_pong_with_timestamp(harness: _Harness):
+    with harness.client().websocket_connect("/ws") as ws:
+        ws.receive_json()  # snapshot
+        ws.send_text(json.dumps({"type": "ping"}))
+        pong = ws.receive_json()
+    assert pong["type"] == "pong"
+    assert "timestamp" in pong["data"]
+
+
+def test_non_ping_message_yields_no_response(harness: _Harness):
+    """A normal (non-ping) frame is dispatched but produces no reply frame."""
+    with harness.client().websocket_connect("/ws") as ws:
+        ws.receive_json()  # snapshot
+        ws.send_text(json.dumps({"type": "noop"}))
+        # Next thing we receive must be the pong, not a reply to "noop".
+        ws.send_text(json.dumps({"type": "ping"}))
+        nxt = ws.receive_json()
+    assert nxt["type"] == "pong"
+
+
+def test_on_message_none_is_tolerated():
+    """When no on_message callback is supplied the loop still processes frames."""
+    conns: set[WebSocket] = set()
+    app = FastAPI()
+    app.include_router(
+        include_ws_routes(
+            get_connections=lambda: conns,
+            set_connections=lambda c: None,
+            get_state_snapshot=lambda: {"current_state": "idle"},
+            on_message=None,
+        )
+    )
+    with TestClient(app).websocket_connect("/ws") as ws:
+        ws.receive_json()  # snapshot
+        ws.send_text(json.dumps({"type": "ping"}))
+        assert ws.receive_json()["type"] == "pong"
+
+
+def test_heartbeat_emitted_on_receive_timeout():
+    """A tiny heartbeat interval forces the TimeoutError branch to fire."""
+    h = _Harness(heartbeat_seconds=0.05)
+    with h.client().websocket_connect("/ws") as ws:
+        ws.receive_json()  # snapshot
+        # We send nothing, so receive_text times out and a heartbeat is pushed.
+        beat = ws.receive_json()
+    assert beat["type"] == "heartbeat"
+    assert "timestamp" in beat["data"]
+
+
+def test_multiple_clients_share_connection_set(harness: _Harness):
+    """Two simultaneous clients are both registered in the shared set.
+
+    The shared, externally-readable connection set is exactly what a broadcaster
+    iterates over; here we assert both live sockets are present and independently
+    serviceable (each gets its own snapshot + pong).
+    """
+    client = harness.client()
+    with client.websocket_connect("/ws") as ws_a, client.websocket_connect(
+        "/ws"
+    ) as ws_b:
+        snap_a = ws_a.receive_json()
+        snap_b = ws_b.receive_json()
+        assert snap_a["type"] == snap_b["type"] == "connection_established"
+        assert len(harness.connections) == 2
+        # Each connection is the genuine starlette WebSocket a broadcaster uses.
+        assert all(isinstance(c, WebSocket) for c in harness.connections)
+
+        # Both clients independently serviceable through the same router.
+        for ws in (ws_a, ws_b):
+            ws.send_text(json.dumps({"type": "ping"}))
+            assert ws.receive_json()["type"] == "pong"
+
+    # Both connections cleaned up on disconnect.
+    assert harness.connections == set()
+
+
+def test_disconnect_cleanup_with_concurrent_clients(harness: _Harness):
+    client = harness.client()
+    with client.websocket_connect("/ws") as ws_a:
+        ws_a.receive_json()
+        with client.websocket_connect("/ws") as ws_b:
+            ws_b.receive_json()
+            assert len(harness.connections) == 2
+        # ws_b closed; its finally-block discards it, ws_a remains.
+        # Sync ws_a so its loop has cycled at least once after ws_b left.
+        ws_a.send_text(json.dumps({"type": "ping"}))
+        assert ws_a.receive_json()["type"] == "pong"
+        assert len(harness.connections) == 1
+    assert harness.connections == set()
+
+
+class _FakeWebSocket:
+    """Minimal in-memory WebSocket double driving the endpoint coroutine directly.
+
+    Used for the error/heartbeat branches where starlette's synchronous
+    ``TestClient`` deadlocks on a server that returns mid-stream (the server
+    endpoint catches everything and returns, but TestClient blocks forever on the
+    pending receive). Driving the coroutine directly runs the *real* loop body —
+    accept, snapshot send, receive dispatch, the generic ``except`` branch, and
+    the ``finally`` cleanup — with no transport portal involved.
+    """
+
+    def __init__(self, inbound: list[str]):
+        self.accepted = False
+        self._inbound = list(inbound)
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+    async def receive_text(self) -> str:
+        if self._inbound:
+            return self._inbound.pop(0)
+        # No more scripted frames: emulate the client going away.
+        from starlette.websockets import WebSocketDisconnect
+
+        raise WebSocketDisconnect(code=1000)
+
+
+def _endpoint(router):
+    return router.routes[0].endpoint
+
+
+def test_on_message_exception_hits_generic_handler_and_cleans_up():
+    """A raising on_message exercises the generic ``except Exception`` branch.
+
+    The error is swallowed (logged at error level), the loop exits, and the
+    ``finally`` block still discards the connection so no socket leaks.
+    """
+    conns: set[WebSocket] = set()
+    state: dict = {"conns": conns}
+
+    def _set(c):
+        state["conns"] = c
+
+    def _boom(_msg: dict) -> None:
+        raise RuntimeError("on_message blew up")
+
+    router = include_ws_routes(
+        get_connections=lambda: state["conns"],
+        set_connections=_set,
+        get_state_snapshot=lambda: {"current_state": "idle"},
+        on_message=_boom,
+    )
+    fake = _FakeWebSocket(inbound=[json.dumps({"type": "anything"})])
+
+    import asyncio
+
+    asyncio.run(_endpoint(router)(fake))  # type: ignore[arg-type]
+
+    assert fake.accepted is True
+    # Snapshot was sent before the failing frame was processed.
+    assert json.loads(fake.sent[0])["type"] == "connection_established"
+    # The RuntimeError from on_message was caught by the generic handler; the
+    # connection was still registered then discarded.
+    assert state["conns"] == set()
+
+
+def test_websocket_disconnect_branch_cleans_up_connection():
+    """Client disconnect mid-receive hits the WebSocketDisconnect handler."""
+    state: dict = {"conns": set()}
+
+    def _set(c):
+        state["conns"] = c
+
+    router = include_ws_routes(
+        get_connections=lambda: state["conns"],
+        set_connections=_set,
+        get_state_snapshot=lambda: {"current_state": "idle"},
+        on_message=None,
+    )
+    # One ping (gets a pong) then the fake raises WebSocketDisconnect.
+    fake = _FakeWebSocket(inbound=[json.dumps({"type": "ping"})])
+
+    import asyncio
+
+    asyncio.run(_endpoint(router)(fake))  # type: ignore[arg-type]
+
+    types = [json.loads(s)["type"] for s in fake.sent]
+    assert types[0] == "connection_established"
+    assert "pong" in types  # ping handled before the disconnect
+    assert state["conns"] == set()  # finally cleaned up
+
+
+def test_on_message_exception_is_logged(caplog):
+    """The generic handler logs the error (not silently swallowed)."""
+    import asyncio
+    import logging
+
+    state: dict = {"conns": set()}
+
+    router = include_ws_routes(
+        get_connections=lambda: state["conns"],
+        set_connections=lambda c: state.__setitem__("conns", c),
+        get_state_snapshot=lambda: {"current_state": "idle"},
+        on_message=lambda _m: (_ for _ in ()).throw(ValueError("kaboom")),
+    )
+    fake = _FakeWebSocket(inbound=[json.dumps({"type": "x"})])
+
+    with caplog.at_level(logging.ERROR, logger="chatty_commander.web.routes.ws"):
+        asyncio.run(_endpoint(router)(fake))  # type: ignore[arg-type]
+
+    assert any("WebSocket error" in rec.message for rec in caplog.records)
+
+
+def test_state_snapshot_reflects_live_provider():
+    """get_state_snapshot is read at connect time, not bound at router build."""
+    h = _Harness(snapshot={"current_state": "chatty"})
+    h.snapshot = {"current_state": "computer", "active_models": ["a", "b"]}
+    with h.client().websocket_connect("/ws") as ws:
+        msg = ws.receive_json()
+    assert msg["data"] == {"current_state": "computer", "active_models": ["a", "b"]}


### PR DESCRIPTION
Four hermetic, **test-only** suites (no production source changed):

| Module | Before | After |
|---|---|---|
| web/routes/ws.py | 34% | **100%** |
| llm/manager.py | 16% | **100%** |
| voice/wakeword.py | 35% | **99%** |
| web/lifecycle.py | 0% | **100%** |

Coverage is meaningful, not line-touching: real branches — WS connect/snapshot/dispatch/ping-pong/heartbeat-timeout/multi-client/disconnect-cleanup; LLM backend priority/env-selection/fallback chains; wakeword detector init/mock-fallback/scoring-threshold/lifecycle (deps mocked); lifecycle startup/shutdown.

Notable: the starlette sync TestClient deadlocks on the WS error/disconnect branches mid-receive — covered hermetically by driving the endpoint coroutine with an in-memory fake socket instead of weakening assertions.

**No production bugs surfaced.** Full suite green (1122 passed, 1 skipped), ruff clean. Test-only — Docker image unaffected, no rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)