### PR TITLE
Fix the two real auth bugs (key wiring + frontend login path)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@
 # DOGRAH_MINIO_PUBLIC_ENDPOINT=http://localhost:9001
 
 # --- Web server / bridge ---
+# CHATTY_API_KEY=replace-with-a-long-random-string # REQUIRED when web_server.auth_enabled=true (and not --no-auth):
+#                                                  # value clients send as the X-API-Key header. Takes precedence over
+#                                                  # auth.api_key in config. Startup fails fast if auth is enabled but
+#                                                  # neither this nor auth.api_key is set (web/middleware/auth.py).
+# CHATTY_JWT_SECRET=replace-with-a-64-hex-secret   # REQUIRED for the /api/v1/auth JWT login flow when auth.users is
+#                                                  # configured; signs access tokens. Falls back to auth.jwt_secret.
 # CHATTY_ENV=production                            # production refuses --no-auth (web/server.py)
 # CHATTY_CORS_ORIGINS=http://localhost:3000        # comma-separated browser origins allowed by CORS; defaults to localhost-only (esp. in --no-auth mode)
 # CHATTY_BRIDGE_TOKEN=your-bridge-token            # auth token for the /bridge endpoint (overrides web_server.bridge_token)

--- a/src/chatty_commander/app/env_validation.py
+++ b/src/chatty_commander/app/env_validation.py
@@ -18,6 +18,9 @@ Current rules:
   warning only (local OpenAI-compatible servers often need no key).
 - Any command configured with a ``dograh_call`` action → ``DOGRAH_BASE_URL``
   and ``DOGRAH_API_KEY`` are required (see ``integrations/dograh_client.py``).
+- Web auth enabled (``web_server.auth_enabled``) with no API key configured
+  anywhere (``CHATTY_API_KEY`` env or ``auth.api_key`` config) → ``CHATTY_API_KEY``
+  is required. Without it the middleware would silently 401 every request.
 
 All checks are defensive about config shape (tests inject mocks/partial
 configs); anything that is not a real dict is treated as "feature off".
@@ -163,19 +166,83 @@ def _check_dograh(config: Any, env: Mapping[str, str], report: EnvReport) -> Non
             )
 
 
+def _check_web_auth(config: Any, env: Mapping[str, str], report: EnvReport) -> None:
+    """Require an API key when web auth is *explicitly* enabled but none is set.
+
+    The middleware only authenticates when an expected key exists. If a user
+    turns auth on yet configures no key (via ``CHATTY_API_KEY`` or
+    ``auth.api_key``), every ``/api`` request would 401 silently — so we fail
+    fast at startup with an actionable message instead.
+
+    Two invariants keep this safe:
+
+    * **Zero-config boots.** ``web_server.auth_enabled`` defaults to ``True`` in
+      ``Config`` even when the user wrote no config at all, so the bare default
+      must NOT trip this check. We therefore only fire when the user
+      *explicitly* set ``web_server.auth_enabled: true`` in their raw config
+      (``config.config["web_server"]``) — the stock default carries no
+      ``web_server`` block and is left untouched.
+    * **--no-auth bypass.** The dev bypass sets ``auth_enabled=False`` before
+      validating (see CLI entrypoints and ``web_mode.run_web_server``), so it
+      never reaches this check.
+    """
+    # The --no-auth bypass sets auth_enabled=False on the *resolved*
+    # web_server dict (CLI entrypoints + web_mode.run_web_server). Honor that
+    # first so a config file with auth_enabled:true + --no-auth never trips.
+    resolved_web = _as_dict(getattr(config, "web_server", None))
+    if resolved_web.get("auth_enabled") is False:
+        return
+
+    raw = _as_dict(getattr(config, "config", None))
+    raw_web = raw.get("web_server")
+    # Only an *explicit* auth_enabled:true in the user's config triggers the
+    # requirement; the dataclass default must keep the zero-config boot clean.
+    if not (isinstance(raw_web, dict) and raw_web.get("auth_enabled") is True):
+        return
+
+    if _env_set(env, "CHATTY_API_KEY"):
+        return
+
+    auth_cfg = raw.get("auth")
+    if not isinstance(auth_cfg, dict):
+        # Tolerate DummyConfig.auth too.
+        auth_cfg = _as_dict(getattr(config, "auth", None))
+    api_key = auth_cfg.get("api_key") if isinstance(auth_cfg, dict) else None
+    if api_key:
+        return
+
+    report.missing.append(
+        EnvIssue(
+            var="CHATTY_API_KEY",
+            feature="web auth",
+            reason=(
+                "web_server.auth_enabled is true but no API key is configured "
+                "via CHATTY_API_KEY or auth.api_key; the server would reject "
+                "every /api request. Set CHATTY_API_KEY or run with --no-auth"
+            ),
+        )
+    )
+
+
 def collect_env_report(
-    config: Any, env: Mapping[str, str] | None = None
+    config: Any, env: Mapping[str, str] | None = None, *, for_web: bool = False
 ) -> EnvReport:
     """Inspect ``config`` and ``env`` and report missing/recommended env vars.
 
     Pure (no logging, no raising); use :func:`validate_startup_env` at call
     sites that want fail-fast behavior.
+
+    ``for_web`` enables the web-auth check, which is only meaningful when the
+    web server is actually being launched (gui/shell/CLI utility modes must not
+    be gated by a missing API key).
     """
     if env is None:
         env = os.environ
     report = EnvReport()
     _check_advisors(config, env, report)
     _check_dograh(config, env, report)
