### PR TITLE
WebRTC phase-0: dograh call-state bridge (state-only, no shared audio)

### DIFF
--- a/src/chatty_commander/integrations/dograh_call_state.py
+++ b/src/chatty_commander/integrations/dograh_call_state.py
@@ -1,0 +1,291 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+
+"""Phase-0 dograh call-state bridge (state-only, no shared audio).
+
+This module reflects dograh *call* state into ChattyCommander so the
+dashboard can show live call status. It is deliberately a **state-only**
+bridge: no audio is shared, and no new dograh capability is assumed
+beyond the REST surface that ``DograhClient`` already exposes.
+
+Design notes (see docs/developer/WEBRTC_BRIDGE_SPIKE.md, "Phase 0"):
+
+- We poll ``DograhClient.get_workflow_run(workflow_id, run_id)`` on an
+  interval and map the run's state to a small, CC-owned set of *call*
+  states (``ringing`` / ``in_call`` / ``ended`` / ``unknown``).
+- These call states are kept **separate** from CC's ``StateManager``
+  mode enum (``idle``/``chatty``/``computer``). The spike explicitly
+  warns against conflating dograh call state with CC mode state, so we
+  broadcast a dedicated ``dograh_call_state`` WS message and keep a small
+  in-memory holder rather than mutating ``StateManager``.
+
+UNVERIFIED ASSUMPTION (must be confirmed against a live dograh instance):
+
+    The exact field name on a run record that encodes the call's
+    lifecycle is **not known** without a live dograh. We assume it is
+    one of ``_RUN_STATE_FIELDS`` (see below) and that its values map via
+    ``_DOGRAH_STATE_TO_CALL_STATE``. Both are single, easy-to-correct
+    constants. If a live instance uses a different field name or values,
+    update those two constants only — the rest of the bridge is generic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# --- CC-owned call states (intentionally NOT StateManager modes) ---------
+
+CALL_STATE_RINGING = "ringing"
+CALL_STATE_IN_CALL = "in_call"
+CALL_STATE_ENDED = "ended"
+CALL_STATE_UNKNOWN = "unknown"
+
+# --- UNVERIFIED dograh run-record assumptions ----------------------------
+#
+# The run-state field name is unknown without a live dograh instance. We
+# probe these candidate keys in order and use the first one present. This
+# is the single place to correct once the real field is confirmed.
+_RUN_STATE_FIELDS: tuple[str, ...] = ("state", "status", "call_status", "phase")
+
+# Map of (lower-cased) dograh run-state value -> CC call state. Unknown /
+# unmapped values fall through to CALL_STATE_UNKNOWN. Again: the value
+# vocabulary here is a best-effort guess pending live confirmation.
+_DOGRAH_STATE_TO_CALL_STATE: dict[str, str] = {
+    # ringing / dialing / queued
+    "ringing": CALL_STATE_RINGING,
+    "dialing": CALL_STATE_RINGING,
+    "queued": CALL_STATE_RINGING,
+    "initiated": CALL_STATE_RINGING,
+    "pending": CALL_STATE_RINGING,
+    # active / answered / in progress
+    "in_call": CALL_STATE_IN_CALL,
+    "in-call": CALL_STATE_IN_CALL,
+    "in_progress": CALL_STATE_IN_CALL,
+    "in-progress": CALL_STATE_IN_CALL,
+    "active": CALL_STATE_IN_CALL,
+    "answered": CALL_STATE_IN_CALL,
+    "running": CALL_STATE_IN_CALL,
+    "connected": CALL_STATE_IN_CALL,
+    # terminal
+    "ended": CALL_STATE_ENDED,
+    "completed": CALL_STATE_ENDED,
+    "complete": CALL_STATE_ENDED,
+    "finished": CALL_STATE_ENDED,
+    "failed": CALL_STATE_ENDED,
+    "canceled": CALL_STATE_ENDED,
+    "cancelled": CALL_STATE_ENDED,
+    "hung_up": CALL_STATE_ENDED,
+    "hangup": CALL_STATE_ENDED,
+}
+
+# Terminal call states — once reached, the poller stops polling.
+_TERMINAL_CALL_STATES = frozenset({CALL_STATE_ENDED})
+
+
+def extract_run_state(run: dict[str, Any]) -> str | None:
+    """Pull the raw dograh run-state string from a run record, if present.
+
+    Returns the first non-empty value among ``_RUN_STATE_FIELDS`` or
+    ``None`` if no candidate field is present. Kept separate from mapping
+    so the field-name assumption is testable in isolation.
+    """
+    for field in _RUN_STATE_FIELDS:
+        value = run.get(field)
+        if value is not None and str(value).strip():
+            return str(value)
+    return None
+
+
+def map_dograh_state(raw_state: str | None) -> str:
+    """Map a raw dograh run-state value to a CC call state.
+
+    Any unknown / missing value maps to ``CALL_STATE_UNKNOWN``.
+    """
+    if raw_state is None:
+        return CALL_STATE_UNKNOWN
+    return _DOGRAH_STATE_TO_CALL_STATE.get(
+        raw_state.strip().lower(), CALL_STATE_UNKNOWN
+    )
+
+
+def map_run_record(run: dict[str, Any]) -> str:
+    """Convenience: extract + map in one call from a run record."""
+    return map_dograh_state(extract_run_state(run))
+
+
+class _RunFetcher(Protocol):
+    """Structural type for the bit of DograhClient the poller needs."""
+
+    def get_workflow_run(self, workflow_id: int, run_id: int) -> dict[str, Any]: ...
+
+
+@dataclass
+class DograhCallState:
+    """Snapshot of the current dograh call state for one run."""
+
+    state: str = CALL_STATE_UNKNOWN
+    workflow_id: int | None = None
+    run_id: int | None = None
+
+    def as_message_data(self) -> dict[str, Any]:
+        """Shape used as the ``data`` of a ``dograh_call_state`` WS message."""
+        return {
+            "state": self.state,
+            "workflow_id": self.workflow_id,
+            "run_id": self.run_id,
+        }
+
+
+# Callback invoked on every *transition*. May be sync or async; the poller
+# awaits it if it returns an awaitable.
+OnChange = Callable[[DograhCallState], Awaitable[None] | None]
+
+# Injectable async sleep so tests never block on real seconds.
+SleepFn = Callable[[float], Awaitable[None]]
+
+
+class DograhCallStatePoller:
+    """Polls one dograh workflow-run's state and fires a callback on change.
+
+    Pure / injectable: the dograh client, the change callback, the poll
+    interval and the sleep function are all constructor args, so unit
+    tests drive it with a fake client and a manual clock — no real sleeps,
+    no live dograh instance.
+
+    Lifecycle: ``start()`` launches a cancellable asyncio task; ``stop()``
+    cancels and awaits it. The loop also self-terminates once a terminal
+    call state (``ended``) is observed, so a finished call stops polling
+    on its own.
+    """
+
+    def __init__(
+        self,
+        client: _RunFetcher,
+        workflow_id: int,
+        run_id: int,
+        on_change: OnChange,
+        *,
+        interval_seconds: float = 2.0,
+        sleep: SleepFn | None = None,
+    ) -> None:
+        self._client = client
+        self._workflow_id = workflow_id
+        self._run_id = run_id
+        self._on_change = on_change
+        self._interval = interval_seconds
+        self._sleep: SleepFn = sleep or asyncio.sleep
+        self._current = DograhCallState(
+            state=CALL_STATE_UNKNOWN, workflow_id=workflow_id, run_id=run_id
+        )
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def current(self) -> DograhCallState:
+        """The most recently observed call state."""
+        return self._current
+
+    async def poll_once(self) -> bool:
+        """Fetch the run once, update state, fire callback on transition.
+
+        Returns ``True`` if the state changed (callback fired), else
+        ``False``. Network/parse errors are swallowed (logged) and treated
+        as "no change" so a transient dograh hiccup never crashes the loop.
+        """
+        try:
+            run = self._client.get_workflow_run(self._workflow_id, self._run_id)
+        except Exception as exc:  # noqa: BLE001 - resilience: never crash the poller
+            logger.debug("dograh get_workflow_run failed: %s", exc)
+            return False
+
+        new_state = map_run_record(run if isinstance(run, dict) else {})
+        if new_state == self._current.state:
+            return False
+
+        self._current = DograhCallState(
+            state=new_state,
+            workflow_id=self._workflow_id,
+            run_id=self._run_id,
+        )
+        await self._fire(self._current)
+        return True
+
+    async def _fire(self, snapshot: DograhCallState) -> None:
+        try:
+            result = self._on_change(snapshot)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as exc:  # noqa: BLE001 - callback must not kill the poller
+            logger.debug("dograh_call_state on_change callback failed: %s", exc)
+
+    async def run(self) -> None:
+        """Poll until a terminal state is reached or the task is cancelled."""
+        try:
+            while True:
+                await self.poll_once()
+                if self._current.state in _TERMINAL_CALL_STATES:
+                    return
+                await self._sleep(self._interval)
+        except asyncio.CancelledError:
+            raise
+
+    def start(self) -> asyncio.Task[None]:
+        """Launch the poll loop as a cancellable task (idempotent)."""
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self.run())
+        return self._task
+
+    async def stop(self) -> None:
+        """Cancel the poll loop and await its teardown."""
+        task = self._task
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+
+
+# --- Process-wide current-call-state holder ------------------------------
+#
+# A tiny in-memory cache of the latest call state so the read route
+# (GET /api/v1/dograh/call-state) can serve it without a WS, and so the
+# poller and any future producers share one source of truth. This holds CC
+# *call* state only — it never touches StateManager's mode enum.
+
+
+class DograhCallStateHolder:
+    """Thread-/task-light holder for the latest dograh call state.
+
+    Intentionally trivial: a single mutable snapshot with a getter/setter.
+    Wired but dormant by default — it only ever reflects a non-``unknown``
+    state once a poller (registered for an active run) updates it.
+    """
+
+    def __init__(self) -> None:
+        self._snapshot = DograhCallState()
+
+    def get(self) -> DograhCallState:
+        return self._snapshot
+
+    def set(self, snapshot: DograhCallState) -> None:
+        self._snapshot = snapshot
+
+
+# Module-level singleton used by the route and the broadcast wiring.
+_HOLDER = DograhCallStateHolder()
+
+
+def get_call_state_holder() -> DograhCallStateHolder:
+    """Return the process-wide call-state holder."""
+    return _HOLDER

--- a/src/chatty_commander/web/routes/dograh.py
+++ b/src/chatty_commander/web/routes/dograh.py
@@ -9,8 +9,10 @@ the client — they always proxy through the in-process DograhClient
 which reads its credentials from environment variables.
 
 Routes:
-    GET /api/v1/dograh/status   — availability + filtered dograh /health info
-    GET /api/v1/dograh/workflows — list of workflow {id, name, status}
+    GET /api/v1/dograh/status     — availability + filtered dograh /health info
+    GET /api/v1/dograh/workflows  — list of workflow {id, name, status}
+    GET /api/v1/dograh/call-state — current cached dograh call state (phase-0
+                                    state bridge; read without a WS)
 """
 
 from __future__ import annotations
