### PR TITLE
Frontend polish: dev-gated logging, lazy dashboard chart, prefers-reduced-motion

### DIFF
--- a/webui/frontend/src/components/PerformanceChart.tsx
+++ b/webui/frontend/src/components/PerformanceChart.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+
+export interface PerfMetric {
+  time: string;
+  cpu: number;
+  memory: number;
+}
+
+const CustomTooltip = React.memo(({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-base-300 border border-base-content/20 p-3 rounded-lg shadow-xl text-xs">
+        <p className="font-mono mb-2 text-base-content/60">{label}</p>
+        {payload.map((entry: any) => (
+          <div key={entry.name} className="flex items-center gap-2 mb-1">
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: entry.stroke }} />
+            <span className="font-semibold" style={{ color: entry.stroke }}>
+              {entry.name}: {entry.value.toFixed(1)}%
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return null;
+});
+
+interface PerformanceChartProps {
+  history: PerfMetric[];
+}
+
+const PerformanceChart = React.memo(({ history }: PerformanceChartProps) => {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={history}>
+        <defs>
+          <linearGradient id="colorCpu" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#3abff8" stopOpacity={0.8} />
+            <stop offset="95%" stopColor="#3abff8" stopOpacity={0} />
+          </linearGradient>
+          <linearGradient id="colorMem" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#fbbd23" stopOpacity={0.8} />
+            <stop offset="95%" stopColor="#fbbd23" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
+        <XAxis dataKey="time" hide />
+        <YAxis
+          domain={[0, 100]}
+          tickFormatter={(value) => `${value}%`}
+        />
+        <Tooltip content={<CustomTooltip />} />
+        <Area
+          type="monotone"
+          dataKey="cpu"
+          stroke="#3abff8"
+          fillOpacity={1}
+          fill="url(#colorCpu)"
+          name="CPU"
+          isAnimationActive={false}
+        />
+        <Area
+          type="monotone"
+          dataKey="memory"
+          stroke="#fbbd23"
+          fillOpacity={1}
+          fill="url(#colorMem)"
+          name="Memory"
+          isAnimationActive={false}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+});
+
+export default PerformanceChart;

--- a/webui/frontend/src/components/ThemeProvider.tsx
+++ b/webui/frontend/src/components/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { logger } from '../utils/logger';
 
 interface ThemeContextType {
     theme: string;
@@ -26,7 +27,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
                 }
             } catch (e) {
                 // Non-fatal: fall back to the default theme, but don't fail silently.
-                console.debug('ThemeProvider: could not load theme from /api/v1/config, using default', e);
+                logger.debug('ThemeProvider: could not load theme from /api/v1/config, using default', e);
             }
             return 'dark'; // Fallback
         },

--- a/webui/frontend/src/components/ToastProvider.tsx
+++ b/webui/frontend/src/components/ToastProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
 } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { useReducedMotionPref } from "../hooks/useReducedMotionPref";
 
 type ToastType = "success" | "error" | "info" | "warning";
 