+    if for_web:
+        _check_web_auth(config, env, report)
     return report
 
 
@@ -183,6 +250,8 @@ def validate_startup_env(
     config: Any,
     env: Mapping[str, str] | None = None,
     log: logging.Logger | None = None,
+    *,
+    for_web: bool = False,
 ) -> EnvReport:
     """Validate env vars for enabled features; fail fast when required ones are missing.
 
@@ -190,8 +259,11 @@ def validate_startup_env(
     :class:`EnvValidationError` (whose message aggregates *all* missing vars)
     if any required variable is absent. Returns the report when everything
     required is present.
+
+    Pass ``for_web=True`` from the web-server launch path to additionally
+    require a web API key when ``web_server.auth_enabled`` is explicitly set.
     """
-    report = collect_env_report(config, env)
+    report = collect_env_report(config, env, for_web=for_web)
     log = log or logger
     for issue in report.warnings:
         log.warning("Optional env var not set: %s", issue)

--- a/src/chatty_commander/cli/cli.py
+++ b/src/chatty_commander/cli/cli.py
@@ -157,6 +157,23 @@ def run_web_mode(
         f"Starting web mode (auth={'disabled' if no_auth else 'enabled'}) on {host}:{port}"
     )
 
+    # Fail fast (web-scoped) when web_server.auth_enabled is explicitly on but
+    # no API key is configured — otherwise every /api request would 401. The
+    # --no-auth bypass disables the gate, so reflect that before validating.
+    if no_auth and isinstance(getattr(config, "web_server", None), dict):
+        config.web_server["auth_enabled"] = False
+    from chatty_commander.app.env_validation import (
+        EnvValidationError,
+        validate_startup_env,
+    )
+
+    try:
+        validate_startup_env(config, log=logger, for_web=True)
+    except EnvValidationError as e:
+        logger.error(str(e))
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
     # Create web server instance
     web_server = WebModeServer(
         config,

--- a/src/chatty_commander/cli/main.py
+++ b/src/chatty_commander/cli/main.py
@@ -136,6 +136,23 @@ def run_web_mode(
         f"Starting web mode (auth={'disabled' if no_auth else 'enabled'}) on {host}:{port}"
     )
 
+    # Fail fast (web-scoped) when web_server.auth_enabled is explicitly on but
+    # no API key is configured — otherwise every /api request would 401. The
+    # --no-auth bypass disables the gate, so reflect that before validating.
+    if no_auth and isinstance(getattr(config, "web_server", None), dict):
+        config.web_server["auth_enabled"] = False
+    from chatty_commander.app.env_validation import (
+        EnvValidationError,
+        validate_startup_env,
+    )
+
+    try:
+        validate_startup_env(config, log=logger, for_web=True)
+    except EnvValidationError as e:
+        logger.error(str(e))
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
     # Create web server instance
     web_server = WebModeServer(
         config,

--- a/src/chatty_commander/web/middleware/auth.py
+++ b/src/chatty_commander/web/middleware/auth.py
@@ -23,6 +23,7 @@
 """Authentication middleware for FastAPI."""
 
 import logging
+import os
 import posixpath
 import urllib.parse
 from collections.abc import Callable
@@ -33,6 +34,31 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from chatty_commander.utils.security import constant_time_compare
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_expected_api_key(config_manager) -> str | None:
+    """Resolve the expected X-API-Key from env or config.
+
+    Precedence (highest first):
+    1. ``CHATTY_API_KEY`` environment variable (non-blank).
+    2. ``config_manager.auth["api_key"]`` — test/DummyConfig objects.
+    3. ``config_manager.config["auth"]["api_key"]`` — the real ``Config``.
+
+    Returns ``None`` when no key is configured anywhere (the zero-config
+    default), in which case authentication cannot succeed.
+    """
+    env_key = os.environ.get("CHATTY_API_KEY")
+    if env_key and env_key.strip():
+        return env_key
+
+    key: object = None
+    # Check for DummyConfig pattern (test configs)
+    if hasattr(config_manager, "auth"):
+        key = config_manager.auth.get("api_key")
+    # Check for regular Config pattern
+    elif hasattr(config_manager, "config") and config_manager.config:
+        key = config_manager.config.get("auth", {}).get("api_key")
+    return key if isinstance(key, str) else None
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
@@ -91,6 +117,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if request.method == "OPTIONS":
             return await call_next(request)  # type: ignore[no-any-return]
 
+        # The JWT auth router (/api/v1/auth/*) validates user credentials /
+        # bearer tokens itself, so it must NOT require the global X-API-Key
+        # (the unauthenticated login form has no key). It sits under /api/ so
+        # this exemption has to come before the X-API-Key gate below.
+        if path == "/api/v1/auth" or path.startswith("/api/v1/auth/"):
+            return await call_next(request)  # type: ignore[no-any-return]
+
         # Validate API key for protected endpoints
         if path == "/api" or path.startswith("/api/"):
             api_key = request.headers.get("X-API-Key")
@@ -98,22 +131,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 f"API request to {path}, API key present: {api_key is not None}"
             )
 
-            # Get expected API key from config
-            expected_key = None
-
-            # Check for DummyConfig pattern (test configs)
-            if hasattr(self.config_manager, "auth"):
-                expected_key = self.config_manager.auth.get("api_key")
-                logger.debug("Found auth config in DummyConfig: key present=%s", bool(expected_key))
-            # Check for regular Config pattern
-            elif hasattr(self.config_manager, "config") and self.config_manager.config:
-                auth_config = self.config_manager.config.get("auth", {})
-                expected_key = auth_config.get("api_key")
-                logger.debug("Found auth config in regular Config: key present=%s", bool(expected_key))
-            else:
-                logger.debug(
-                    "No auth config found, config_manager type: %s", type(self.config_manager).__name__
-                )
+            # Get expected API key from env (preferred) or config.
+            expected_key = resolve_expected_api_key(self.config_manager)
+            logger.debug("Expected API key resolved: present=%s", bool(expected_key))
 
             # Check if API key is valid
             if not constant_time_compare(api_key, expected_key):

--- a/src/chatty_commander/web/routes/auth.py
+++ b/src/chatty_commander/web/routes/auth.py
@@ -1,0 +1,252 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Minimal JWT user-login router (AUTHZ_DESIGN.md §2, Phase 1).
+
+Implements exactly the endpoints the existing frontend already calls
+(``webui/frontend/src/services/authService.ts``):
+
+- ``POST /api/v1/auth/login`` — ``{username, password}`` →
+  ``{access_token, token_type:"bearer", expires_in}``.
+- ``GET  /api/v1/auth/me``    — ``Authorization: Bearer <token>`` →
+  ``{username, roles, is_active}``.
+- ``POST /api/v1/auth/logout``— stateless no-op (client drops the token).
+
+Credentials are validated against an ``auth.users`` config block holding
+bcrypt password hashes and a ``roles`` list (design doc §3/§4). The JWT is
+signed HS256 with ``CHATTY_JWT_SECRET`` (env, preferred) or ``auth.jwt_secret``
+(config).
+
+**Opt-in / back-compat:** when no ``auth.users`` are configured these endpoints
+return ``404`` so the default and ``--no-auth`` flows are byte-for-byte
+unchanged — the frontend's no-auth probe (``authService.ts``) keeps working.
+This deliberately does NOT build refresh tokens, a revocation denylist, an RBAC
+dependency system, or service keys — those remain deferred per the design doc.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Callable
+from typing import Any
+
+import bcrypt
+import jwt
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Access-token lifetime (seconds). 15 min per AUTHZ_DESIGN.md §2.
+ACCESS_TOKEN_TTL_SECONDS = 15 * 60
+JWT_ALGORITHM = "HS256"
+# Small leeway absorbs minor clock drift on decode (design §7).
+JWT_LEEWAY_SECONDS = 30
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class TokenResponse(BaseModel):
+    # Field names/types match authService.ts TokenResponse exactly.
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int = ACCESS_TOKEN_TTL_SECONDS
+
+
+class UserResponse(BaseModel):
+    # Field names/types match authService.ts User (minus the optional
+    # client-only noAuth flag, which the backend never sets).
+    username: str
+    is_active: bool = True
+    roles: list[str]
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _auth_config(config_manager: Any) -> dict[str, Any]:
+    """Return the ``auth`` config block from either Config shape.
+
+    Mirrors the middleware's dual lookup: ``config_manager.auth`` (DummyConfig
+    / test objects) or ``config_manager.config["auth"]`` (real ``Config``).
+    """
+    if config_manager is None:
+        return {}
+    # DummyConfig pattern: a plain ``.auth`` dict.
+    auth_attr = getattr(config_manager, "auth", None)
+    if isinstance(auth_attr, dict):
+        return auth_attr
+    # Real Config pattern: raw JSON under ``.config["auth"]``.
+    cfg = getattr(config_manager, "config", None)
+    if isinstance(cfg, dict):
+        return _as_dict(cfg.get("auth"))
+    return {}
+
+
+def _users(config_manager: Any) -> dict[str, Any]:
+    return _as_dict(_auth_config(config_manager).get("users"))
+
+
+def _jwt_secret(config_manager: Any) -> str | None:
+    """Resolve the JWT signing secret: env preferred, then config."""
+    env_secret = os.environ.get("CHATTY_JWT_SECRET")
+    if env_secret and env_secret.strip():
+        return env_secret
+    secret = _auth_config(config_manager).get("jwt_secret")
+    return secret if isinstance(secret, str) and secret.strip() else None
+
+
+def _verify_password(password: str, password_hash: Any) -> bool:
+    """Constant-time bcrypt check; tolerant of malformed/empty hashes."""
+    if not isinstance(password_hash, str) or not password_hash:
+        return False
+    try:
+        return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+    except (ValueError, TypeError):
+        return False
+
+
+def _issue_access_token(username: str, roles: list[str], secret: str) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": username,
+        "roles": roles,
+        "type": "access",
+        "iat": now,
+        "exp": now + ACCESS_TOKEN_TTL_SECONDS,
+    }
+    return jwt.encode(claims, secret, algorithm=JWT_ALGORITHM)
+
+
+def _decode_access_token(token: str, secret: str) -> dict[str, Any]:
+    """Decode + validate an access token; raises 401 on any problem."""
+    try:
+        claims: dict[str, Any] = jwt.decode(
+            token,
+            secret,
+            algorithms=[JWT_ALGORITHM],
+            leeway=JWT_LEEWAY_SECONDS,
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise HTTPException(status_code=401, detail="Token expired") from exc
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+    if claims.get("type") != "access":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+    return claims
+
+
+def _bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        raise HTTPException(status_code=401, detail="Malformed Authorization header")
+    return token.strip()
+
+
+def include_auth_routes(*, get_config_manager: Callable[[], Any]) -> APIRouter:
+    """Build the JWT auth router bound to a config accessor."""
+    router = APIRouter()
+
+    def _require_enabled() -> dict[str, Any]:
+        """Resolve users or 404 when the feature is unconfigured (opt-in)."""
+        users = _users(get_config_manager())
+        if not users:
+            # No user store => feature off. 404 keeps the default/no-auth flow
+            # unchanged: the frontend falls back to its no-auth probe.
+            raise HTTPException(status_code=404, detail="User auth is not configured")
+        return users
+
+    @router.post("/api/v1/auth/login", response_model=TokenResponse)
+    async def login(body: LoginRequest) -> TokenResponse:
+        users = _require_enabled()
+        cm = get_config_manager()
+        secret = _jwt_secret(cm)
+        if not secret:
+            # Users configured but no signing secret: misconfiguration.
+            logger.error("auth.users configured but no CHATTY_JWT_SECRET/jwt_secret")
+            raise HTTPException(status_code=500, detail="JWT secret not configured")
+
+        record = _as_dict(users.get(body.username))
+        # Always run a bcrypt check (even for unknown users) to avoid leaking
+        # which usernames exist via response timing.
+        password_hash = record.get("password_hash")
+        if not _verify_password(body.password, password_hash):
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+
+        roles_raw = record.get("roles", [])
+        roles = (
+            [r for r in roles_raw if isinstance(r, str)]
+            if isinstance(roles_raw, list)
+            else []
+        )
+        token = _issue_access_token(body.username, roles, secret)
+        return TokenResponse(access_token=token)
+
+    @router.get("/api/v1/auth/me", response_model=UserResponse)
+    async def me(authorization: str | None = Header(default=None)) -> UserResponse:
+        users = _require_enabled()
+        cm = get_config_manager()
+        secret = _jwt_secret(cm)
+        if not secret:
+            raise HTTPException(status_code=500, detail="JWT secret not configured")
+
+        token = _bearer_token(authorization)
+        claims = _decode_access_token(token, secret)
+        username = claims.get("sub")
+        if not isinstance(username, str) or username not in users:
+            # Token's subject no longer exists in the user store.
+            raise HTTPException(status_code=401, detail="Unknown user")
+
+        record = _as_dict(users.get(username))
+        roles_raw = claims.get("roles", record.get("roles", []))
+        roles = (
+            [r for r in roles_raw if isinstance(r, str)]
+            if isinstance(roles_raw, list)
+            else []
+        )
+        is_active = bool(record.get("is_active", True))
+        return UserResponse(username=username, roles=roles, is_active=is_active)
+
+    @router.post("/api/v1/auth/logout")
+    async def logout() -> dict[str, bool]:
+        # Stateless tokens: logout is a client-side token drop. We keep the
+        # endpoint so the frontend's logout call always succeeds; server-side
+        # revocation (a denylist) is deferred per the design doc.
+        _require_enabled()
+        return {"ok": True}
+
+    return router
+
+
+def register_auth_routes(app: Any, config_manager: Any = None) -> None:
+    """Single-call registration hook used by ``server.register_shared_routers``."""
+    app.include_router(
+        include_auth_routes(get_config_manager=lambda: config_manager)
+    )

--- a/src/chatty_commander/web/server.py
+++ b/src/chatty_commander/web/server.py
@@ -89,6 +89,11 @@ except ImportError:
     register_voice_test_routes = None  # type: ignore[assignment]
 
 try:
+    from .routes.auth import register_auth_routes
+except ImportError:
+    register_auth_routes = None  # type: ignore[assignment]
+
+try:
     from .routes.dograh import router as dograh_router
 except ImportError:
     dograh_router = None  # type: ignore[assignment]
@@ -189,6 +194,11 @@ def register_shared_routers(app: FastAPI, config_manager: Any = None) -> None:
 
     if register_voice_test_routes is not None:
         register_voice_test_routes(app, config_manager)
+
+    # JWT user-login router (/api/v1/auth/*). Self-disables (404) unless
+    # auth.users is configured, so default/no-auth flows are unchanged.
+    if register_auth_routes is not None:
+        register_auth_routes(app, config_manager)
 
     # Standardized {error, code, details, request_id} bodies on /api/* paths
     # for HTTPException, 422 validation and unhandled exceptions. Registered

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -1036,9 +1036,15 @@ def run_server(
 
     # Fail fast (EnvValidationError) when required env vars for explicitly
     # enabled features are missing (ROADMAP "Secrets validation at startup").
+    # The --no-auth dev bypass disables the global API-key gate entirely, so
+    # reflect that on the config before validating: otherwise the web-auth
+    # check would demand a key that no_auth makes irrelevant.
+    if no_auth and isinstance(getattr(config_manager, "web_server", None), dict):
+        config_manager.web_server["auth_enabled"] = False
+
     from chatty_commander.app.env_validation import validate_startup_env
 
-    validate_startup_env(config_manager)
+    validate_startup_env(config_manager, for_web=True)
 
     app = WebModeServer(
         config_manager, state_manager, model_manager, command_executor, no_auth=no_auth

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -253,3 +253,73 @@ def test_run_server_fails_fast(monkeypatch):
     with pytest.raises(EnvValidationError) as exc_info:
         run_server(config, MagicMock(), MagicMock(), MagicMock())
     assert "OPENAI_API_KEY" in str(exc_info.value)
+
+
+# ── web auth (BUG 2) ──────────────────────────────────────────────────────
+
+
+def _web_cfg(*, raw_web=None, resolved_web=None, auth=None):
+    """Build a Config-shaped object for the web-auth validator.
+
+    ``config`` is the raw parsed JSON; ``web_server`` is the resolved dict the
+    runtime uses. The validator reads both, mirroring the real ``Config``.
+    """
+    raw = {}
+    if raw_web is not None:
+        raw["web_server"] = raw_web
+    if auth is not None:
+        raw["auth"] = auth
+    return SimpleNamespace(
+        advisors={"enabled": False},
+        model_actions={},
+        config=raw,
+        web_server=resolved_web if resolved_web is not None else {},
+    )
+
+
+def test_explicit_web_auth_enabled_without_key_fails_fast():
+    config = _web_cfg(raw_web={"auth_enabled": True}, resolved_web={"auth_enabled": True})
+    report = collect_env_report(config, env={}, for_web=True)
+    assert [i.var for i in report.missing] == ["CHATTY_API_KEY"]
+    with pytest.raises(EnvValidationError) as exc_info:
+        validate_startup_env(config, env={}, for_web=True)
+    assert "CHATTY_API_KEY" in str(exc_info.value)
+
+
+def test_web_auth_check_only_runs_for_web_launch():
+    """gui/shell/CLI utility modes (for_web=False) must NOT require an API key,
+    even when auth_enabled is explicitly true — only the web launch is gated.
+    """
+    config = _web_cfg(raw_web={"auth_enabled": True}, resolved_web={"auth_enabled": True})
+    assert collect_env_report(config, env={}).ok  # default for_web=False
+    validate_startup_env(config, env={})  # must not raise
+
+
+def test_web_auth_enabled_with_env_key_ok():
+    config = _web_cfg(raw_web={"auth_enabled": True}, resolved_web={"auth_enabled": True})
+    assert collect_env_report(config, env={"CHATTY_API_KEY": "k"}, for_web=True).ok
+
+
+def test_web_auth_enabled_with_config_key_ok():
+    config = _web_cfg(
+        raw_web={"auth_enabled": True},
+        resolved_web={"auth_enabled": True},
+        auth={"api_key": "config-key"},
+    )
+    assert collect_env_report(config, env={}, for_web=True).ok
+
+
+def test_default_auth_enabled_does_not_fail_fast():
+    """The stock default (auth_enabled True via dataclass default, no explicit
+    web_server block in raw config) must NOT require a key — zero-config boots.
+    """
+    config = _web_cfg(raw_web=None, resolved_web={"auth_enabled": True})
+    assert collect_env_report(config, env={}, for_web=True).ok
+
+
+def test_no_auth_bypass_skips_web_auth_check():
+    """--no-auth sets resolved auth_enabled=False even if the file says true:
+    the check must not demand a key.
+    """
+    config = _web_cfg(raw_web={"auth_enabled": True}, resolved_web={"auth_enabled": False})
+    assert collect_env_report(config, env={}, for_web=True).ok

--- a/tests/test_web_auth_router.py
+++ b/tests/test_web_auth_router.py
@@ -1,0 +1,258 @@
+"""Tests for the JWT user-login router (BUG 1, AUTHZ_DESIGN.md §2).
+
+Covers the exact request/response shapes ``authService.ts`` sends and parses:
+login -> {access_token, token_type, expires_in}; /me with Bearer -> {username,
+roles, is_active}. Also asserts the opt-in contract: with no ``auth.users``
+configured the endpoints 404 so the default / --no-auth flows are unchanged.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import bcrypt
+import jwt
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except ImportError:  # pragma: no cover
+    pytest.skip("FastAPI not available", allow_module_level=True)
+
+from chatty_commander.web.routes.auth import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    JWT_ALGORITHM,
+    include_auth_routes,
+)
+
+SECRET = "test-jwt-secret"
+
+
+def _hash(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def _config(users: dict | None = None, jwt_secret: str | None = SECRET) -> Mock:
+    auth: dict = {}
+    if users is not None:
+        auth["users"] = users
+    if jwt_secret is not None:
+        auth["jwt_secret"] = jwt_secret
+    cfg = Mock()
+    cfg.auth = auth
+    return cfg
+
+
+def _client(config_manager) -> TestClient:
+    app = FastAPI()
+    app.include_router(include_auth_routes(get_config_manager=lambda: config_manager))
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_env_secret(monkeypatch):
+    # Tests drive the secret via config unless they opt into the env path.
+    monkeypatch.delenv("CHATTY_JWT_SECRET", raising=False)
+
+
+def _users():
+    return {"alice": {"password_hash": _hash("s3cret"), "roles": ["admin", "user"]}}
+
+
+# ── login ────────────────────────────────────────────────────────────────
+
+
+def test_login_valid_credentials_returns_parseable_token():
+    client = _client(_config(users=_users()))
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": "s3cret"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Shape authService.ts TokenResponse expects.
+    assert set(body) == {"access_token", "token_type", "expires_in"}
+    assert body["token_type"] == "bearer"
+    assert body["expires_in"] == ACCESS_TOKEN_TTL_SECONDS
+
+    # The token authService stores must decode with the configured secret and
+    # carry the roles claim the frontend models.
+    claims = jwt.decode(body["access_token"], SECRET, algorithms=[JWT_ALGORITHM])
+    assert claims["sub"] == "alice"
+    assert claims["roles"] == ["admin", "user"]
+    assert claims["type"] == "access"
+
+
+def test_login_invalid_password_rejected():
+    client = _client(_config(users=_users()))
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": "wrong"}
+    )
+    assert resp.status_code == 401
+
+
+def test_login_unknown_user_rejected():
+    client = _client(_config(users=_users()))
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": "nobody", "password": "s3cret"}
+    )
+    assert resp.status_code == 401
+
+
+def test_login_env_secret_takes_precedence(monkeypatch):
+    monkeypatch.setenv("CHATTY_JWT_SECRET", "env-secret")
+    client = _client(_config(users=_users(), jwt_secret="config-secret"))
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": "s3cret"}
+    )
+    assert resp.status_code == 200
+    # Signed with the env secret, not the config one.
+    jwt.decode(resp.json()["access_token"], "env-secret", algorithms=[JWT_ALGORITHM])
+    with pytest.raises(jwt.InvalidTokenError):
+        jwt.decode(
+            resp.json()["access_token"], "config-secret", algorithms=[JWT_ALGORITHM]
+        )
+
+
+# ── /me ──────────────────────────────────────────────────────────────────
+
+
+def test_me_with_valid_token_returns_user_shape():
+    client = _client(_config(users=_users()))
+    token = client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": "s3cret"}
+    ).json()["access_token"]
+
+    resp = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    body = resp.json()
+    # Shape authService.ts User expects.
+    assert body == {"username": "alice", "is_active": True, "roles": ["admin", "user"]}
+
+
+def test_me_missing_token_401():
+    client = _client(_config(users=_users()))
+    resp = client.get("/api/v1/auth/me")
+    assert resp.status_code == 401
+
+
+def test_me_malformed_header_401():
+    client = _client(_config(users=_users()))
+    resp = client.get("/api/v1/auth/me", headers={"Authorization": "Token abc"})
+    assert resp.status_code == 401
+
+
+def test_me_expired_token_401():
+    client = _client(_config(users=_users()))
+    expired = jwt.encode(
+        {
+            "sub": "alice",
+            "roles": ["admin"],
+            "type": "access",
+            "iat": int(time.time()) - 3600,
+            "exp": int(time.time()) - 1800,
+        },
+        SECRET,
+        algorithm=JWT_ALGORITHM,
+    )
+    resp = client.get(
+        "/api/v1/auth/me", headers={"Authorization": f"Bearer {expired}"}
+    )
+    assert resp.status_code == 401
+
+
+def test_me_wrong_token_type_401():
+    client = _client(_config(users=_users()))
+    refresh = jwt.encode(
+        {
+            "sub": "alice",
+            "type": "refresh",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+        },
+        SECRET,
+        algorithm=JWT_ALGORITHM,
+    )
+    resp = client.get(
+        "/api/v1/auth/me", headers={"Authorization": f"Bearer {refresh}"}
+    )
+    assert resp.status_code == 401
+
+
+def test_me_token_for_unknown_subject_401():
+    client = _client(_config(users=_users()))
+    token = jwt.encode(
+        {
+            "sub": "ghost",
+            "roles": ["admin"],
+            "type": "access",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 600,
+        },
+        SECRET,
+        algorithm=JWT_ALGORITHM,
+    )
+    resp = client.get(
+        "/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 401
+
+
+# ── logout ───────────────────────────────────────────────────────────────
+
+
+def test_logout_ok_when_enabled():
+    client = _client(_config(users=_users()))
+    resp = client.post("/api/v1/auth/logout")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+# ── opt-in / disabled-when-no-users (default + no-auth unchanged) ──────────
+
+
+def test_endpoints_404_when_no_users_configured():
+    # No auth.users => feature off. All three endpoints 404 so the default and
+    # --no-auth flows are byte-for-byte unchanged (frontend no-auth probe path).
+    client = _client(_config(users=None))
+    assert (
+        client.post(
+            "/api/v1/auth/login", json={"username": "a", "password": "b"}
+        ).status_code
+        == 404
+    )
+    assert client.get("/api/v1/auth/me").status_code == 404
+    assert client.post("/api/v1/auth/logout").status_code == 404
+
+
+def test_endpoints_404_with_no_config_manager():
+    client = _client(None)
+    assert (
+        client.post(
+            "/api/v1/auth/login", json={"username": "a", "password": "b"}
+        ).status_code
+        == 404
+    )
+
+
+def test_login_500_when_users_but_no_secret():
+    # Users configured but no signing secret anywhere => clear 500, not a crash.
+    client = _client(_config(users=_users(), jwt_secret=None))
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": "s3cret"}
+    )
+    assert resp.status_code == 500
+
+
+def test_real_config_shape_via_config_dict():
+    # Exercise the real Config path: auth lives under .config["auth"], no .auth.
+    cfg = SimpleNamespace(
+        config={"auth": {"users": _users(), "jwt_secret": SECRET}}
+    )
+    client = _client(cfg)
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": "s3cret"}
+    )
+    assert resp.status_code == 200

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -250,6 +250,57 @@ class TestCreateAppAuthMiddleware:
         response = client.get("/api/v1/dograh/status")
         assert response.status_code == 401
 
+    # --- BUG 2: CHATTY_API_KEY env var key source -----------------------
+
+    def test_api_accessible_with_env_key(self, monkeypatch):
+        # An env-supplied CHATTY_API_KEY authenticates even with no config key.
+        monkeypatch.setenv("CHATTY_API_KEY", "env-secret")
+        app = create_app(no_auth=False, config_manager=Mock(spec=[]))
+        client = TestClient(app)
+        ok = client.get("/api/v1/dograh/status", headers={"X-API-Key": "env-secret"})
+        assert ok.status_code == 200
+        bad = client.get("/api/v1/dograh/status", headers={"X-API-Key": "nope"})
+        assert bad.status_code == 401
+
+    def test_env_key_takes_precedence_over_config_key(self, monkeypatch):
+        # CHATTY_API_KEY overrides auth.api_key from config.
+        monkeypatch.setenv("CHATTY_API_KEY", "env-secret")
+        app = create_app(no_auth=False, config_manager=self._config_with_key("config-key"))
+        client = TestClient(app)
+        # The config key no longer works once the env key is set.
+        assert (
+            client.get("/api/v1/dograh/status", headers={"X-API-Key": "config-key"}).status_code
+            == 401
+        )
+        assert (
+            client.get("/api/v1/dograh/status", headers={"X-API-Key": "env-secret"}).status_code
+            == 200
+        )
+
+    def test_config_key_still_works_without_env(self, monkeypatch):
+        # Existing config-key path keeps working when no env var is set.
+        monkeypatch.delenv("CHATTY_API_KEY", raising=False)
+        app = create_app(no_auth=False, config_manager=self._config_with_key("config-key"))
+        client = TestClient(app)
+        assert (
+            client.get("/api/v1/dograh/status", headers={"X-API-Key": "config-key"}).status_code
+            == 200
+        )
+
+    def test_auth_router_exempt_from_api_key_middleware(self, monkeypatch):
+        # BUG 1: /api/v1/auth/* validates credentials itself and must NOT be
+        # gated by the global X-API-Key (the login form has no key). With no
+        # auth.users configured it 404s (feature off) rather than 401-ing.
+        monkeypatch.delenv("CHATTY_API_KEY", raising=False)
+        app = create_app(no_auth=False, config_manager=self._config_with_key("config-key"))
+        client = TestClient(app)
+        # No X-API-Key header: a non-auth /api route 401s, the auth route does not.
+        assert client.get("/api/v1/dograh/status").status_code == 401
+        login = client.post(
+            "/api/v1/auth/login", json={"username": "x", "password": "y"}
+        )
+        assert login.status_code == 404  # not 401: middleware let it through
+
 
 # ---------------------------------------------------------------------------
 # Production refusal of the no_auth dev bypass (CHATTY_ENV=production)
@@ -477,6 +528,7 @@ class TestServerImportSafety:
                 "models_router",
                 "command_authoring_router",
                 "register_voice_test_routes",
+                "register_auth_routes",
                 "RequestMetricsMiddleware",
             ]
             for name in router_names:


### PR DESCRIPTION
Minimal 'make auth usable' slice from the AuthZ survey — opt-in, default + --no-auth unchanged. Does NOT implement the full AuthZ design (refresh/revocation/RBAC/service keys stay deferred for your review).

## Bug 2 — `web_server.auth_enabled` disconnected from the middleware
Config never populated an api_key, so enabling auth silently 401'd every request. The middleware now resolves the key from `CHATTY_API_KEY` (env, precedence) then config; startup **fails fast** with a clear message if web auth is enabled with no key. Zero-config + --no-auth byte-for-byte unchanged.

## Bug 1 — frontend login was a dead path
The webui called `/api/v1/auth/login` + `/api/v1/auth/me` but no backend existed. New `web/routes/auth.py`: HS256 JWT login (bcrypt creds against an `auth.users` config block), `/me`, stateless logout — matching the existing frontend shapes exactly (no frontend changes needed). **Opt-in: all three 404 when no `auth.users` configured**, so default flows are untouched.

## Evidence
- pytest **1147 passed, 1 skipped**; ruff clean; mypy clean (100 files)
- frontend: build green, 69 vitest tests pass (no frontend changes)
- **Docker-proven**: default `/health` 200; with `CHATTY_API_KEY` set → `/api/v1/status` **401 without key, 200 with key**
- Named regression tests pin default-boots / --no-auth / production-refusal / router-self-disables-by-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)