@@ -51,7 +53,47 @@ class DograhWorkflow(BaseModel):
     status: str | None = None
 
 
+class DograhCallStateResponse(BaseModel):
+    """Current CC-owned dograh *call* state (phase-0 state bridge).
+
+    This is intentionally distinct from CC's StateManager mode
+    (idle/chatty/computer): ``state`` is one of
+    ``ringing``/``in_call``/``ended``/``unknown`` and reflects a dograh
+    workflow-run's lifecycle, not CC's mode.
+    """
+
+    state: str = Field(
+        ..., description="ringing | in_call | ended | unknown"
+    )
+    workflow_id: int | None = Field(default=None)
+    run_id: int | None = Field(default=None)
+
+
 router = APIRouter()
+
+
+@router.get(
+    "/api/v1/dograh/call-state",
+    response_model=DograhCallStateResponse,
+)
+async def get_dograh_call_state() -> DograhCallStateResponse:
+    """Return the latest cached dograh call state.
+
+    Reads the in-memory holder updated by the call-state poller. When no
+    run is being tracked (the default), this is ``unknown`` with null
+    ids — so the endpoint is always safe to call even when dograh is
+    unconfigured. Lets the UI/tests read call state without a WebSocket.
+    """
+    from chatty_commander.integrations.dograh_call_state import (
+        get_call_state_holder,
+    )
+
+    snapshot = get_call_state_holder().get()
+    return DograhCallStateResponse(
+        state=snapshot.state,
+        workflow_id=snapshot.workflow_id,
+        run_id=snapshot.run_id,
+    )
 
 
 @router.get("/api/v1/dograh/status", response_model=DograhStatus)

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -425,6 +425,12 @@ class WebModeServer:
         self._telemetry_task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._telemetry_running: bool = False
 