@@ -30,6 +31,7 @@ const alertClass: Record<ToastType, string> = {
 };
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const reduceMotion = useReducedMotionPref();
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   const addToast = useCallback((message: string, type: ToastType) => {
@@ -48,10 +50,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           {toasts.map((toast) => (
             <motion.div
               key={toast.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 20 }}
-              transition={{ duration: 0.25 }}
+              initial={reduceMotion ? false : { opacity: 0, y: 20 }}
+              animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+              exit={reduceMotion ? undefined : { opacity: 0, y: 20 }}
+              transition={reduceMotion ? undefined : { duration: 0.25 }}
               className={`alert ${alertClass[toast.type]} shadow-lg`}
             >
               <span>{toast.message}</span>

--- a/webui/frontend/src/components/WebSocketProvider.tsx
+++ b/webui/frontend/src/components/WebSocketProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, useRef, useCallback } from "react";
 import { useAuth } from "../hooks/useAuth";
+import { logger } from "../utils/logger";
 
 type WebSocketContextType = {
   ws: WebSocket | null;
@@ -42,18 +43,18 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
       wsUrl += `?token=${token}`;
     }
 
-    console.log(`WebSocketProvider: Connecting to ${wsUrl} (Attempt ${reconnectAttemptRef.current})`);
+    logger.info(`WebSocketProvider: Connecting to ${wsUrl} (Attempt ${reconnectAttemptRef.current})`);
     const socket = new WebSocket(wsUrl);
 
     socket.onopen = () => {
-      console.log("WebSocketProvider: Connected");
+      logger.info("WebSocketProvider: Connected");
       setIsConnected(true);
       reconnectAttemptRef.current = 0;
       setReconnectAttempt(0); // Sync display state
     };
 
     socket.onclose = (ev) => {
-      console.log("WebSocketProvider: Disconnected", ev.code, ev.reason);
+      logger.info("WebSocketProvider: Disconnected", ev.code, ev.reason);
       setIsConnected(false);
       setWs(null);
 
@@ -62,7 +63,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
       if (reconnectAttemptRef.current < maxReconnectAttempts) {
         const attempt = reconnectAttemptRef.current;
         const delay = Math.min(30000, baseReconnectDelay * Math.pow(1.5, attempt));
-        console.log(`WebSocketProvider: Reconnecting in ${delay}ms...`);
+        logger.debug(`WebSocketProvider: Reconnecting in ${delay}ms...`);
 
         reconnectTimeoutRef.current = setTimeout(() => {
           reconnectAttemptRef.current += 1;
@@ -70,7 +71,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
           connect();
         }, delay);
       } else {
-        console.error("WebSocketProvider: Max reconnect attempts reached");
+        logger.error("WebSocketProvider: Max reconnect attempts reached");
       }
     };
 
@@ -87,7 +88,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
     };
 
     socket.onerror = (error) => {
-      console.error("WebSocketProvider: Error", error);
+      logger.error("WebSocketProvider: Error", error);
     };
 
     setWs(socket);
@@ -101,7 +102,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
     connect();
 
     return () => {
-      console.log("WebSocketProvider: Cleanup/Closing socket");
+      logger.debug("WebSocketProvider: Cleanup/Closing socket");
       shouldReconnectRef.current = false;
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);

--- a/webui/frontend/src/hooks/useAuth.tsx
+++ b/webui/frontend/src/hooks/useAuth.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, createContext, useContext, useRef, useCallback } from "react";
 import { authService, User } from "../services/authService";
+import { logger } from "../utils/logger";
 
 interface AuthContextType {
   user: User | null;
@@ -27,14 +28,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setUser(userData);
       setLoading(false);
     } catch (error) {
-      console.warn("Auth check failed:", error);
+      logger.warn("Auth check failed:", error);
       if (!isMountedRef.current) return;
       // If we failed, specifically in a dev/test environment where the server might be starting up,
       // we should retry a few times for the 'no-auth' check.
       if (retryCount.current < 5) {
         retryCount.current += 1;
         const delay = 1000 * retryCount.current;
-        console.log(`Retrying auth check in ${delay}ms...`);
+        logger.debug(`Retrying auth check in ${delay}ms...`);
         retryTimeoutRef.current = setTimeout(checkAuth, delay);
       } else {
         localStorage.removeItem("auth_token");
@@ -66,7 +67,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setUser(userData);
       return true;
     } catch (error) {
-      console.error("Login failed:", error);
+      logger.error("Login failed:", error);
       return false;
     } finally {
       setLoading(false);

--- a/webui/frontend/src/hooks/useReducedMotionPref.ts
+++ b/webui/frontend/src/hooks/useReducedMotionPref.ts
@@ -1,0 +1,17 @@
+import { useReducedMotion } from 'framer-motion';
+
+/**
+ * Thin wrapper around framer-motion's `useReducedMotion` that returns a boolean
+ * reflecting the user's `prefers-reduced-motion: reduce` setting.
+ *
+ * When `true`, entrance/stagger animations should be disabled: render the final
+ * visual state immediately, with no transform/opacity transition and no
+ * per-index delay. This keeps the rendered output identical while respecting
+ * users who are sensitive to motion.
+ *
+ * framer-motion's hook can return `null` before it has resolved the media
+ * query; we coerce that to `false` so callers always get a plain boolean.
+ */
+export function useReducedMotionPref(): boolean {
+  return useReducedMotion() ?? false;
+}

--- a/webui/frontend/src/pages/CommandAuthoringPage.tsx
+++ b/webui/frontend/src/pages/CommandAuthoringPage.tsx
@@ -18,6 +18,7 @@ import {
   Code,
   Shield,
 } from 'lucide-react';
+import { useReducedMotionPref } from '../hooks/useReducedMotionPref';
 
 // --- TypeScript Interfaces ---
 
@@ -120,6 +121,7 @@ const ActionField: React.FC<{
   onRemove: () => void;
   index: number;
 }> = ({ action, onChange, onRemove, index }) => {
+  const reduceMotion = useReducedMotionPref();
   const handleTypeChange = (type: CommandAction['type']) => {
     onChange({ type } as CommandAction);
   };
@@ -130,9 +132,9 @@ const ActionField: React.FC<{
 
   return (
     <motion.div
-      initial={{ opacity: 0, x: -20 }}
-      animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: 20 }}
+      initial={reduceMotion ? false : { opacity: 0, x: -20 }}
+      animate={reduceMotion ? undefined : { opacity: 1, x: 0 }}
+      exit={reduceMotion ? undefined : { opacity: 0, x: 20 }}
       className="card bg-base-200/50 border border-base-content/10 p-4 space-y-3"
     >
       <div className="flex justify-between items-center">
@@ -233,6 +235,7 @@ const ActionField: React.FC<{
 // --- Main Page Component ---
 
 export default function CommandAuthoringPage() {
+  const reduceMotion = useReducedMotionPref();
   const [searchParams] = useSearchParams();
   const editName = searchParams.get('edit');
   const isEditing = Boolean(editName);
@@ -463,8 +466,8 @@ export default function CommandAuthoringPage() {
     <div className="space-y-6">
       {/* Header Section */}
       <motion.div
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
+        initial={reduceMotion ? false : { opacity: 0, y: -20 }}
+        animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
         className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4"
       >
         <div>
@@ -518,9 +521,9 @@ export default function CommandAuthoringPage() {
       <AnimatePresence>
         {error && (
           <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
+            initial={reduceMotion ? false : { opacity: 0, height: 0 }}
+            animate={reduceMotion ? undefined : { opacity: 1, height: 'auto' }}
+            exit={reduceMotion ? undefined : { opacity: 0, height: 0 }}
             className="alert alert-error"
           >
             <AlertCircle size={20} />
@@ -538,8 +541,8 @@ export default function CommandAuthoringPage() {
           id="ai-mode-panel"
           role="tabpanel"
           aria-labelledby="tab-ai-mode"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={reduceMotion ? false : { opacity: 0, y: 20 }}
+          animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
           className="card glass-card"
         >
           <div className="card-body">
@@ -588,8 +591,8 @@ export default function CommandAuthoringPage() {
       {/* Generated Command Preview */}
       {mode === 'ai' && generatedCommand && (
         <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
+          initial={reduceMotion ? false : { opacity: 0, scale: 0.95 }}
+          animate={reduceMotion ? undefined : { opacity: 1, scale: 1 }}
           className="card glass-card border-primary/30"
         >
           <div className="card-body">
@@ -673,8 +676,8 @@ export default function CommandAuthoringPage() {
           id="manual-mode-panel"
           role="tabpanel"
           aria-labelledby="tab-manual-mode"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={reduceMotion ? false : { opacity: 0, y: 20 }}
+          animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
           className="card glass-card"
         >
           <div className="card-body">
@@ -802,8 +805,8 @@ export default function CommandAuthoringPage() {
       {/* LLM Unavailable Helper */}
       {mode === 'ai' && error?.includes('LLM') && (
         <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
+          initial={reduceMotion ? false : { opacity: 0 }}
+          animate={reduceMotion ? undefined : { opacity: 1 }}
           className="alert alert-warning"
         >
           <AlertCircle size={20} />
@@ -822,16 +825,16 @@ export default function CommandAuthoringPage() {
         {showConfirmModal && (
           <>
             <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
+              initial={reduceMotion ? false : { opacity: 0 }}
+              animate={reduceMotion ? undefined : { opacity: 1 }}
+              exit={reduceMotion ? undefined : { opacity: 0 }}
               className="fixed inset-0 bg-black/50 z-40"
               onClick={() => setShowConfirmModal(false)}
             />
             <motion.div
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.9 }}
+              initial={reduceMotion ? false : { opacity: 0, scale: 0.9 }}
+              animate={reduceMotion ? undefined : { opacity: 1, scale: 1 }}
+              exit={reduceMotion ? undefined : { opacity: 0, scale: 0.9 }}
               className="fixed inset-0 flex items-center justify-center z-50 p-4"
             >
               <div className="card glass-card max-w-lg w-full bg-base-100 shadow-2xl">

--- a/webui/frontend/src/pages/CommandsPage.test.tsx
+++ b/webui/frontend/src/pages/CommandsPage.test.tsx
@@ -2,9 +2,32 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
+// framer-motion caches the reduced-motion preference in this module-level
+// singleton (read once on first useReducedMotion() call). We reset it per-test
+// so a freshly-mocked matchMedia is re-read instead of a stale cached value.
+import { hasReducedMotionListener, prefersReducedMotion } from "motion-dom";
 import CommandsPage from "./CommandsPage";
 import { apiService } from "../services/apiService";
+
+// Force `prefers-reduced-motion: reduce` to report as active so framer-motion's
+// useReducedMotion() hook returns true. Other media queries keep the default
+// (matches: false) behaviour from setupTests.ts.
+function mockReducedMotion(prefersReduced: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: prefersReduced && query.includes("prefers-reduced-motion"),
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+  // Invalidate framer-motion's cache so the new matchMedia value is picked up.
+  hasReducedMotionListener.current = false;
+  prefersReducedMotion.current = null;
+}
 
 vi.mock("../services/apiService", () => ({
   apiService: { getCommands: vi.fn() },
@@ -30,6 +53,11 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  // Restore the default matchMedia stub so other tests are unaffected.
+  mockReducedMotion(false);
+});
+
 test("each command card shows its name", async () => {
   renderPage();
   // The command name is the card title (previously the card was anonymous).
@@ -47,4 +75,39 @@ test("each card describes the command's actual action", async () => {
   expect(
     await screen.findByText("https://example.com/docs")
   ).toBeInTheDocument();
+});
+
+test("respects prefers-reduced-motion: reduce on the card cascade", async () => {
+  mockReducedMotion(true);
+  renderPage();
+
+  // Wait for cards to render.
+  await screen.findByText("take_screenshot");
+
+  const cards = document.querySelectorAll('[data-reduced-motion]');
+  expect(cards.length).toBeGreaterThan(0);
+
+  cards.forEach((card) => {
+    // The reduced-motion branch must be taken for every cascade card...
+    expect(card.getAttribute("data-reduced-motion")).toBe("true");
+    // ...and no entrance transform/opacity should be applied inline, so the
+    // final rendered state is shown immediately with no staggered delay.
+    const style = (card as HTMLElement).style;
+    expect(style.transform === "" || style.transform === "none").toBe(true);
+    expect(style.opacity === "" || style.opacity === "1").toBe(true);
+    expect(style.transitionDelay).toBe("");
+  });
+});
+
+test("applies the staggered cascade when motion is allowed", async () => {
+  mockReducedMotion(false);
+  renderPage();
+
+  await screen.findByText("take_screenshot");
+
+  const cards = document.querySelectorAll('[data-reduced-motion]');
+  expect(cards.length).toBeGreaterThan(0);
+  cards.forEach((card) => {
+    expect(card.getAttribute("data-reduced-motion")).toBe("false");
+  });
 });

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -17,6 +17,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
 import { DynamicDropdown } from '../components/DynamicDropdown';
+import { useReducedMotionPref } from '../hooks/useReducedMotionPref';
 
 // Backend response is a Record<string, CommandConfig>
 interface CommandConfig {
@@ -42,6 +43,7 @@ export default function CommandsPage() {
     document.title = "Commands | ChattyCommander";
   }, []);
 
+  const reduceMotion = useReducedMotionPref();
   const [searchParams, setSearchParams] = useSearchParams();
   const searchQuery = searchParams.get('q') || '';
   const [pendingDeleteCommand, setPendingDeleteCommand] = useState<string | null>(null);
@@ -198,8 +200,8 @@ export default function CommandsPage() {
     <div className="space-y-6">
       {/* Header Section */}
       <motion.div
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
+        initial={reduceMotion ? false : { opacity: 0, y: -20 }}
+        animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
         className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4"
       >
         <div>
@@ -305,9 +307,10 @@ export default function CommandsPage() {
           {filteredCommands.map(([name, config], idx) => (
             <motion.div
               key={name}
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ delay: idx * 0.05 }}
+              data-reduced-motion={reduceMotion ? 'true' : 'false'}
+              initial={reduceMotion ? false : { opacity: 0, scale: 0.95 }}
+              animate={reduceMotion ? undefined : { opacity: 1, scale: 1 }}
+              transition={reduceMotion ? undefined : { delay: idx * 0.05 }}
               className="card glass-card overflow-hidden"
             >
               <div className="border-gradient"></div>

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -1,41 +1,20 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback, useMemo, Suspense, lazy } from "react";
 import { useWebSocket } from "../components/WebSocketProvider";
 import { useQuery } from "@tanstack/react-query";
 import { Server, Clock, Terminal, Wifi, WifiOff, Send, Activity as AssessmentIcon, Pause, Play, Download, Zap } from "lucide-react";
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { apiService } from "../services/apiService";
 import { fetchAgentStatus, Agent } from "../services/api";
 import { formatTimestamp } from "../utils/formatTime";
 import DograhStatusCard from "../components/DograhStatusCard";
+import type { PerfMetric } from "../components/PerformanceChart";
+
+// Lazy-load the recharts-backed chart so the heavy charting bundle is split out
+// of the main DashboardPage chunk and only fetched when the dashboard renders.
+const PerformanceChart = lazy(() => import("../components/PerformanceChart"));
 
 const MAX_MESSAGES = 100;
 const MAX_RECENT_MESSAGES = 15;
 const MAX_HISTORY_ITEMS = 20;
-
-interface PerfMetric {
-  time: string;
-  cpu: number;
-  memory: number;
-}
-
-const CustomTooltip = React.memo(({ active, payload, label }: any) => {
-  if (active && payload && payload.length) {
-    return (
-      <div className="bg-base-300 border border-base-content/20 p-3 rounded-lg shadow-xl text-xs">
-        <p className="font-mono mb-2 text-base-content/60">{label}</p>
-        {payload.map((entry: any) => (
-          <div key={entry.name} className="flex items-center gap-2 mb-1">
-            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: entry.stroke }} />
-            <span className="font-semibold" style={{ color: entry.stroke }}>
-              {entry.name}: {entry.value.toFixed(1)}%
-            </span>
-          </div>
-        ))}
-      </div>
-    );
-  }
-  return null;
-});
 
 const DashboardPage = React.memo(() => {
   useEffect(() => {
@@ -339,45 +318,19 @@ const DashboardPage = React.memo(() => {
             </div>
           </div>
           <div className="h-64 w-full">
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={history}>
-                <defs>
-                  <linearGradient id="colorCpu" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#3abff8" stopOpacity={0.8} />
-                    <stop offset="95%" stopColor="#3abff8" stopOpacity={0} />
-                  </linearGradient>
-                  <linearGradient id="colorMem" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#fbbd23" stopOpacity={0.8} />
-                    <stop offset="95%" stopColor="#fbbd23" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
-                <XAxis dataKey="time" hide />
-                <YAxis
-                  domain={[0, 100]}
-                  tickFormatter={(value) => `${value}%`}
-                />
-                <Tooltip content={<CustomTooltip />} />
-                <Area
-                  type="monotone"
-                  dataKey="cpu"
-                  stroke="#3abff8"
-                  fillOpacity={1}
-                  fill="url(#colorCpu)"
-                  name="CPU"
-                  isAnimationActive={false}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="memory"
-                  stroke="#fbbd23"
-                  fillOpacity={1}
-                  fill="url(#colorMem)"
-                  name="Memory"
-                  isAnimationActive={false}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
+            <Suspense
+              fallback={
+                <div
+                  className="h-full w-full skeleton rounded-box flex items-center justify-center"
+                  aria-busy="true"
+                  aria-label="Loading performance chart"
+                >
+                  <span className="loading loading-spinner text-primary"></span>
+                </div>
+              }
+            >
+              <PerformanceChart history={history} />
+            </Suspense>
           </div>
         </div>
       </div>

--- a/webui/frontend/src/services/authService.ts
+++ b/webui/frontend/src/services/authService.ts
@@ -1,3 +1,5 @@
+import { logger } from "../utils/logger";
+
 export interface TokenResponse {
   access_token: string;
   token_type: string;
@@ -43,11 +45,11 @@ class AuthService {
         }
         // The token was present but rejected by the backend. Log the reason so
         // an invalid/expired token isn't silently masked by the no-auth probe.
-        console.warn(
+        logger.warn(
           `authService: token auth rejected (${response.status} ${response.statusText})`,
         );
       } catch (e) {
-        console.warn("Auth check failed with token", e);
+        logger.warn("Auth check failed with token", e);
       }
     }
 
@@ -60,7 +62,7 @@ class AuthService {
         return { username: 'local_admin', roles: ['admin'], is_active: true, noAuth: true };
       }
     } catch (e) {
-      console.debug("authService: no-auth probe failed", e);
+      logger.debug("authService: no-auth probe failed", e);
     }
 
     throw new Error("Authentication required");

--- a/webui/frontend/src/utils/logger.test.ts
+++ b/webui/frontend/src/utils/logger.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger";
+
+describe("logger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe("in DEV", () => {
+    beforeEach(() => {
+      vi.stubEnv("DEV", true);
+    });
+
+    it("emits debug/info/warn", () => {
+      logger.debug("d");
+      logger.info("i");
+      logger.warn("w");
+      expect(console.debug).toHaveBeenCalledWith("d");
+      expect(console.info).toHaveBeenCalledWith("i");
+      expect(console.warn).toHaveBeenCalledWith("w");
+    });
+
+    it("emits error", () => {
+      logger.error("boom");
+      expect(console.error).toHaveBeenCalledWith("boom");
+    });
+  });
+
+  describe("in production (DEV=false)", () => {
+    beforeEach(() => {
+      vi.stubEnv("DEV", false);
+    });
+
+    it("suppresses debug/info/warn", () => {
+      logger.debug("d");
+      logger.info("i");
+      logger.warn("w");
+      expect(console.debug).not.toHaveBeenCalled();
+      expect(console.info).not.toHaveBeenCalled();
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("still emits error", () => {
+      logger.error("boom", { code: 1 });
+      expect(console.error).toHaveBeenCalledWith("boom", { code: 1 });
+    });
+  });
+});

--- a/webui/frontend/src/utils/logger.ts
+++ b/webui/frontend/src/utils/logger.ts
@@ -1,0 +1,30 @@
+/**
+ * Lightweight console wrapper that gates verbose logging behind the dev build.
+ *
+ * `debug`, `info`, and `warn` only emit when `import.meta.env.DEV` is true, so
+ * connection chatter and retry notices stay out of production users' consoles.
+ * `error` always logs — failures should never be silently swallowed.
+ */
+
+const isDev = (): boolean => {
+  try {
+    return Boolean(import.meta.env?.DEV);
+  } catch {
+    return false;
+  }
+};
+
+export const logger = {
+  debug: (...args: unknown[]): void => {
+    if (isDev()) console.debug(...args);
+  },
+  info: (...args: unknown[]): void => {
+    if (isDev()) console.info(...args);
+  },
+  warn: (...args: unknown[]): void => {
+    if (isDev()) console.warn(...args);
+  },
+  error: (...args: unknown[]): void => {
+    console.error(...args);
+  },
+};


### PR DESCRIPTION
Three independent UI improvements (the opportunities surfaced in the last review).

| # | Improvement | Evidence |
|---|---|---|
| 1 | **No console noise in prod** — logger util gated on `import.meta.env.DEV`; replaced 8 raw console.log/debug across WebSocketProvider/useAuth/ThemeProvider/authService | grep confirms zero raw console.log/debug remain; +4 logger tests |
| 2 | **Dashboard bundle split** — recharts chart lazy-loaded via React.lazy + Suspense | DashboardPage chunk **401.64 kB → 17.65 kB** (gzip 110.59 → 4.86); recharts now in its own on-demand PerformanceChart chunk |
| 3 | **prefers-reduced-motion** — gate framer-motion entrance/stagger in CommandsPage cards, CommandAuthoringPage, ToastProvider | +2 tests asserting the reduced-motion branch; final rendered state identical |

vitest 69/69 (was 63), tsc clean, build green. Frontend-only — no Python/Docker change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)