### PR TITLE
Coverage: llm/cli, voice/cli, voice/pipeline, cli/cli

### DIFF
--- a/tests/test_cli_cli_coverage.py
+++ b/tests/test_cli_cli_coverage.py
@@ -1,0 +1,704 @@
+"""Targeted coverage for chatty_commander.cli.cli helper functions and
+cli_main dispatch branches that the existing CLI test files do not exercise.
+
+Existing coverage lives in:
+- tests/test_cli_features.py    -> cli_main dispatch (help/web/gui/config/shell) + list/exec
+- tests/test_main_orchestrator.py -> run_orchestrator_mode + build_advisor_sink
+
+This file fills the gaps: run_cli_mode, run_web_mode, run_gui_mode,
+run_interactive_shell, _detect_action_type edge cases, and a handful of
+cli_main argument-validation / env-override branches. All heavy side effects
+(model loading, server start, signal handlers, GUI launchers) are patched so
+tests are hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock openwakeword the same way the other CLI test modules do, so importing
+# the app stack underneath cli does not fail in CI.
+sys.modules.setdefault("openwakeword", types.ModuleType("openwakeword"))
+_owm = types.ModuleType("openwakeword.model")
+_owm.Model = type("Model", (), {})
+sys.modules.setdefault("openwakeword.model", _owm)
+
+from chatty_commander.cli import cli as cli_mod  # noqa: E402
+from chatty_commander.cli.cli import (  # noqa: E402
+    _detect_action_type,
+    run_cli_mode,
+    run_gui_mode,
+    run_interactive_shell,
+    run_web_mode,
+)
+
+# ── _detect_action_type ──────────────────────────────────────────────────
+
+
+class TestDetectActionType:
+    def test_dict_keypress(self):
+        assert _detect_action_type({"keypress": "ctrl+c"}) == "keypress"
+
+    def test_dict_shell_and_url(self):
+        assert _detect_action_type({"shell": {}}) == "shell"
+        assert _detect_action_type({"url": "http://x"}) == "url"
+
+    def test_dict_unknown(self):
+        assert _detect_action_type({"mystery": 1}) == "unknown"
+
+    def test_string_heuristic(self):
+        assert _detect_action_type("open url please") == "url"
+        assert _detect_action_type("run shell thing") == "shell"
+        assert _detect_action_type("keypress ctrl") == "keypress"
+
+    def test_string_unknown(self):
+        assert _detect_action_type("just words") == "unknown"
+
+    def test_non_dict_non_str(self):
+        assert _detect_action_type(42) == "unknown"
+        assert _detect_action_type(None) == "unknown"
+
+
+# ── run_cli_mode ─────────────────────────────────────────────────────────
+
+
+def _logger():
+    return MagicMock()
+
+
+class _Config:
+    def __init__(self, actions=None):
+        self.model_actions = actions or {}
+        self.web_server = {}
+        self.advisors = {"enabled": False}
+
+
+class TestRunCliMode:
+    def test_loop_processes_command_and_executes_action(self, monkeypatch):
+        """One actionable command, then signal flips the shutdown flag."""
+        logger = _logger()
+        config = _Config({"hello": {"shell": {}}})
+
+        mm = MagicMock()
+        sm = MagicMock()
+        sm.current_state = "idle"
+        ce = MagicMock()
+
+        # Capture the registered signal handlers so we can trigger graceful
+        # shutdown deterministically instead of relying on real signals.
+        handlers = {}
+        monkeypatch.setattr(
+            cli_mod.signal,
+            "signal",
+            lambda signum, handler: handlers.setdefault(signum, handler),
+        )
+
+        # update_state both reports a transition and flips the shutdown flag
+        # so the loop runs exactly one full iteration.
+        def update_then_stop(cmd):
+            handlers[cli_mod.signal.SIGINT](cli_mod.signal.SIGINT, None)
+            return "active"
+
+        sm.update_state.side_effect = update_then_stop
+        mm.listen_for_commands.return_value = "hello"
+
+        with pytest.raises(SystemExit) as exc:
+            run_cli_mode(config, mm, sm, ce, logger)
+        assert exc.value.code == 0
+
+        mm.reload_models.assert_any_call("idle")
+        mm.reload_models.assert_any_call("active")
+        ce.execute_command.assert_called_once_with("hello")
+        mm.shutdown.assert_called_once()
+        sm.shutdown.assert_called_once()
+
+    def test_empty_command_continues_then_shutdown(self, monkeypatch):
+        logger = _logger()
+        config = _Config({})
+        mm = MagicMock()
+        sm = MagicMock()
+        sm.current_state = "idle"
+        ce = MagicMock()
+
+        handlers = {}
+        monkeypatch.setattr(
+            cli_mod.signal,
+            "signal",
+            lambda signum, handler: handlers.setdefault(signum, handler),
+        )
+
+        seq = ["", None]
+
+        def fake_listen():
+            if seq:
+                val = seq.pop(0)
+                if not seq:
+                    handlers[cli_mod.signal.SIGINT](cli_mod.signal.SIGINT, None)
+                return val
+            return None
+
+        mm.listen_for_commands.side_effect = fake_listen
+
+        with pytest.raises(SystemExit):
+            run_cli_mode(config, mm, sm, ce, logger)
+        ce.execute_command.assert_not_called()
+
+    def test_inner_exception_logged_and_loop_survives(self, monkeypatch):
+        logger = _logger()
+        config = _Config({})
+        mm = MagicMock()
+        sm = MagicMock()
+        sm.current_state = "idle"
+        ce = MagicMock()
+
+        handlers = {}
+        monkeypatch.setattr(
+            cli_mod.signal,
+            "signal",
+            lambda signum, handler: handlers.setdefault(signum, handler),
+        )
+
+        state = {"n": 0}
+
+        def fake_listen():
+            state["n"] += 1
+            if state["n"] == 1:
+                raise RuntimeError("transient")
+            handlers[cli_mod.signal.SIGTERM](cli_mod.signal.SIGTERM, None)
+            return None
+
+        mm.listen_for_commands.side_effect = fake_listen
+
+        with pytest.raises(SystemExit):
+            run_cli_mode(config, mm, sm, ce, logger)
+        assert any(
+            "Error while processing command loop" in str(c)
+            for c in logger.error.call_args_list
+        )
+
+    def test_shutdown_cleanup_errors_are_swallowed(self, monkeypatch):
+        logger = _logger()
+        config = _Config({})
+        # model_manager.shutdown raises; finally block must catch and exit(0).
+        mm = MagicMock()
+        mm.shutdown.side_effect = RuntimeError("cleanup boom")
+        sm = MagicMock()
+        sm.current_state = "idle"
+        ce = MagicMock()
+
+        handlers = {}
+        monkeypatch.setattr(
+            cli_mod.signal,
+            "signal",
+            lambda signum, handler: handlers.setdefault(signum, handler),
+        )
+
+        def fake_listen():
+            handlers[cli_mod.signal.SIGINT](cli_mod.signal.SIGINT, None)
+            return None
+
+        mm.listen_for_commands.side_effect = fake_listen
+
+        with pytest.raises(SystemExit) as exc:
+            run_cli_mode(config, mm, sm, ce, logger)
+        assert exc.value.code == 0
+        assert any(
+            "Error during shutdown" in str(c) for c in logger.error.call_args_list
+        )
+
+
+# ── run_web_mode ─────────────────────────────────────────────────────────
+
+
+class TestRunWebMode:
+    def _patch_web(self, monkeypatch, server=None):
+        """Install a fake WebModeServer + no-op env validation + no-op signals."""
+        fake_server = server or MagicMock()
+        fake_module = types.ModuleType("chatty_commander.web.web_mode")
+        fake_module.WebModeServer = MagicMock(return_value=fake_server)
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.web.web_mode", fake_module
+        )
+        monkeypatch.setattr(
+            cli_mod.signal, "signal", lambda *a, **k: None
+        )
+        return fake_server, fake_module
+
+    def test_import_error_exits_1(self, monkeypatch):
+        # Force the lazy import to raise ImportError.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **k):
+            if name == "chatty_commander.web.web_mode":
+                raise ImportError("no fastapi")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        logger = _logger()
+        with pytest.raises(SystemExit) as exc:
+            run_web_mode(_Config(), MagicMock(), MagicMock(), MagicMock(), logger)
+        assert exc.value.code == 1
+        logger.error.assert_called()
+
+    def test_happy_path_runs_server_and_shuts_down(self, monkeypatch):
+        server, _ = self._patch_web(monkeypatch)
+        # Patch env validation to a no-op.
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        logger = _logger()
+        mm = MagicMock()
+        sm = MagicMock()
+        ce = MagicMock()
+
+        run_web_mode(_Config(), mm, sm, ce, logger, host="1.2.3.4", port=9000)
+
+        server.run.assert_called_once_with(host="1.2.3.4", port=9000)
+        mm.add_command_callback.assert_called_once()
+        sm.add_state_change_callback.assert_called_once()
+        mm.shutdown.assert_called_once()
+        sm.shutdown.assert_called_once()
+
+    def test_no_auth_disables_auth_in_dict_config(self, monkeypatch):
+        server, _ = self._patch_web(monkeypatch)
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        config = _Config()
+        config.web_server = {"auth_enabled": True}
+        run_web_mode(
+            config, MagicMock(), MagicMock(), MagicMock(), _logger(), no_auth=True
+        )
+        assert config.web_server["auth_enabled"] is False
+
+    def test_env_validation_error_exits_1(self, monkeypatch):
+        self._patch_web(monkeypatch)
+        err_cls = type("EnvValidationError", (Exception,), {})
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = err_cls
+
+        def _raise(*a, **k):
+            raise err_cls("missing OPENAI_API_KEY")
+
+        env_mod.validate_startup_env = _raise
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        logger = _logger()
+        stderr = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", stderr)
+        with pytest.raises(SystemExit) as exc:
+            run_web_mode(_Config(), MagicMock(), MagicMock(), MagicMock(), logger)
+        assert exc.value.code == 1
+        assert "missing OPENAI_API_KEY" in stderr.getvalue()
+
+    def test_env_host_port_and_log_level_overrides(self, monkeypatch):
+        server, _ = self._patch_web(monkeypatch)
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        monkeypatch.setenv("CHATCOMM_HOST", "10.0.0.1")
+        monkeypatch.setenv("CHATCOMM_PORT", "7777")
+        monkeypatch.setenv("CHATCOMM_LOG_LEVEL", "DEBUG")
+        logger = MagicMock()
+        run_web_mode(
+            _Config(), MagicMock(), MagicMock(), MagicMock(), logger,
+            host="0.0.0.0", port=8100,
+        )
+        server.run.assert_called_once_with(host="10.0.0.1", port=7777)
+        logger.setLevel.assert_called()  # DEBUG applied
+
+    def test_invalid_env_port_warns_and_keeps_default(self, monkeypatch):
+        server, _ = self._patch_web(monkeypatch)
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        monkeypatch.setenv("CHATCOMM_PORT", "not-a-number")
+        logger = MagicMock()
+        run_web_mode(
+            _Config(), MagicMock(), MagicMock(), MagicMock(), logger,
+            host="0.0.0.0", port=8100,
+        )
+        server.run.assert_called_once_with(host="0.0.0.0", port=8100)
+        assert any(
+            "Invalid CHATCOMM_PORT" in str(c) for c in logger.warning.call_args_list
+        )
+
+    def test_invalid_env_log_level_warns(self, monkeypatch):
+        server, _ = self._patch_web(monkeypatch)
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        monkeypatch.setenv("CHATCOMM_LOG_LEVEL", "BOGUS")
+        logger = MagicMock()
+        run_web_mode(
+            _Config(), MagicMock(), MagicMock(), MagicMock(), logger,
+            host="0.0.0.0", port=8100,
+        )
+        assert any(
+            "Invalid CHATCOMM_LOG_LEVEL" in str(c)
+            for c in logger.warning.call_args_list
+        )
+
+    def test_run_error_still_runs_shutdown_cleanup(self, monkeypatch):
+        server = MagicMock()
+        server.run.side_effect = RuntimeError("server crashed")
+        self._patch_web(monkeypatch, server=server)
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        mm = MagicMock()
+        with pytest.raises(RuntimeError):
+            run_web_mode(_Config(), mm, MagicMock(), MagicMock(), _logger())
+        # finally still ran shutdown
+        mm.shutdown.assert_called_once()
+
+
+# ── run_gui_mode ─────────────────────────────────────────────────────────
+
+
+class TestRunGuiMode:
+    def test_no_gui_returns_0(self):
+        assert (
+            run_gui_mode(_Config(), MagicMock(), MagicMock(), MagicMock(), _logger(),
+                         no_gui=True)
+            == 0
+        )
+
+    def test_headless_posix_skips(self, monkeypatch):
+        monkeypatch.setattr(cli_mod.os, "name", "posix")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        logger = MagicMock()
+        rc = run_gui_mode(_Config(), MagicMock(), MagicMock(), MagicMock(), logger)
+        assert rc == 0
+        logger.warning.assert_called()
+
+    def test_display_override_applied(self, monkeypatch):
+        monkeypatch.setattr(cli_mod.os, "name", "posix")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        # With a display override set but no real avatar GUI, the avatar import
+        # will fail and fall through; we only assert DISPLAY got set and an int
+        # is returned.
+        rc = run_gui_mode(
+            _Config(), MagicMock(), MagicMock(), MagicMock(), MagicMock(),
+            display_override=":99",
+        )
+        assert cli_mod.os.environ.get("DISPLAY") == ":99"
+        assert isinstance(rc, int)
+
+    def test_avatar_gui_success(self, monkeypatch):
+        monkeypatch.setattr(cli_mod.os, "name", "posix")
+        monkeypatch.setenv("DISPLAY", ":0")
+        avatar_mod = types.ModuleType("chatty_commander.avatars.avatar_gui")
+        avatar_mod.run_avatar_gui = MagicMock(return_value=None)
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.avatars.avatar_gui", avatar_mod
+        )
+        rc = run_gui_mode(_Config(), MagicMock(), MagicMock(), MagicMock(), _logger())
+        assert rc == 0
+        avatar_mod.run_avatar_gui.assert_called_once()
+
+    def test_avatar_gui_returns_code(self, monkeypatch):
+        monkeypatch.setattr(cli_mod.os, "name", "posix")
+        monkeypatch.setenv("DISPLAY", ":0")
+        avatar_mod = types.ModuleType("chatty_commander.avatars.avatar_gui")
+        avatar_mod.run_avatar_gui = MagicMock(return_value=3)
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.avatars.avatar_gui", avatar_mod
+        )
+        rc = run_gui_mode(_Config(), MagicMock(), MagicMock(), MagicMock(), _logger())
+        assert rc == 3
+
+    def test_falls_back_to_tray_popup(self, monkeypatch):
+        monkeypatch.setattr(cli_mod.os, "name", "posix")
+        monkeypatch.setenv("DISPLAY", ":0")
+        # avatar + pyqt5 both raise on import -> tray popup path.
+        avatar_mod = types.ModuleType("chatty_commander.avatars.avatar_gui")
+
+        def _avatar_boom():
+            raise RuntimeError("no webview")
+
+        avatar_mod.run_avatar_gui = _avatar_boom
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.avatars.avatar_gui", avatar_mod
+        )
+
+        pyqt_mod = types.ModuleType("chatty_commander.gui.pyqt5_avatar")
+
+        def _pyqt_boom():
+            raise RuntimeError("no pyqt")
+
+        pyqt_mod.run_pyqt5_avatar = _pyqt_boom
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.gui.pyqt5_avatar", pyqt_mod
+        )
+
+        tray_mod = types.ModuleType("chatty_commander.gui.tray_popup")
+        tray_mod.run_tray_popup = MagicMock(return_value=None)
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.gui.tray_popup", tray_mod
+        )
+
+        rc = run_gui_mode(_Config(), MagicMock(), MagicMock(), MagicMock(), _logger())
+        assert rc == 0
+        tray_mod.run_tray_popup.assert_called_once()
+
+
+# ── run_interactive_shell ────────────────────────────────────────────────
+
+
+def _feed_inputs(monkeypatch, lines):
+    it = iter(lines)
+
+    def fake_input(prompt=""):
+        try:
+            return next(it)
+        except StopIteration as exc:
+            raise EOFError from exc
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+class TestRunInteractiveShell:
+    def _patch_readline(self, monkeypatch):
+        fake_readline = types.ModuleType("readline")
+        fake_readline.set_completer = MagicMock()
+        fake_readline.parse_and_bind = MagicMock()
+        monkeypatch.setitem(sys.modules, "readline", fake_readline)
+        return fake_readline
+
+    def test_help_state_models_and_exit(self, monkeypatch, capsys):
+        self._patch_readline(monkeypatch)
+        config = _Config({"foo": {"shell": {}}})
+        sm = MagicMock()
+        sm.current_state = "idle"
+        mm = MagicMock()
+        mm.models = {"general": {"m1": object()}, "system": {}}
+        _feed_inputs(monkeypatch, ["", "help", "state", "models", "exit"])
+        run_interactive_shell(config, mm, sm, MagicMock(), MagicMock())
+        out = capsys.readouterr().out
+        assert "Available commands: help, exit" in out
+        assert "Current state: idle" in out
+        assert "Loaded models: m1" in out
+
+    def test_execute_known_and_unknown(self, monkeypatch, capsys):
+        self._patch_readline(monkeypatch)
+        config = _Config({"foo": {"shell": {}}})
+        sm = MagicMock()
+        ce = MagicMock()
+        mm = MagicMock()
+        mm.models = {}
+        _feed_inputs(
+            monkeypatch, ["execute foo", "execute nope", "exit"]
+        )
+        run_interactive_shell(config, mm, sm, ce, MagicMock())
+        out = capsys.readouterr().out
+        ce.execute_command.assert_called_once_with("foo")
+        assert "Executed: foo" in out
+        assert "Unknown command: nope" in out
+
+    def test_execute_known_raises_prints_error(self, monkeypatch, capsys):
+        self._patch_readline(monkeypatch)
+        config = _Config({"foo": {"shell": {}}})
+        ce = MagicMock()
+        ce.execute_command.side_effect = RuntimeError("kaboom")
+        mm = MagicMock()
+        mm.models = {}
+        _feed_inputs(monkeypatch, ["execute foo", "exit"])
+        run_interactive_shell(config, mm, MagicMock(), ce, MagicMock())
+        out = capsys.readouterr().out
+        assert "Error executing 'foo': kaboom" in out
+
+    def test_voice_simulation_transitions_and_executes(self, monkeypatch, capsys):
+        self._patch_readline(monkeypatch)
+        config = _Config({"hello": {"shell": {}}})
+        sm = MagicMock()
+        sm.update_state.return_value = "active"
+        mm = MagicMock()
+        mm.models = {}
+        ce = MagicMock()
+        _feed_inputs(monkeypatch, ["hello", "exit"])
+        run_interactive_shell(config, mm, sm, ce, MagicMock())
+        sm.update_state.assert_called_with("hello")
+        mm.reload_models.assert_called_with("active")
+        ce.execute_command.assert_called_once_with("hello")
+
+    def test_voice_simulation_execute_error(self, monkeypatch, capsys):
+        self._patch_readline(monkeypatch)
+        config = _Config({"hello": {"shell": {}}})
+        sm = MagicMock()
+        sm.update_state.return_value = None
+        mm = MagicMock()
+        mm.models = {}
+        ce = MagicMock()
+        ce.execute_command.side_effect = RuntimeError("bad")
+        _feed_inputs(monkeypatch, ["hello", "exit"])
+        run_interactive_shell(config, mm, sm, ce, MagicMock())
+        assert "Error executing 'hello': bad" in capsys.readouterr().out
+
+    def test_eof_terminates_loop(self, monkeypatch):
+        self._patch_readline(monkeypatch)
+        config = _Config({})
+        mm = MagicMock()
+        mm.models = {}
+        _feed_inputs(monkeypatch, [])  # immediate EOFError
+        # Should return cleanly without raising.
+        run_interactive_shell(config, mm, MagicMock(), MagicMock(), MagicMock())
+
+    def test_completer_logic(self, monkeypatch):
+        """Exercise the tab-completer closure set via readline.set_completer."""
+        fake_readline = self._patch_readline(monkeypatch)
+        config = _Config({"alpha": {"shell": {}}, "beta": {"url": "u"}})
+        mm = MagicMock()
+        mm.models = {}
+        _feed_inputs(monkeypatch, ["exit"])
+        run_interactive_shell(config, mm, MagicMock(), MagicMock(), MagicMock())
+
+        completer = fake_readline.set_completer.call_args[0][0]
+        # Top-level commands starting with 'e' -> 'execute', 'exit'
+        first = completer("e", 0)
+        assert first in ("execute", "exit")
+        # Exhausted -> None
+        assert completer("zzz", 0) is None
+        # 'execute ' subcompletion over model_actions
+        assert completer("execute al", 0) == "execute alpha"
+        assert completer("execute al", 5) is None
+
+
+# ── cli_main argument validation branches ────────────────────────────────
+
+
+class _DummyConfig:
+    def __init__(self):
+        self.model_actions = {}
+        self.web_server = {}
+        self.advisors = {"enabled": False}
+
+
+def _install_light_app(monkeypatch):
+    """Patch cli_main's lazily-resolved heavy deps with light fakes."""
+    monkeypatch.setattr(cli_mod, "Config", lambda: _DummyConfig())
+    monkeypatch.setattr(cli_mod, "ModelManager", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(cli_mod, "StateManager", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(cli_mod, "CommandExecutor", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(cli_mod, "generate_default_config_if_needed", lambda: False)
+
+
+def _run_main(monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", ["chatty-commander"] + argv)
+    stdout, stderr = io.StringIO(), io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    try:
+        code = cli_mod.cli_main()
+    except SystemExit as e:
+        code = int(e.code) if e.code is not None else 0
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+class TestCliMainArgValidation:
+    def test_low_port_with_web_errors(self, monkeypatch):
+        # parser.error -> SystemExit(2)
+        code, _out, err = _run_main(monkeypatch, ["--web", "--port", "80"])
+        assert code == 2
+        assert "Port must be 1024 or higher" in err
+
+    def test_no_auth_without_web_errors(self, monkeypatch):
+        code, _out, err = _run_main(monkeypatch, ["--no-auth"])
+        assert code == 2
+        assert "--no-auth only applicable in web mode" in err
+
+    def test_orchestrate_dispatch(self, monkeypatch):
+        _install_light_app(monkeypatch)
+        # skip AI core + env validation by going through orchestrate path,
+        # but env validation still runs for non-config; patch it to no-op.
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        # Skip AI core import.
+        monkeypatch.setattr(
+            cli_mod, "run_orchestrator_mode", lambda *a, **k: 0
+        )
+        with patch(
+            "chatty_commander.ai.create_intelligence_core",
+            side_effect=Exception("no ai"),
+        ):
+            code, out, _err = _run_main(
+                monkeypatch, ["--orchestrate", "--test-mode"]
+            )
+        assert code == 0
+
+    def test_shell_dispatch(self, monkeypatch):
+        _install_light_app(monkeypatch)
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        with patch.object(cli_mod, "run_interactive_shell") as shell:
+            code, _o, _e = _run_main(monkeypatch, ["--shell", "--test-mode"])
+        assert code == 0
+        shell.assert_called_once()
+
+    def test_env_validation_failure_returns_1(self, monkeypatch):
+        _install_light_app(monkeypatch)
+        err_cls = type("EnvValidationError", (Exception,), {})
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = err_cls
+
+        def _raise(*a, **k):
+            raise err_cls("OPENAI_API_KEY required")
+
+        env_mod.validate_startup_env = _raise
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        code, _o, err = _run_main(monkeypatch, ["--shell", "--test-mode"])
+        assert code == 1
+        assert "OPENAI_API_KEY required" in err
+
+    def test_default_cli_mode_dispatch(self, monkeypatch):
+        _install_light_app(monkeypatch)
+        env_mod = types.ModuleType("chatty_commander.app.env_validation")
+        env_mod.EnvValidationError = type("EnvValidationError", (Exception,), {})
+        env_mod.validate_startup_env = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, "chatty_commander.app.env_validation", env_mod
+        )
+        # Provide a non-mode arg so interactive_mode is False and we reach the
+        # default run_cli_mode branch.
+        with patch.object(cli_mod, "run_cli_mode") as cli_run:
+            code, _o, _e = _run_main(
+                monkeypatch, ["--log-level", "DEBUG", "--test-mode"]
+            )
+        assert code == 0
+        cli_run.assert_called_once()

--- a/tests/test_llm_cli_coverage.py
+++ b/tests/test_llm_cli_coverage.py
@@ -1,0 +1,476 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Tests for src/chatty_commander/llm/cli.py — the LLM CLI surface.
+# All external LLM backends are mocked at the import boundary so nothing real
+# (network/onnx/torch) loads.
+
+"""Coverage tests for the LLM CLI subcommands.
+
+The production module imports ``LLMManager`` and ``CommandProcessor`` at module
+load time:
+
+    from .manager import LLMManager
+    from .processor import CommandProcessor
+
+so we patch ``chatty_commander.llm.cli.LLMManager`` /
+``chatty_commander.llm.cli.CommandProcessor`` (the names bound in the cli module)
+to keep everything hermetic.
+"""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from chatty_commander.llm import cli as llm_cli
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(**overrides):
+    """Build a MagicMock that behaves like an LLMManager."""
+    m = MagicMock(name="LLMManager")
+    m.get_active_backend_name.return_value = overrides.get("active", "mock")
+    m.is_available.return_value = overrides.get("available", True)
+    m.get_all_backends_info.return_value = overrides.get(
+        "all_info",
+        {
+            "active": "mock",
+            "mock": {"available": True, "responses_count": 5, "call_count": 2},
+            "openai": {
+                "available": False,
+                "base_url": "https://api.openai.com",
+                "has_api_key": False,
+                "error": "no key",
+            },
+        },
+    )
+    m.get_backend_info.return_value = overrides.get(
+        "backend_info", {"name": "mock", "available": True}
+    )
+    m.generate_response.return_value = overrides.get("response", "hi there")
+    m.test_backend.return_value = overrides.get(
+        "test_result",
+        {"success": True, "response": "ok", "response_time": 0.123},
+    )
+    return m
+
+
+def _make_processor(**overrides):
+    p = MagicMock(name="CommandProcessor")
+    p.get_processor_status.return_value = overrides.get(
+        "status",
+        {
+            "llm_backend": "mock",
+            "available_commands": ["lights", "music"],
+        },
+    )
+    p.process_command.return_value = overrides.get(
+        "process", ("lights", 0.92, "matched lights")
+    )
+    p.explain_command.return_value = overrides.get(
+        "explain", {"description": "toggle the lights"}
+    )
+    p.get_command_suggestions.return_value = overrides.get(
+        "suggestions",
+        [
+            {"command": "lights", "confidence": 0.8},
+            {"command": "music", "confidence": 0.5},
+        ],
+    )
+    return p
+
+
+@pytest.fixture
+def patch_manager(monkeypatch):
+    """Patch LLMManager at the cli import boundary; returns the mock instance."""
+    instance = _make_manager()
+    factory = MagicMock(return_value=instance)
+    monkeypatch.setattr(llm_cli, "LLMManager", factory)
+    return SimpleNamespace(factory=factory, instance=instance)
+
+
+@pytest.fixture
+def patch_processor(monkeypatch):
+    instance = _make_processor()
+    factory = MagicMock(return_value=instance)
+    monkeypatch.setattr(llm_cli, "CommandProcessor", factory)
+    return SimpleNamespace(factory=factory, instance=instance)
+
+
+# ---------------------------------------------------------------------------
+# add_llm_subcommands — argument parsing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="cc")
+    sub = parser.add_subparsers(dest="command")
+    llm_cli.add_llm_subcommands(sub)
+    return parser
+
+
+def test_add_subcommands_status_parses():
+    parser = _build_parser()
+    ns = parser.parse_args(["llm", "status"])
+    assert ns.command == "llm"
+    assert ns.llm_command == "status"
+
+
+def test_add_subcommands_test_defaults():
+    parser = _build_parser()
+    ns = parser.parse_args(["llm", "test"])
+    assert ns.llm_command == "test"
+    assert ns.backend is None
+    assert ns.prompt == "Hello, how are you?"
+    assert ns.mock is False
+
+
+def test_add_subcommands_test_flags():
+    parser = _build_parser()
+    ns = parser.parse_args(
+        ["llm", "test", "--backend", "openai", "--prompt", "yo", "--mock"]
+    )
+    assert ns.backend == "openai"
+    assert ns.prompt == "yo"
+    assert ns.mock is True
+
+
+def test_add_subcommands_process_requires_text():
+    parser = _build_parser()
+    ns = parser.parse_args(["llm", "process", "turn on lights", "--mock"])
+    assert ns.llm_command == "process"
+    assert ns.text == "turn on lights"
+    assert ns.mock is True
+
+
+def test_add_subcommands_process_missing_text_errors():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["llm", "process"])
+
+
+def test_add_subcommands_backends_parses():
+    parser = _build_parser()
+    ns = parser.parse_args(["llm", "backends"])
+    assert ns.llm_command == "backends"
+
+
+# ---------------------------------------------------------------------------
+# handle_llm_command — dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_handle_no_llm_command_attr(capsys):
+    args = SimpleNamespace()  # no llm_command attribute
+    llm_cli.handle_llm_command(args)
+    out = capsys.readouterr().out
+    assert "No LLM command specified" in out
+
+
+def test_handle_empty_llm_command(capsys):
+    args = SimpleNamespace(llm_command=None)
+    llm_cli.handle_llm_command(args)
+    out = capsys.readouterr().out
+    assert "No LLM command specified" in out
+
+
+def test_handle_unknown_llm_command(capsys):
+    args = SimpleNamespace(llm_command="bogus")
+    llm_cli.handle_llm_command(args)
+    out = capsys.readouterr().out
+    assert "Unknown LLM command: bogus" in out
+
+
+def test_handle_dispatches_status(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        llm_cli, "_handle_llm_status", lambda a: called.setdefault("status", a)
+    )
+    args = SimpleNamespace(llm_command="status")
+    llm_cli.handle_llm_command(args)
+    assert "status" in called
+
+
+def test_handle_dispatches_test(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        llm_cli, "_handle_llm_test", lambda a: called.setdefault("test", a)
+    )
+    llm_cli.handle_llm_command(SimpleNamespace(llm_command="test"))
+    assert "test" in called
+
+
+def test_handle_dispatches_process(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        llm_cli,
+        "_handle_llm_process",
+        lambda a, c=None: called.setdefault("process", (a, c)),
+    )
+    cm = object()
+    llm_cli.handle_llm_command(SimpleNamespace(llm_command="process"), config_manager=cm)
+    assert called["process"][1] is cm
+
+
+def test_handle_dispatches_backends(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        llm_cli, "_handle_llm_backends", lambda a: called.setdefault("backends", a)
+    )
+    llm_cli.handle_llm_command(SimpleNamespace(llm_command="backends"))
+    assert "backends" in called
+
+
+# ---------------------------------------------------------------------------
+# _handle_llm_status
+# ---------------------------------------------------------------------------
+
+
+def test_status_happy_path(patch_manager, monkeypatch, capsys):
+    # Control env vars: one set (masked key), one plain, one unset.
+    monkeypatch.setenv("OPENAI_API_KEY", "abcd1234efgh5678")
+    monkeypatch.setenv("LLM_BACKEND", "mock")
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+
+    llm_cli._handle_llm_status(SimpleNamespace())
+    out = capsys.readouterr().out
+
+    assert "LLM System Status" in out
+    assert "Dependencies:" in out
+    assert "Active backend: mock" in out
+    # masked key: first4 + ... + last4
+    assert "abcd...5678" in out
+    assert "OPENAI_API_KEY: abcd...5678" in out
+    assert "LLM_BACKEND: mock" in out
+    assert "OPENAI_API_BASE: Not set" in out
+    patch_manager.factory.assert_called_once_with(use_mock=True)
+
+
+def test_status_backend_with_error(patch_manager, monkeypatch, capsys):
+    patch_manager.instance.get_all_backends_info.return_value = {
+        "active": "mock",
+        "openai": {"available": False, "error": "boom"},
+    }
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    llm_cli._handle_llm_status(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Error: boom" in out
+    assert "openai: Not available" in out
+
+
+def test_status_short_key_not_masked(patch_manager, monkeypatch, capsys):
+    monkeypatch.setenv("OPENAI_API_KEY", "short")  # len <= 8 -> shown raw
+    llm_cli._handle_llm_status(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "OPENAI_API_KEY: short" in out
+
+
+def test_status_exception_path(monkeypatch, capsys):
+    boom = MagicMock(side_effect=RuntimeError("init failed"))
+    monkeypatch.setattr(llm_cli, "LLMManager", boom)
+    llm_cli._handle_llm_status(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Status check failed: init failed" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_llm_test
+# ---------------------------------------------------------------------------
+
+
+def test_test_specific_backend_success(patch_manager, capsys):
+    args = SimpleNamespace(backend="openai", prompt="hi", mock=False)
+    llm_cli._handle_llm_test(args)
+    out = capsys.readouterr().out
+    assert "Testing backend: openai" in out
+    assert "Success!" in out
+    assert "Response: ok" in out
+    assert "Time: 0.123s" in out
+    patch_manager.instance.test_backend.assert_called_once_with("openai", "hi")
+    patch_manager.factory.assert_called_once_with(use_mock=False)
+
+
+def test_test_specific_backend_failure(patch_manager, capsys):
+    patch_manager.instance.test_backend.return_value = {
+        "success": False,
+        "error": "backend down",
+    }
+    args = SimpleNamespace(backend="openai", prompt="hi", mock=True)
+    llm_cli._handle_llm_test(args)
+    out = capsys.readouterr().out
+    assert "Failed: backend down" in out
+
+
+def test_test_specific_backend_failure_unknown_error(patch_manager, capsys):
+    patch_manager.instance.test_backend.return_value = {"success": False}
+    args = SimpleNamespace(backend="openai", prompt="hi", mock=True)
+    llm_cli._handle_llm_test(args)
+    out = capsys.readouterr().out
+    assert "Failed: Unknown error" in out
+
+
+def test_test_active_backend_success(patch_manager, capsys):
+    args = SimpleNamespace(backend=None, prompt="hello", mock=True)
+    llm_cli._handle_llm_test(args)
+    out = capsys.readouterr().out
+    assert "Testing active backend: mock" in out
+    assert "Response: hi there" in out
+    patch_manager.instance.generate_response.assert_called_once_with(
+        "hello", max_tokens=50
+    )
+
+
+def test_test_active_backend_generate_raises(patch_manager, capsys):
+    patch_manager.instance.generate_response.side_effect = RuntimeError("gen err")
+    args = SimpleNamespace(backend=None, prompt="hello", mock=True)
+    llm_cli._handle_llm_test(args)
+    out = capsys.readouterr().out
+    assert "Failed: gen err" in out
+    # Backend info still printed afterward
+    assert "Backend Info:" in out
+
+
+def test_test_outer_exception(monkeypatch, capsys):
+    monkeypatch.setattr(
+        llm_cli, "LLMManager", MagicMock(side_effect=RuntimeError("no manager"))
+    )
+    args = SimpleNamespace(backend=None, prompt="x", mock=False)
+    llm_cli._handle_llm_test(args)
+    out = capsys.readouterr().out
+    assert "LLM test failed: no manager" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_llm_process
+# ---------------------------------------------------------------------------
+
+
+def test_process_matched_command(patch_manager, patch_processor, capsys):
+    args = SimpleNamespace(text="turn on lights", mock=True)
+    cm = object()
+    llm_cli._handle_llm_process(args, config_manager=cm)
+    out = capsys.readouterr().out
+    assert "Processing command: 'turn on lights'" in out
+    assert "Available commands: lights, music" in out
+    assert "Matched command: lights" in out
+    assert "Confidence: 0.92" in out
+    assert "Explanation: matched lights" in out
+    assert "Action: toggle the lights" in out
+    assert "Suggestions:" in out
+    patch_processor.factory.assert_called_once_with(
+        llm_manager=patch_manager.instance, config_manager=cm
+    )
+    patch_processor.instance.get_command_suggestions.assert_called_once_with("tur")
+
+
+def test_process_no_match(patch_manager, patch_processor, capsys):
+    patch_processor.instance.process_command.return_value = (None, 0.0, "nothing fit")
+    patch_processor.instance.get_command_suggestions.return_value = []
+    args = SimpleNamespace(text="zzz", mock=True)
+    llm_cli._handle_llm_process(args)
+    out = capsys.readouterr().out
+    assert "No command matched" in out
+    assert "Reason: nothing fit" in out
+    assert "Suggestions:" not in out
+
+
+def test_process_exception(monkeypatch, capsys):
+    monkeypatch.setattr(
+        llm_cli, "LLMManager", MagicMock(side_effect=RuntimeError("proc boom"))
+    )
+    args = SimpleNamespace(text="x", mock=False)
+    llm_cli._handle_llm_process(args)
+    out = capsys.readouterr().out
+    assert "Command processing failed: proc boom" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_llm_backends
+# ---------------------------------------------------------------------------
+
+
+def test_backends_all_branches(patch_manager, capsys):
+    patch_manager.instance.get_all_backends_info.return_value = {
+        "active": "ollama",
+        "openai": {"available": True, "base_url": "u", "has_api_key": True},
+        "ollama": {"available": True, "host": "localhost", "model": "llama"},
+        "local": {"available": False, "model_name": "gpt2", "device": "cpu"},
+        "mock": {"available": True, "responses_count": 3, "call_count": 7},
+    }
+    llm_cli._handle_llm_backends(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Active Backend: ollama" in out
+    assert "OPENAI" in out
+    assert "Has API Key: True" in out
+    assert "Host: localhost" in out
+    assert "Model: llama" in out
+    assert "Model: gpt2" in out
+    assert "Device: cpu" in out
+    assert "Responses: 3" in out
+    assert "Calls: 7" in out
+
+
+def test_backends_with_error_and_no_active(patch_manager, capsys):
+    patch_manager.instance.get_all_backends_info.return_value = {
+        "openai": {"available": False, "error": "key missing"},
+    }
+    llm_cli._handle_llm_backends(SimpleNamespace())
+    out = capsys.readouterr().out
+    # active key absent -> default "none"
+    assert "Active Backend: none" in out
+    assert "Error: key missing" in out
+
+
+def test_backends_exception(monkeypatch, capsys):
+    monkeypatch.setattr(
+        llm_cli, "LLMManager", MagicMock(side_effect=RuntimeError("be boom"))
+    )
+    llm_cli._handle_llm_backends(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Failed to get backend information: be boom" in out
+
+
+# ---------------------------------------------------------------------------
+# demo_llm_integration
+# ---------------------------------------------------------------------------
+
+
+def test_demo_happy_path(patch_manager, patch_processor, capsys):
+    # First input matches, return a no-match for one to hit both branches.
+    results = iter(
+        [
+            ("lights", 0.9, "ok"),
+            (None, 0.0, "no"),
+            ("music", 0.7, "ok2"),
+            (None, 0.0, "no2"),
+            (None, 0.1, "unknown"),
+        ]
+    )
+    patch_processor.instance.process_command.side_effect = lambda _i: next(results)
+    llm_cli.demo_llm_integration(config_manager=object())
+    out = capsys.readouterr().out
+    assert "LLM Integration Demo" in out
+    assert "LLM Backend: mock" in out
+    assert "→ lights (confidence: 0.90)" in out
+    assert "No match (no)" in out
+    assert "demo completed!" in out
+
+
+def test_demo_exception(monkeypatch, caplog, capsys):
+    monkeypatch.setattr(
+        llm_cli, "LLMManager", MagicMock(side_effect=RuntimeError("demo boom"))
+    )
+    with caplog.at_level("ERROR"):
+        llm_cli.demo_llm_integration()
+    out = capsys.readouterr().out
+    assert "Demo failed: demo boom" in out
+    assert any("LLM demo error" in r.message for r in caplog.records)

--- a/tests/test_voice_cli_coverage.py
+++ b/tests/test_voice_cli_coverage.py
@@ -1,0 +1,478 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Coverage tests for chatty_commander.voice.cli.
+
+All audio/hardware/model boundaries are patched so no devices or models are
+touched. We drive the CLI handlers directly through their argparse Namespace
+contract and via the assembled argparse parser to exercise arg parsing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from chatty_commander.voice import cli as voice_cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_status():
+    return {
+        "transcriber_info": {
+            "backend_type": "mock",
+            "sample_rate": 16000,
+            "channels": 1,
+        },
+        "transcriber_available": True,
+        "available_wake_words": ["hey_jarvis"],
+    }
+
+
+def _make_pipeline_mock():
+    pipeline = MagicMock()
+    pipeline.get_status.return_value = _mock_status()
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# add_voice_subcommands / argparse wiring
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cc")
+    subparsers = parser.add_subparsers(dest="command")
+    voice_cli.add_voice_subcommands(subparsers)
+    return parser
+
+
+def test_add_voice_subcommands_test_defaults():
+    parser = _build_parser()
+    args = parser.parse_args(["voice", "test"])
+    assert args.voice_command == "test"
+    assert args.mock is False
+    assert args.duration == 30
+    assert args.wake_words is None
+    # The voice parser sets a dispatch func.
+    assert callable(args.func)
+
+
+def test_add_voice_subcommands_test_with_flags():
+    parser = _build_parser()
+    args = parser.parse_args(
+        ["voice", "test", "--mock", "--duration", "5", "--wake-words", "a", "b"]
+    )
+    assert args.mock is True
+    assert args.duration == 5
+    assert args.wake_words == ["a", "b"]
+
+
+def test_add_voice_subcommands_transcribe_defaults_and_choices():
+    parser = _build_parser()
+    args = parser.parse_args(["voice", "transcribe"])
+    assert args.backend == "whisper_local"
+    assert args.timeout == 5.0
+
+    args = parser.parse_args(
+        ["voice", "transcribe", "--backend", "mock", "--timeout", "2.5"]
+    )
+    assert args.backend == "mock"
+    assert args.timeout == 2.5
+
+
+def test_add_voice_subcommands_transcribe_invalid_backend_exits():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["voice", "transcribe", "--backend", "bogus"])
+
+
+def test_add_voice_subcommands_selftest_run_and_improve():
+    parser = _build_parser()
+    args = parser.parse_args(
+        ["voice", "self-test", "run", "--openai-key", "k", "--phrases", "one", "two"]
+    )
+    assert args.voice_command == "self-test"
+    assert args.test_command == "run"
+    assert args.openai_key == "k"
+    assert args.phrases == ["one", "two"]
+
+    args = parser.parse_args(
+        ["voice", "self-test", "improve", "--iterations", "7", "--openai-key", "k2"]
+    )
+    assert args.test_command == "improve"
+    assert args.iterations == 7
+
+
+def test_add_voice_subcommands_func_dispatch(monkeypatch):
+    parser = _build_parser()
+    args = parser.parse_args(["voice", "status"])
+    called = {}
+    monkeypatch.setattr(
+        voice_cli, "handle_voice_command", lambda a: called.setdefault("ran", a)
+    )
+    # func was bound to a lambda calling handle_voice_command at definition time;
+    # patching the module attribute means we invoke the real lambda which will
+    # look up the (now patched) name.
+    args.func(args)
+    assert called["ran"] is args
+
+
+# ---------------------------------------------------------------------------
+# handle_voice_command dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_handle_voice_command_no_attr(capsys):
+    voice_cli.handle_voice_command(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "No voice command specified" in out
+
+
+def test_handle_voice_command_empty(capsys):
+    voice_cli.handle_voice_command(SimpleNamespace(voice_command=None))
+    out = capsys.readouterr().out
+    assert "No voice command specified" in out
+
+
+def test_handle_voice_command_unknown(capsys):
+    voice_cli.handle_voice_command(SimpleNamespace(voice_command="frobnicate"))
+    out = capsys.readouterr().out
+    assert "Unknown voice command: frobnicate" in out
+
+
+def test_handle_voice_command_dispatch_test():
+    args = SimpleNamespace(voice_command="test")
+    with patch.object(voice_cli, "_handle_voice_test") as h:
+        voice_cli.handle_voice_command(args, "cfg", "exec", "state")
+    h.assert_called_once_with(args, "cfg", "exec", "state")
+
+
+def test_handle_voice_command_dispatch_status():
+    args = SimpleNamespace(voice_command="status")
+    with patch.object(voice_cli, "_handle_voice_status") as h:
+        voice_cli.handle_voice_command(args)
+    h.assert_called_once_with(args)
+
+
+def test_handle_voice_command_dispatch_transcribe():
+    args = SimpleNamespace(voice_command="transcribe")
+    with patch.object(voice_cli, "_handle_voice_transcribe") as h:
+        voice_cli.handle_voice_command(args)
+    h.assert_called_once_with(args)
+
+
+def test_handle_voice_command_dispatch_self_test_ok():
+    args = SimpleNamespace(voice_command="self-test")
+    fake_mod = types.ModuleType("chatty_commander.voice.self_test")
+    fake_mod.handle_self_test_command = MagicMock()
+    with patch.dict(
+        sys.modules, {"chatty_commander.voice.self_test": fake_mod}
+    ):
+        voice_cli.handle_voice_command(args)
+    fake_mod.handle_self_test_command.assert_called_once_with(args)
+
+
+def test_handle_voice_command_dispatch_self_test_import_error(capsys):
+    args = SimpleNamespace(voice_command="self-test")
+    real_import = __import__
+
+    def fake_import(name, *a, **k):
+        if name == "chatty_commander.voice.self_test" or name.endswith("self_test"):
+            raise ImportError("no module")
+        return real_import(name, *a, **k)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        voice_cli.handle_voice_command(args)
+    out = capsys.readouterr().out
+    assert "Self-test not available" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_voice_test
+# ---------------------------------------------------------------------------
+
+
+def test_handle_voice_test_mock_path(capsys):
+    pipeline = _make_pipeline_mock()
+    args = SimpleNamespace(wake_words=None, mock=True, duration=0)
+    with (
+        patch.object(voice_cli, "VoicePipeline", return_value=pipeline) as P,
+        patch.object(voice_cli.time, "sleep") as sleep,
+    ):
+        voice_cli._handle_voice_test(args)
+
+    out = capsys.readouterr().out
+    assert "Starting voice pipeline test" in out
+    assert "Pipeline status" in out
+    assert "Mock mode" in out
+    assert "Testing mock wake word" in out
+    assert "test completed" in out
+
+    P.assert_called_once()
+    pipeline.add_command_callback.assert_called_once()
+    pipeline.start.assert_called_once()
+    pipeline.trigger_mock_wake_word.assert_called_once_with("hey_jarvis")
+    pipeline.process_text_command.assert_called_once_with("hello there")
+    pipeline.stop.assert_called_once()
+    # mock path sleeps 2 + 2 + duration(0) = 3 calls
+    assert sleep.call_count == 3
+
+
+def test_handle_voice_test_callback_branches(capsys):
+    pipeline = _make_pipeline_mock()
+    captured = {}
+
+    def grab(cb):
+        captured["cb"] = cb
+
+    pipeline.add_command_callback.side_effect = grab
+    args = SimpleNamespace(wake_words=["x"], mock=True, duration=0)
+    with (
+        patch.object(voice_cli, "VoicePipeline", return_value=pipeline),
+        patch.object(voice_cli.time, "sleep"),
+    ):
+        voice_cli._handle_voice_test(args)
+
+    cb = captured["cb"]
+    cb("turn_on", "turn on lights")
+    cb("", "garbled audio")
+    out = capsys.readouterr().out
+    assert "Command executed: 'turn_on'" in out
+    assert "No command matched: 'garbled audio'" in out
+
+
+def test_handle_voice_test_real_path(capsys):
+    pipeline = _make_pipeline_mock()
+    args = SimpleNamespace(wake_words=None, mock=False, duration=0)
+    with (
+        patch.object(voice_cli, "VoicePipeline", return_value=pipeline),
+        patch.object(voice_cli.time, "sleep") as sleep,
+    ):
+        voice_cli._handle_voice_test(args)
+
+    out = capsys.readouterr().out
+    assert "Say a wake word" in out
+    assert "Mock mode" not in out
+    pipeline.trigger_mock_wake_word.assert_not_called()
+    # real path only sleeps for duration -> 1 call
+    assert sleep.call_count == 1
+
+
+def test_handle_voice_test_exception(capsys):
+    args = SimpleNamespace(wake_words=None, mock=False, duration=0)
+    with patch.object(
+        voice_cli, "VoicePipeline", side_effect=RuntimeError("boom")
+    ):
+        voice_cli._handle_voice_test(args)
+    out = capsys.readouterr().out
+    assert "Voice test failed: boom" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_voice_status
+# ---------------------------------------------------------------------------
+
+
+def test_handle_voice_status_deps_available(capsys):
+    pipeline = _make_pipeline_mock()
+    with (
+        patch("importlib.util.find_spec", return_value=object()),
+        patch.object(voice_cli, "VoicePipeline", return_value=pipeline),
+    ):
+        voice_cli._handle_voice_status(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Voice System Status" in out
+    assert "OpenWakeWord: Available" in out
+    assert "Pipeline Status" in out
+    assert "Sample rate: 16000 Hz" in out
+    assert "Channels: 1" in out
+
+
+def test_handle_voice_status_deps_missing(capsys):
+    pipeline = _make_pipeline_mock()
+    with (
+        patch("importlib.util.find_spec", return_value=None),
+        patch.object(voice_cli, "VoicePipeline", return_value=pipeline),
+    ):
+        voice_cli._handle_voice_status(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Not installed" in out
+
+
+def test_handle_voice_status_pipeline_failure(capsys):
+    with (
+        patch("importlib.util.find_spec", return_value=None),
+        patch.object(
+            voice_cli, "VoicePipeline", side_effect=RuntimeError("nopipe")
+        ),
+    ):
+        voice_cli._handle_voice_status(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Pipeline test failed: nopipe" in out
+
+
+def test_handle_voice_status_outer_failure(capsys):
+    # Force the outer try to blow up by making importlib import fail.
+    with patch.dict(sys.modules, {"importlib.util": None}):
+        # importing importlib.util with a None entry raises ImportError
+        voice_cli._handle_voice_status(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "Status check failed" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_voice_transcribe
+# ---------------------------------------------------------------------------
+
+
+def _patch_transcriber(transcriber):
+    fake_mod = types.ModuleType("chatty_commander.voice.transcription")
+    fake_mod.VoiceTranscriber = MagicMock(return_value=transcriber)
+    return patch.dict(
+        sys.modules, {"chatty_commander.voice.transcription": fake_mod}
+    ), fake_mod
+
+
+def test_handle_voice_transcribe_mock_backend(capsys):
+    transcriber = MagicMock()
+    transcriber.is_available.return_value = True
+    transcriber.get_backend_info.return_value = {"backend": "mock"}
+    transcriber.transcribe_audio_data.return_value = "mock text"
+    ctx, fake_mod = _patch_transcriber(transcriber)
+    args = SimpleNamespace(backend="mock", timeout=1.0)
+    with ctx:
+        voice_cli._handle_voice_transcribe(args)
+    out = capsys.readouterr().out
+    assert "Testing transcription with mock backend" in out
+    assert "Mock transcription: 'mock text'" in out
+    transcriber.transcribe_audio_data.assert_called_once_with(b"dummy_audio")
+
+
+def test_handle_voice_transcribe_not_available(capsys):
+    transcriber = MagicMock()
+    transcriber.is_available.return_value = False
+    ctx, _ = _patch_transcriber(transcriber)
+    args = SimpleNamespace(backend="whisper_local", timeout=1.0)
+    with ctx:
+        voice_cli._handle_voice_transcribe(args)
+    out = capsys.readouterr().out
+    assert "not available" in out
+
+
+def test_handle_voice_transcribe_real_with_result(capsys):
+    transcriber = MagicMock()
+    transcriber.is_available.return_value = True
+    transcriber.get_backend_info.return_value = {"backend": "whisper_local"}
+    transcriber.record_and_transcribe.return_value = "hello world"
+    ctx, _ = _patch_transcriber(transcriber)
+    args = SimpleNamespace(backend="whisper_local", timeout=3.0)
+    with ctx:
+        voice_cli._handle_voice_transcribe(args)
+    out = capsys.readouterr().out
+    assert "Recording for 3.0 seconds" in out
+    assert "Transcription: 'hello world'" in out
+
+
+def test_handle_voice_transcribe_real_no_result(capsys):
+    transcriber = MagicMock()
+    transcriber.is_available.return_value = True
+    transcriber.get_backend_info.return_value = {}
+    transcriber.record_and_transcribe.return_value = None
+    ctx, _ = _patch_transcriber(transcriber)
+    args = SimpleNamespace(backend="whisper_api", timeout=1.0)
+    with ctx:
+        voice_cli._handle_voice_transcribe(args)
+    out = capsys.readouterr().out
+    assert "No transcription received" in out
+
+
+def test_handle_voice_transcribe_exception(capsys):
+    fake_mod = types.ModuleType("chatty_commander.voice.transcription")
+    fake_mod.VoiceTranscriber = MagicMock(side_effect=RuntimeError("kaboom"))
+    args = SimpleNamespace(backend="mock", timeout=1.0)
+    with patch.dict(
+        sys.modules, {"chatty_commander.voice.transcription": fake_mod}
+    ):
+        voice_cli._handle_voice_transcribe(args)
+    out = capsys.readouterr().out
+    assert "Transcription test failed: kaboom" in out
+
+
+# ---------------------------------------------------------------------------
+# demo_voice_integration
+# ---------------------------------------------------------------------------
+
+
+def test_demo_voice_integration_happy(capsys):
+    pipeline = _make_pipeline_mock()
+    captured = {}
+    pipeline.add_command_callback.side_effect = lambda cb: captured.setdefault(
+        "cb", cb
+    )
+    config_manager = SimpleNamespace(model_actions={"hello": {}, "lights": {}})
+    with (
+        patch.object(voice_cli, "VoicePipeline", return_value=pipeline),
+        patch.object(voice_cli.time, "sleep"),
+    ):
+        voice_cli.demo_voice_integration(config_manager=config_manager)
+
+    # exercise the demo callback both branches
+    captured["cb"]("hello", "hello world")
+    captured["cb"]("", "junk")
+    out = capsys.readouterr().out
+    assert "Voice Integration Demo" in out
+    assert "Available commands" in out
+    assert "- hello" in out
+    assert "Executed: hello" in out
+    assert "Unknown: 'junk'" in out
+    assert "Demo completed" in out
+    assert pipeline.process_text_command.call_count == 4
+
+
+def test_demo_voice_integration_no_config(capsys):
+    pipeline = _make_pipeline_mock()
+    with (
+        patch.object(voice_cli, "VoicePipeline", return_value=pipeline),
+        patch.object(voice_cli.time, "sleep"),
+    ):
+        voice_cli.demo_voice_integration()
+    out = capsys.readouterr().out
+    assert "Available commands" not in out
+    assert "Demo completed" in out
+
+
+def test_demo_voice_integration_exception(capsys):
+    with patch.object(
+        voice_cli, "VoicePipeline", side_effect=RuntimeError("demoboom")
+    ):
+        voice_cli.demo_voice_integration()
+    out = capsys.readouterr().out
+    assert "Demo failed: demoboom" in out

--- a/tests/test_voice_pipeline_coverage.py
+++ b/tests/test_voice_pipeline_coverage.py
@@ -1,0 +1,584 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction.
+
+"""Branch-coverage tests for ``chatty_commander.voice.pipeline``.
+
+These tests exercise the uncovered paths of :class:`VoicePipeline`:
+construction with mocked components, the full ``_process_voice_command``
+flow with synthetic transcriptions, error handling in start/stop/dispatch,
+state-manager update branches, TTS feedback branches, and lifecycle helpers.
+
+All external/audio dependencies are mocked at the boundary (the transcriber,
+TTS, and wakeword detector) so the tests are fast and hermetic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from chatty_commander.voice.pipeline import VoicePipeline
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_pipeline(**kwargs) -> VoicePipeline:
+    """Build a pipeline forced onto mock components.
+
+    With ``use_mock=True`` the wakeword detector is a ``MockWakeWordDetector``
+    and the transcription backend is forced to ``"mock"`` and the TTS backend
+    is whatever is passed (defaults to a mock-friendly backend via patching in
+    individual tests).
+    """
+    kwargs.setdefault("use_mock", True)
+    return VoicePipeline(**kwargs)
+
+
+def install_fake_io(pipeline: VoicePipeline, *, transcription="", tts_available=True):
+    """Replace transcriber and tts with controllable mocks."""
+    pipeline.transcriber = Mock()
+    pipeline.transcriber.record_and_transcribe.return_value = transcription
+    pipeline.transcriber.is_available.return_value = True
+    pipeline.transcriber.get_backend_info.return_value = {"backend": "mock"}
+
+    pipeline.tts = Mock()
+    pipeline.tts.is_available.return_value = tts_available
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_construction_uses_mock_components():
+    pipeline = make_pipeline(wake_words=["hey_jarvis"])
+    # Mock wake detector exposes trigger_wake_word.
+    assert hasattr(pipeline.wake_detector, "trigger_wake_word")
+    assert pipeline._listening is False
+    assert pipeline._processing is False
+    assert pipeline._callbacks == []
+    # The wake detector should have our internal handler registered.
+    assert pipeline.wake_detector._callbacks  # type: ignore[attr-defined]
+
+
+def test_construction_real_path_when_deps_available(monkeypatch):
+    """When VOICE_DEPS_AVAILABLE and not use_mock, real WakeWordDetector is built.
+
+    We stub WakeWordDetector/VoiceTranscriber/TextToSpeech so no audio stack is
+    touched, then assert the non-mock branch (line 73) is taken.
+    """
+    import chatty_commander.voice.pipeline as mod
+
+    fake_detector = Mock()
+    fake_detector_cls = Mock(return_value=fake_detector)
+    monkeypatch.setattr(mod, "VOICE_DEPS_AVAILABLE", True)
+    monkeypatch.setattr(mod, "WakeWordDetector", fake_detector_cls)
+    monkeypatch.setattr(mod, "VoiceTranscriber", Mock(return_value=Mock()))
+    monkeypatch.setattr(mod, "TextToSpeech", Mock(return_value=Mock()))
+
+    pipeline = VoicePipeline(use_mock=False, wake_words=["x"])
+
+    fake_detector_cls.assert_called_once()
+    assert pipeline.wake_detector is fake_detector
+    fake_detector.add_callback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Callbacks
+# ---------------------------------------------------------------------------
+
+
+def test_add_and_remove_command_callback():
+    pipeline = make_pipeline()
+
+    def cb(name, txt):  # pragma: no cover - body not invoked here
+        return None
+
+    pipeline.add_command_callback(cb)
+    assert cb in pipeline._callbacks
+    pipeline.remove_command_callback(cb)
+    assert cb not in pipeline._callbacks
+    # Removing again is a no-op (covers the guarded branch).
+    pipeline.remove_command_callback(cb)
+
+
+def test_notify_callbacks_swallows_exceptions():
+    pipeline = make_pipeline()
+    good = Mock()
+    bad = Mock(side_effect=RuntimeError("boom"))
+    pipeline.add_command_callback(bad)
+    pipeline.add_command_callback(good)
+    # Should not raise even though one callback errors.
+    pipeline._notify_callbacks("hello", "hello there")
+    good.assert_called_once_with("hello", "hello there")
+
+
+# ---------------------------------------------------------------------------
+# start / stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_start_sets_listening_and_updates_state():
+    state = Mock()
+    pipeline = make_pipeline(state_manager=state)
+    pipeline.wake_detector = Mock()
+    pipeline.start()
+    assert pipeline._listening is True
+    state.change_state.assert_called_with("voice_listening")
+
+
+def test_start_when_already_listening_warns_and_returns():
+    pipeline = make_pipeline()
+    pipeline.wake_detector = Mock()
+    pipeline._listening = True
+    pipeline.start()
+    # Detector should never be told to start again.
+    pipeline.wake_detector.start_listening.assert_not_called()
+
+
+def test_start_state_update_failure_is_swallowed():
+    state = Mock()
+    state.change_state.side_effect = RuntimeError("nope")
+    pipeline = make_pipeline(state_manager=state)
+    pipeline.wake_detector = Mock()
+    # Should not raise despite state error.
+    pipeline.start()
+    assert pipeline._listening is True
+
+
+def test_start_detector_failure_reraises():
+    pipeline = make_pipeline()
+    pipeline.wake_detector = Mock()
+    pipeline.wake_detector.start_listening.side_effect = RuntimeError("hw fail")
+    with pytest.raises(RuntimeError):
+        pipeline.start()
+
+
+def test_stop_updates_state_idle():
+    state = Mock()
+    pipeline = make_pipeline(state_manager=state)
+    pipeline.wake_detector = Mock()
+    pipeline._listening = True
+    pipeline.stop()
+    assert pipeline._listening is False
+    state.change_state.assert_called_with("idle")
+
+
+def test_stop_state_update_failure_swallowed():
+    state = Mock()
+    state.change_state.side_effect = RuntimeError("nope")
+    pipeline = make_pipeline(state_manager=state)
+    pipeline.wake_detector = Mock()
+    pipeline.stop()
+    assert pipeline._listening is False
+
+
+def test_stop_detector_failure_swallowed():
+    pipeline = make_pipeline()
+    pipeline.wake_detector = Mock()
+    pipeline.wake_detector.stop_listening.side_effect = RuntimeError("boom")
+    # Should not raise.
+    pipeline.stop()
+    assert pipeline._listening is False
+
+
+# ---------------------------------------------------------------------------
+# _on_wake_word_detected dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_on_wake_word_ignored_when_processing():
+    pipeline = make_pipeline()
+    pipeline._processing = True
+    called = {}
+    pipeline._process_voice_command = lambda w: called.setdefault("x", w)  # type: ignore
+    pipeline._on_wake_word_detected("hey", 0.99)
+    assert called == {}
+
+
+def test_on_wake_word_spawns_processing_thread(monkeypatch):
+    pipeline = make_pipeline()
+    seen = {}
+
+    def fake_process(wake_word):
+        seen["wake_word"] = wake_word
+
+    pipeline._process_voice_command = fake_process  # type: ignore
+
+    # Run the spawned thread synchronously by stubbing Thread.
+    import chatty_commander.voice.pipeline as mod
+
+    class ImmediateThread:
+        def __init__(self, target, args, daemon):
+            self._target = target
+            self._args = args
+
+        def start(self):
+            self._target(*self._args)
+
+    monkeypatch.setattr(mod.threading, "Thread", ImmediateThread)
+    pipeline._on_wake_word_detected("hey_jarvis", 0.5)
+    assert seen["wake_word"] == "hey_jarvis"
+
+
+# ---------------------------------------------------------------------------
+# _process_voice_command flow
+# ---------------------------------------------------------------------------
+
+
+def test_process_no_transcription_returns_early():
+    state = Mock()
+    pipeline = make_pipeline(state_manager=state)
+    install_fake_io(pipeline, transcription="")
+    cb = Mock()
+    pipeline.add_command_callback(cb)
+    pipeline._process_voice_command("hey")
+    cb.assert_not_called()
+    assert pipeline._processing is False
+    # Final state returns to listening.
+    state.change_state.assert_called_with("voice_listening")
+
+
+def test_process_matched_command_success_notifies_and_speaks():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    executor = Mock()
+    executor.execute_command.return_value = True
+    state = Mock()
+    pipeline = make_pipeline(
+        config_manager=config,
+        command_executor=executor,
+        state_manager=state,
+        voice_only=True,
+    )
+    install_fake_io(pipeline, transcription="hello there")
+    cb = Mock()
+    pipeline.add_command_callback(cb)
+
+    pipeline._process_voice_command("hey")
+
+    executor.execute_command.assert_called_once_with("hello")
+    cb.assert_called_once_with("hello", "hello there")
+    pipeline.tts.speak.assert_called_once_with("hello")
+
+
+def test_process_matched_command_failure_speaks_failure():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    executor = Mock()
+    executor.execute_command.return_value = False
+    pipeline = make_pipeline(
+        config_manager=config,
+        command_executor=executor,
+        voice_only=True,
+    )
+    install_fake_io(pipeline, transcription="hello there")
+    cb = Mock()
+    pipeline.add_command_callback(cb)
+
+    pipeline._process_voice_command("hey")
+
+    cb.assert_not_called()
+    pipeline.tts.speak.assert_called_once_with("Failed to execute hello")
+
+
+def test_process_no_match_notifies_empty_and_speaks_apology():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    pipeline = make_pipeline(config_manager=config, voice_only=True)
+    install_fake_io(pipeline, transcription="banana split")
+    cb = Mock()
+    pipeline.add_command_callback(cb)
+
+    pipeline._process_voice_command("hey")
+
+    cb.assert_called_once_with("", "banana split")
+    pipeline.tts.speak.assert_called_once_with("Sorry, I didn't understand that")
+
+
+def test_process_recording_exception_swallowed():
+    state = Mock()
+    pipeline = make_pipeline(state_manager=state)
+    install_fake_io(pipeline)
+    pipeline.transcriber.record_and_transcribe.side_effect = RuntimeError("mic")
+    # Should not raise; processing flag reset in finally.
+    pipeline._process_voice_command("hey")
+    assert pipeline._processing is False
+
+
+def test_process_state_update_failures_swallowed_throughout():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    executor = Mock()
+    executor.execute_command.return_value = True
+    state = Mock()
+    state.change_state.side_effect = RuntimeError("state down")
+    pipeline = make_pipeline(
+        config_manager=config,
+        command_executor=executor,
+        state_manager=state,
+    )
+    install_fake_io(pipeline, transcription="hello there")
+    # All state.change_state calls raise but the flow completes.
+    pipeline._process_voice_command("hey")
+    executor.execute_command.assert_called_once_with("hello")
+    assert pipeline._processing is False
+
+
+def test_process_not_voice_only_skips_tts():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    executor = Mock()
+    executor.execute_command.return_value = True
+    pipeline = make_pipeline(
+        config_manager=config, command_executor=executor, voice_only=False
+    )
+    install_fake_io(pipeline, transcription="hello there")
+    pipeline._process_voice_command("hey")
+    pipeline.tts.speak.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _match_command
+# ---------------------------------------------------------------------------
+
+
+def test_match_command_no_config_manager():
+    pipeline = make_pipeline()
+    assert pipeline._match_command("hello") is None
+
+
+def test_match_command_empty_model_actions():
+    config = Mock()
+    config.model_actions = {}
+    pipeline = make_pipeline(config_manager=config)
+    assert pipeline._match_command("hello") is None
+
+
+def test_match_command_direct_whole_word():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    pipeline = make_pipeline(config_manager=config)
+    assert pipeline._match_command("please say hello now") == "hello"
+
+
+def test_match_command_avoids_substring_false_positive():
+    config = Mock()
+    config.model_actions = {"play": {}}
+    pipeline = make_pipeline(config_manager=config)
+    # "replay" should NOT match the single-word command "play".
+    assert pipeline._match_command("replay that") is None
+
+
+def test_match_command_multiword_phrase():
+    config = Mock()
+    config.model_actions = {"turn on": {}}
+    pipeline = make_pipeline(config_manager=config)
+    assert pipeline._match_command("please turn on the fan") == "turn on"
+    assert pipeline._match_command("turn the fan on") is None
+
+
+def test_match_command_keyword_fallback():
+    config = Mock()
+    config.model_actions = {"lights": {}}
+    pipeline = make_pipeline(config_manager=config)
+    # "lamp" is a keyword for "lights"; direct name "lights" not in transcript.
+    assert pipeline._match_command("switch on the lamp") == "lights"
+
+
+def test_match_command_empty_command_name_skipped():
+    config = Mock()
+    # An empty / whitespace-only command name exercises the early-return at
+    # line 249 (phrase is empty after strip).
+    config.model_actions = {"   ": {}, "hello": {}}
+    pipeline = make_pipeline(config_manager=config)
+    assert pipeline._match_command("say hello") == "hello"
+
+
+def test_match_command_punctuation_only_name_skipped():
+    config = Mock()
+    # A punctuation-only command name has no alphanumeric tokens, exercising
+    # the early-return at line 252.
+    config.model_actions = {"!!!": {}, "hello": {}}
+    pipeline = make_pipeline(config_manager=config)
+    assert pipeline._match_command("say hello") == "hello"
+    # And when nothing matches, returns None.
+    assert pipeline._match_command("!!!") is None
+
+
+def test_match_command_no_match_returns_none():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    pipeline = make_pipeline(config_manager=config)
+    assert pipeline._match_command("xyzzy") is None
+
+
+def test_match_command_handles_internal_exception():
+    config = Mock()
+    # model_actions.keys() raising forces the except path.
+    bad = Mock()
+    bad.keys.side_effect = RuntimeError("boom")
+    config.model_actions = bad
+    pipeline = make_pipeline(config_manager=config)
+    assert pipeline._match_command("hello") is None
+
+
+# ---------------------------------------------------------------------------
+# _execute_command
+# ---------------------------------------------------------------------------
+
+
+def test_execute_command_no_executor():
+    pipeline = make_pipeline()
+    assert pipeline._execute_command("hello") is False
+
+
+def test_execute_command_none_result_is_success():
+    executor = Mock()
+    executor.execute_command.return_value = None
+    pipeline = make_pipeline(command_executor=executor)
+    assert pipeline._execute_command("hello") is True
+
+
+def test_execute_command_false_result_is_failure():
+    executor = Mock()
+    executor.execute_command.return_value = False
+    pipeline = make_pipeline(command_executor=executor)
+    assert pipeline._execute_command("hello") is False
+
+
+def test_execute_command_exception_returns_false():
+    executor = Mock()
+    executor.execute_command.side_effect = RuntimeError("boom")
+    pipeline = make_pipeline(command_executor=executor)
+    assert pipeline._execute_command("hello") is False
+
+
+# ---------------------------------------------------------------------------
+# trigger_mock_wake_word
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_mock_wake_word_present():
+    pipeline = make_pipeline()
+    pipeline.wake_detector = Mock()
+    pipeline.trigger_mock_wake_word("hey_jarvis")
+    pipeline.wake_detector.trigger_wake_word.assert_called_once_with("hey_jarvis")
+
+
+def test_trigger_mock_wake_word_absent_logs_warning():
+    pipeline = make_pipeline()
+
+    # Detector without trigger_wake_word attribute.
+    class NoTrigger:
+        pass
+
+    pipeline.wake_detector = NoTrigger()
+    # Should not raise.
+    pipeline.trigger_mock_wake_word("hey")
+
+
+# ---------------------------------------------------------------------------
+# process_text_command
+# ---------------------------------------------------------------------------
+
+
+def test_process_text_command_success_returns_name():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    executor = Mock()
+    executor.execute_command.return_value = True
+    pipeline = make_pipeline(
+        config_manager=config, command_executor=executor, voice_only=True
+    )
+    install_fake_io(pipeline)
+    cb = Mock()
+    pipeline.add_command_callback(cb)
+    assert pipeline.process_text_command("say hello") == "hello"
+    cb.assert_called_once_with("hello", "say hello")
+    pipeline.tts.speak.assert_called_once_with("hello")
+
+
+def test_process_text_command_exec_failure_speaks_and_returns_none():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    executor = Mock()
+    executor.execute_command.return_value = False
+    pipeline = make_pipeline(
+        config_manager=config, command_executor=executor, voice_only=True
+    )
+    install_fake_io(pipeline)
+    assert pipeline.process_text_command("say hello") is None
+    pipeline.tts.speak.assert_called_once_with("Failed to execute hello")
+
+
+def test_process_text_command_no_match_speaks_apology():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    pipeline = make_pipeline(config_manager=config, voice_only=True)
+    install_fake_io(pipeline)
+    assert pipeline.process_text_command("xyzzy") is None
+    pipeline.tts.speak.assert_called_once_with("Sorry, I didn't understand that")
+
+
+def test_process_text_command_no_match_no_voice_only_silent():
+    config = Mock()
+    config.model_actions = {"hello": {}}
+    pipeline = make_pipeline(config_manager=config, voice_only=False)
+    install_fake_io(pipeline)
+    assert pipeline.process_text_command("xyzzy") is None
+    pipeline.tts.speak.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# status / is_listening
+# ---------------------------------------------------------------------------
+
+
+def test_get_status_with_mock_detector():
+    pipeline = make_pipeline(wake_words=["hey_jarvis"])
+    install_fake_io(pipeline)
+    status = pipeline.get_status()
+    assert set(status) == {
+        "listening",
+        "processing",
+        "wake_detector_available",
+        "transcriber_available",
+        "transcriber_info",
+        "available_wake_words",
+    }
+    assert status["listening"] is False
+    assert status["transcriber_available"] is True
+
+
+def test_get_status_detector_without_optional_methods():
+    pipeline = make_pipeline()
+    install_fake_io(pipeline)
+
+    class BareDetector:
+        pass
+
+    pipeline.wake_detector = BareDetector()
+    status = pipeline.get_status()
+    # Falls back to True / [] when methods are missing.
+    assert status["wake_detector_available"] is True
+    assert status["available_wake_words"] == []
+
+
+def test_is_listening_reflects_flags():
+    pipeline = make_pipeline()
+    assert pipeline.is_listening() is False
+    pipeline._listening = True
+    pipeline._processing = False
+    assert pipeline.is_listening() is True
+    pipeline._processing = True
+    assert pipeline.is_listening() is False


### PR DESCRIPTION
Four hermetic, **test-only** suites (no production source changed).

| Module | Before | After |
|---|---|---|
| llm/cli.py | 0% | **100%** |
| voice/cli.py | 0% | **100%** |
| voice/pipeline.py | 54% | **100%** |
| cli/cli.py | 45% | ~65% standalone (**86%** with existing cli tests) |

Real branches exercised — argparse + subcommand dispatch, each handler's happy/error/exception paths, mock-vs-real, command matching edges, TTS feedback, lifecycle — all deps mocked at the import boundary (no network/torch/onnx/audio).

**No production bugs surfaced.** Full suite **1321 passed, 1 skipped**; ruff clean. The cli loop test that looked flaky mid-workflow (a write race) verified stable under adverse ordering (3×). Test-only — Docker image unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)