+        # Phase-0 dograh call-state bridge (state-only; no shared audio).
+        # Wired-but-dormant: no poller runs until start_dograh_call_poller()
+        # registers an active workflow-run. Kept separate from StateManager
+        # mode (idle/chatty/computer) per WEBRTC_BRIDGE_SPIKE.md "Phase 0".
+        self._dograh_call_poller: Any | None = None
+
         # Initialize FastAPI app and register routes
         self.app = self._create_app()
         # Hook state change broadcasts
@@ -971,6 +977,69 @@ class WebModeServer:
             # e.g. the event loop is closed — fail gracefully rather than
             # propagating into the state manager callback chain.
             logger.debug("state_change broadcast scheduling failed: %s", e)
+
+    # --------------------------
+    # Phase-0 dograh call-state bridge
+    # --------------------------
+    async def _on_dograh_call_state(self, snapshot: Any) -> None:
+        """Update the cached holder and broadcast a dograh_call_state message.
+
+        ``snapshot`` is a ``DograhCallState``. This is the poller's
+        on-change callback: it fires only on transitions, updates the
+        in-memory holder (read by GET /api/v1/dograh/call-state) and fans
+        the change out over the existing /ws broadcast as a dedicated
+        ``dograh_call_state`` message — deliberately NOT a ``state_change``,
+        so CC's mode states stay untouched.
+        """
+        from chatty_commander.integrations.dograh_call_state import (
+            get_call_state_holder,
+        )
+
+        get_call_state_holder().set(snapshot)
+        await self._broadcast_message(
+            WebSocketMessage(
+                type="dograh_call_state",
+                data=snapshot.as_message_data(),
+            )
+        )
+
+    def start_dograh_call_poller(
+        self,
+        client: Any,
+        workflow_id: int,
+        run_id: int,
+        *,
+        interval_seconds: float = 2.0,
+    ) -> Any:
+        """Begin reflecting a dograh workflow-run's call state into CC.
+
+        Wired-but-dormant entry point: nothing polls dograh until this is
+        called with an active run. Returns the started
+        ``DograhCallStatePoller`` (its task is cancellable via ``stop()``).
+        Caller is responsible for only invoking this when dograh is
+        configured and a run is actually active.
+        """
+        from chatty_commander.integrations.dograh_call_state import (
+            DograhCallStatePoller,
+        )
+
+        poller = DograhCallStatePoller(
+            client,
+            workflow_id,
+            run_id,
+            self._on_dograh_call_state,
+            interval_seconds=interval_seconds,
+        )
+        poller.start()
+        self._dograh_call_poller = poller
+        return poller
+
+    async def stop_dograh_call_poller(self) -> None:
+        """Cancel any running dograh call-state poller."""
+        poller = self._dograh_call_poller
+        if poller is not None:
+            await poller.stop()
+            self._dograh_call_poller = None
 
     # Optional convenience callbacks (exposed for tests)
     def on_command_detected(self, command: str, confidence: float) -> None:

--- a/tests/test_dograh_call_state.py
+++ b/tests/test_dograh_call_state.py
@@ -1,0 +1,278 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+
+"""Tests for the phase-0 dograh call-state bridge.
+
+Covers state mapping, change detection, poller lifecycle (start/stop/
+cancel with no real sleeps), and the in-memory holder. The dograh client
+is mocked entirely — no live instance is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from chatty_commander.integrations.dograh_call_state import (
+    CALL_STATE_ENDED,
+    CALL_STATE_IN_CALL,
+    CALL_STATE_RINGING,
+    CALL_STATE_UNKNOWN,
+    DograhCallState,
+    DograhCallStateHolder,
+    DograhCallStatePoller,
+    extract_run_state,
+    get_call_state_holder,
+    map_dograh_state,
+    map_run_record,
+)
+
+
+class _FakeClient:
+    """Fake DograhClient: returns scripted run records in sequence."""
+
+    def __init__(self, records: list[dict]) -> None:
+        self._records = list(records)
+        self.calls = 0
+
+    def get_workflow_run(self, workflow_id: int, run_id: int) -> dict:
+        self.calls += 1
+        # Return last record forever once exhausted.
+        idx = min(self.calls - 1, len(self._records) - 1)
+        return self._records[idx]
+
+
+# --- state mapping -------------------------------------------------------
+
+
+class TestStateMapping:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("ringing", CALL_STATE_RINGING),
+            ("dialing", CALL_STATE_RINGING),
+            ("queued", CALL_STATE_RINGING),
+            ("in_call", CALL_STATE_IN_CALL),
+            ("in-progress", CALL_STATE_IN_CALL),
+            ("active", CALL_STATE_IN_CALL),
+            ("answered", CALL_STATE_IN_CALL),
+            ("ended", CALL_STATE_ENDED),
+            ("completed", CALL_STATE_ENDED),
+            ("failed", CALL_STATE_ENDED),
+            ("cancelled", CALL_STATE_ENDED),
+        ],
+    )
+    def test_known_states_map(self, raw, expected):
+        assert map_dograh_state(raw) == expected
+
+    def test_case_and_whitespace_insensitive(self):
+        assert map_dograh_state("  RINGING ") == CALL_STATE_RINGING
+
+    def test_unknown_value_maps_to_unknown(self):
+        assert map_dograh_state("frobnicating") == CALL_STATE_UNKNOWN
+
+    def test_none_maps_to_unknown(self):
+        assert map_dograh_state(None) == CALL_STATE_UNKNOWN
+
+    def test_extract_run_state_probes_candidate_fields(self):
+        assert extract_run_state({"state": "ringing"}) == "ringing"
+        assert extract_run_state({"status": "active"}) == "active"
+        assert extract_run_state({"call_status": "ended"}) == "ended"
+        # No candidate field present.
+        assert extract_run_state({"unrelated": "x"}) is None
+        # Empty value is treated as absent.
+        assert extract_run_state({"state": ""}) is None
+
+    def test_map_run_record_end_to_end(self):
+        assert map_run_record({"status": "answered"}) == CALL_STATE_IN_CALL
+        assert map_run_record({}) == CALL_STATE_UNKNOWN
+
+
+# --- holder --------------------------------------------------------------
+
+
+class TestHolder:
+    def test_default_is_unknown(self):
+        holder = DograhCallStateHolder()
+        snap = holder.get()
+        assert snap.state == CALL_STATE_UNKNOWN
+        assert snap.workflow_id is None
+        assert snap.run_id is None
+
+    def test_set_and_get(self):
+        holder = DograhCallStateHolder()
+        holder.set(DograhCallState(CALL_STATE_IN_CALL, 7, 9))
+        assert holder.get().state == CALL_STATE_IN_CALL
+        assert holder.get().workflow_id == 7
+
+    def test_module_singleton(self):
+        assert get_call_state_holder() is get_call_state_holder()
+
+
+# --- message shape -------------------------------------------------------
+
+
+def test_message_data_shape():
+    snap = DograhCallState(CALL_STATE_RINGING, workflow_id=3, run_id=11)
+    assert snap.as_message_data() == {
+        "state": "ringing",
+        "workflow_id": 3,
+        "run_id": 11,
+    }
+
+
+# --- change detection (poll_once) ----------------------------------------
+
+
+class TestChangeDetection:
+    @pytest.mark.asyncio
+    async def test_callback_fires_only_on_transition(self):
+        client = _FakeClient(
+            [
+                {"state": "ringing"},
+                {"state": "ringing"},  # no change
+                {"state": "in_call"},  # change
+            ]
+        )
+        seen: list[str] = []
+
+        async def on_change(snap: DograhCallState) -> None:
+            seen.append(snap.state)
+
+        poller = DograhCallStatePoller(
+            client, workflow_id=1, run_id=2, on_change=on_change
+        )
+
+        assert await poller.poll_once() is True  # unknown -> ringing
+        assert await poller.poll_once() is False  # ringing -> ringing
+        assert await poller.poll_once() is True  # ringing -> in_call
+
+        assert seen == [CALL_STATE_RINGING, CALL_STATE_IN_CALL]
+        assert poller.current.state == CALL_STATE_IN_CALL
+
+    @pytest.mark.asyncio
+    async def test_sync_callback_supported(self):
+        client = _FakeClient([{"state": "ringing"}])
+        seen: list[str] = []
+
+        poller = DograhCallStatePoller(
+            client, 1, 2, on_change=lambda s: seen.append(s.state)
+        )
+        await poller.poll_once()
+        assert seen == [CALL_STATE_RINGING]
+
+    @pytest.mark.asyncio
+    async def test_client_error_is_swallowed(self):
+        class Boom:
+            def get_workflow_run(self, *_):
+                raise RuntimeError("dograh down")
+
+        fired: list[str] = []
+        poller = DograhCallStatePoller(
+            Boom(), 1, 2, on_change=lambda s: fired.append(s.state)
+        )
+        assert await poller.poll_once() is False
+        assert fired == []
+        assert poller.current.state == CALL_STATE_UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_callback_error_does_not_crash(self):
+        client = _FakeClient([{"state": "ringing"}])
+
+        def boom(_s):
+            raise ValueError("callback bug")
+
+        poller = DograhCallStatePoller(client, 1, 2, on_change=boom)
+        # Should not raise.
+        assert await poller.poll_once() is True
+        assert poller.current.state == CALL_STATE_RINGING
+
+
+# --- poller lifecycle (no real sleeps) -----------------------------------
+
+
+class TestPollerLifecycle:
+    @pytest.mark.asyncio
+    async def test_run_stops_at_terminal_state(self):
+        client = _FakeClient(
+            [
+                {"state": "ringing"},
+                {"state": "in_call"},
+                {"state": "ended"},
+            ]
+        )
+        seen: list[str] = []
+        # Injected no-op async sleep: no real seconds elapse.
+        slept: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            slept.append(delay)
+
+        poller = DograhCallStatePoller(
+            client,
+            1,
+            2,
+            on_change=lambda s: seen.append(s.state),
+            interval_seconds=5.0,
+            sleep=fake_sleep,
+        )
+        # run() should self-terminate once "ended" is observed.
+        await asyncio.wait_for(poller.run(), timeout=1.0)
+
+        assert seen == [
+            CALL_STATE_RINGING,
+            CALL_STATE_IN_CALL,
+            CALL_STATE_ENDED,
+        ]
+        # Slept between polls but never on the terminal one.
+        assert slept == [5.0, 5.0]
+
+    @pytest.mark.asyncio
+    async def test_start_and_stop_cancels_loop(self):
+        # Never-terminal client: loop runs until cancelled.
+        client = _FakeClient([{"state": "in_call"}])
+
+        sleep_started = asyncio.Event()
+
+        async def blocking_sleep(_delay: float) -> None:
+            sleep_started.set()
+            await asyncio.sleep(3600)  # effectively block until cancelled
+
+        poller = DograhCallStatePoller(
+            client,
+            1,
+            2,
+            on_change=lambda s: None,
+            sleep=blocking_sleep,
+        )
+        task = poller.start()
+        # Wait until the loop has polled once and is parked in sleep.
+        await asyncio.wait_for(sleep_started.wait(), timeout=1.0)
+        assert poller.current.state == CALL_STATE_IN_CALL
+
+        await poller.stop()
+        assert task.cancelled() or task.done()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_safe_when_never_started(self):
+        poller = DograhCallStatePoller(
+            _FakeClient([{}]), 1, 2, on_change=lambda s: None
+        )
+        await poller.stop()  # no-op, must not raise
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self):
+        client = _FakeClient([{"state": "in_call"}])
+
+        async def block(_d):
+            await asyncio.sleep(3600)
+
+        poller = DograhCallStatePoller(
+            client, 1, 2, on_change=lambda s: None, sleep=block
+        )
+        t1 = poller.start()
+        t2 = poller.start()
+        assert t1 is t2
+        await poller.stop()

--- a/tests/test_dograh_call_state_route.py
+++ b/tests/test_dograh_call_state_route.py
@@ -1,0 +1,121 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+
+"""Tests for the GET /api/v1/dograh/call-state read route and the
+WebModeServer dograh_call_state broadcast wiring.
+
+The dograh client is mocked; the route reads the in-memory holder.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from chatty_commander.integrations.dograh_call_state import (
+    CALL_STATE_IN_CALL,
+    CALL_STATE_RINGING,
+    CALL_STATE_UNKNOWN,
+    DograhCallState,
+    get_call_state_holder,
+)
+from chatty_commander.web.routes.dograh import router
+
+
+@pytest.fixture(autouse=True)
+def _reset_holder():
+    # Keep the process-wide singleton clean across tests.
+    get_call_state_holder().set(DograhCallState())
+    yield
+    get_call_state_holder().set(DograhCallState())
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestCallStateRoute:
+    def test_default_is_unknown(self):
+        r = _client().get("/api/v1/dograh/call-state")
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {"state": "unknown", "workflow_id": None, "run_id": None}
+
+    def test_reflects_holder(self):
+        get_call_state_holder().set(
+            DograhCallState(CALL_STATE_RINGING, workflow_id=4, run_id=8)
+        )
+        r = _client().get("/api/v1/dograh/call-state")
+        body = r.json()
+        assert body == {"state": "ringing", "workflow_id": 4, "run_id": 8}
+
+
+class TestBroadcastWiring:
+    """The poller's on-change callback updates the holder and broadcasts a
+    `dograh_call_state` message — NOT a `state_change`."""
+
+    @pytest.mark.asyncio
+    async def test_on_dograh_call_state_updates_holder_and_broadcasts(self):
+        from chatty_commander.web.web_mode import WebModeServer
+
+        # Build a server with light fakes; we only exercise the callback.
+        server = WebModeServer.__new__(WebModeServer)
+        broadcast: list = []
+
+        async def fake_broadcast(msg):
+            broadcast.append(msg)
+
+        server._broadcast_message = fake_broadcast  # type: ignore[assignment]
+
+        snap = DograhCallState(CALL_STATE_IN_CALL, workflow_id=2, run_id=3)
+        await server._on_dograh_call_state(snap)
+
+        # Holder updated.
+        assert get_call_state_holder().get().state == CALL_STATE_IN_CALL
+        # Exactly one broadcast, of the dedicated type (not state_change).
+        assert len(broadcast) == 1
+        msg = broadcast[0]
+        assert msg.type == "dograh_call_state"
+        assert msg.data == {
+            "state": "in_call",
+            "workflow_id": 2,
+            "run_id": 3,
+        }
+
+    @pytest.mark.asyncio
+    async def test_start_poller_wires_callback_and_broadcasts_on_change(self):
+        from chatty_commander.web.web_mode import WebModeServer
+
+        server = WebModeServer.__new__(WebModeServer)
+        server._dograh_call_poller = None
+        broadcast: list = []
+
+        async def fake_broadcast(msg):
+            broadcast.append(msg)
+
+        server._broadcast_message = fake_broadcast  # type: ignore[assignment]
+
+        class FakeClient:
+            def get_workflow_run(self, *_):
+                return {"state": "ringing"}
+
+        poller = server.start_dograh_call_poller(
+            FakeClient(), workflow_id=1, run_id=1
+        )
+        try:
+            changed = await poller.poll_once()
+            assert changed is True
+            assert len(broadcast) == 1
+            assert broadcast[0].type == "dograh_call_state"
+            assert broadcast[0].data["state"] == CALL_STATE_RINGING
+        finally:
+            await server.stop_dograh_call_poller()
+
+    @pytest.mark.asyncio
+    async def test_default_server_has_no_active_poller(self):
+        # Dormant by default: no run registered -> holder stays unknown.
+        assert get_call_state_holder().get().state == CALL_STATE_UNKNOWN

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -540,7 +540,10 @@ class TestServerImportSafety:
             app = server_module.create_app()
             assert isinstance(app, FastAPI)
             route_count = len(app.routes)
-            assert route_count <= 12
+            # dograh_router stays registered here and now carries three
+            # routes (status, workflows, call-state); the phase-0 call-state
+            # read route bumped the baseline from 12 to 13.
+            assert route_count <= 13
         finally:
             for key, value in original_globals.items():
                 setattr(server_module, key, value)


### PR DESCRIPTION
Phase-0 from WEBRTC_BRIDGE_SPIKE — the buildable-now slice. Reflects dograh call state into CC without any shared audio.

## What
- **Poller** (`dograh_call_state.py`): polls a dograh run via the existing client, maps to `ringing/in_call/ended/unknown`, fires on transitions only. Pure/injectable — fake client + injected sleep, no real-time sleeps in tests.
- **Broadcast**: `{type:'dograh_call_state', data:{state, workflow_id, run_id}}` over the existing /ws.
- **Route**: `GET /api/v1/dograh/call-state` → cached state (defaults `unknown`/null, always safe).
- **Design**: CC's `idle/chatty/computer` StateManager enum left untouched (dedicated message, per the spike's caution against conflating). **Wired-but-dormant** — nothing polls until `start_dograh_call_poller` is called with an active run, gated on dograh configured. Default/--no-auth flows unchanged.

## ⚠️ One assumption to confirm against a live dograh
The run-state field name/vocabulary isn't exposed by the client. Isolated to two constants (`_RUN_STATE_FIELDS`, `_DOGRAH_STATE_TO_CALL_STATE`) — if a live dograh differs, correct only those.

## Remaining for full activation (follow-ups, not phase-0)
1. Confirm the field assumption on a live instance. 2. Call `start_dograh_call_poller` right after a run becomes active. 3. Frontend dashboard consumer of the message.

## Evidence
- pytest **1180 passed, 1 skipped**; ruff + mypy clean
- **Docker-proven**: `/health` 200; `/api/v1/dograh/call-state` 200 → `{state:unknown,...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)