### PR TITLE
WebRTC phase-0: activate call-state poller (track API) + live dashboard consumer

### DIFF
--- a/src/chatty_commander/integrations/dograh_call_state.py
+++ b/src/chatty_commander/integrations/dograh_call_state.py
@@ -289,3 +289,70 @@ _HOLDER = DograhCallStateHolder()
 def get_call_state_holder() -> DograhCallStateHolder:
     """Return the process-wide call-state holder."""
     return _HOLDER
+
+
+# --- Process-wide poller-lifecycle registry ------------------------------
+#
+# The poller's lifecycle (start/stop) lives on the WebModeServer instance,
+# but the HTTP route handlers in web/routes/dograh.py are module-level
+# functions with no clean reference to that instance. Mirroring the holder
+# pattern above, web_mode registers small start/stop callables here at
+# startup, and the track/untrack routes reach the poller through this
+# registry. This keeps the route layer decoupled from WebModeServer while
+# reusing the existing module-level-accessor convention.
+#
+# start callable: (workflow_id: int, run_id: int) -> None   (idempotent;
+#   re-track replaces the active poller)
+# stop callable:  () -> Awaitable[None] | None              (safe to call
+#   when nothing is tracked)
+
+StartPoller = Callable[[int, int], Awaitable[None] | None]
+StopPoller = Callable[[], Awaitable[None] | None]
+
+
+class DograhPollerRegistry:
+    """Holds the process-wide start/stop callables for the call-state poller.
+
+    Registered by WebModeServer at startup; consumed by the track/untrack
+    routes. When nothing is registered (e.g. a bare app without a running
+    WebModeServer) ``is_registered()`` is ``False`` and the routes report a
+    clear error rather than silently no-op'ing.
+    """
+
+    def __init__(self) -> None:
+        self._start: StartPoller | None = None
+        self._stop: StopPoller | None = None
+
+    def register(self, *, start: StartPoller, stop: StopPoller) -> None:
+        self._start = start
+        self._stop = stop
+
+    def clear(self) -> None:
+        self._start = None
+        self._stop = None
+
+    def is_registered(self) -> bool:
+        return self._start is not None and self._stop is not None
+
+    async def start(self, workflow_id: int, run_id: int) -> None:
+        if self._start is None:
+            raise RuntimeError("dograh poller lifecycle is not registered")
+        result = self._start(workflow_id, run_id)
+        if asyncio.iscoroutine(result):
+            await result
+
+    async def stop(self) -> None:
+        if self._stop is None:
+            raise RuntimeError("dograh poller lifecycle is not registered")
+        result = self._stop()
+        if asyncio.iscoroutine(result):
+            await result
+
+
+# Module-level singleton mirroring _HOLDER.
+_POLLER_REGISTRY = DograhPollerRegistry()
+
+
+def get_poller_registry() -> DograhPollerRegistry:
+    """Return the process-wide poller-lifecycle registry."""
+    return _POLLER_REGISTRY

--- a/src/chatty_commander/web/routes/dograh.py
+++ b/src/chatty_commander/web/routes/dograh.py
@@ -13,6 +13,12 @@ Routes:
     GET /api/v1/dograh/workflows  — list of workflow {id, name, status}
     GET /api/v1/dograh/call-state — current cached dograh call state (phase-0
                                     state bridge; read without a WS)
+    POST /api/v1/dograh/call-state/track   — start the call-state poller for
+                                    a {workflow_id, run_id} (503 if dograh
+                                    unconfigured; idempotent / re-track
+                                    replaces)
+    POST /api/v1/dograh/call-state/untrack — stop the call-state poller
+                                    (safe when not tracking)
 """
 
 from __future__ import annotations
@@ -20,7 +26,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -51,6 +57,19 @@ class DograhWorkflow(BaseModel):
     id: int
     name: str
     status: str | None = None
+
+
+class DograhTrackRequest(BaseModel):
+    """Body for POST /api/v1/dograh/call-state/track."""
+
+    workflow_id: int = Field(..., description="dograh workflow id to track")
+    run_id: int = Field(..., description="dograh workflow-run id to track")
+
+
+class DograhTrackResponse(BaseModel):
+    tracking: bool
+    workflow_id: int | None = Field(default=None)
+    run_id: int | None = Field(default=None)
 
 
 class DograhCallStateResponse(BaseModel):
@@ -94,6 +113,92 @@ async def get_dograh_call_state() -> DograhCallStateResponse:
         workflow_id=snapshot.workflow_id,
         run_id=snapshot.run_id,
     )
+
+
+def _assert_dograh_configured() -> None:
+    """Raise 503 unless DOGRAH_BASE_URL/API_KEY are set.
+
+    Reuses the same configuration check the status route relies on:
+    constructing a DograhClient raises DograhError (DograhUnavailableError)
+    when the env vars are missing. We immediately close the probe client —
+    the poller builds its own client server-side once tracking starts.
+    """
+    try:
+        from chatty_commander.integrations.dograh_client import (
+            DograhClient,
+            DograhError,
+        )
+    except ImportError as e:  # pragma: no cover - import guard
+        raise HTTPException(
+            status_code=503, detail=f"dograh integration unavailable: {e}"
+        ) from e
+
+    try:
+        client = DograhClient()
+    except DograhError as e:
+        # Unconfigured (or otherwise unusable) — clear 503 so callers know
+        # tracking can't start until dograh is configured.
+        raise HTTPException(status_code=503, detail=str(e)) from e
+    client.close()
+
+
+def _get_poller_registry():
+    from chatty_commander.integrations.dograh_call_state import (
+        get_poller_registry,
+    )
+
+    registry = get_poller_registry()
+    if not registry.is_registered():
+        # No WebModeServer has registered the poller lifecycle (e.g. a bare
+        # app). Tracking can't be driven, so surface a clear 503 rather than
+        # silently doing nothing.
+        raise HTTPException(
+            status_code=503,
+            detail="dograh call-state poller lifecycle is not available",
+        )
+    return registry
+
+
+@router.post(
+    "/api/v1/dograh/call-state/track",
+    response_model=DograhTrackResponse,
+)
+async def track_dograh_call_state(
+    body: DograhTrackRequest,
+) -> DograhTrackResponse:
+    """Begin tracking a dograh workflow-run's call state.
+
+    Starts the (otherwise dormant) call-state poller for ``{workflow_id,
+    run_id}``: the poller reflects mapped state into the in-memory holder
+    and broadcasts ``dograh_call_state`` over /ws. Idempotent — re-tracking
+    replaces any active poller so only the latest run is followed.
+
+    Returns 503 (clear error) when dograh is not configured or when no
+    server poller lifecycle is registered. Auth-gated like the other
+    /api/v1/dograh routes (the router carries no per-route auth; gating is
+    applied at the app/router level).
+    """
+    _assert_dograh_configured()
+    registry = _get_poller_registry()
+    await registry.start(body.workflow_id, body.run_id)
+    return DograhTrackResponse(
+        tracking=True, workflow_id=body.workflow_id, run_id=body.run_id
+    )
+
+
+@router.post(
+    "/api/v1/dograh/call-state/untrack",
+    response_model=DograhTrackResponse,
+)
+async def untrack_dograh_call_state() -> DograhTrackResponse:
+    """Stop tracking the current dograh workflow-run's call state.
+
+    Safe to call when nothing is being tracked (no-op). Does not require
+    dograh to be configured — stopping a poller never touches the network.
+    """
+    registry = _get_poller_registry()
+    await registry.stop()
+    return DograhTrackResponse(tracking=False)
 
 
 @router.get("/api/v1/dograh/status", response_model=DograhStatus)

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -441,6 +441,19 @@ class WebModeServer:
         async def start_telemetry_loop() -> None:
             self._telemetry_running = True
             self._telemetry_task = asyncio.create_task(self._telemetry_loop())
+            # Expose the dograh poller lifecycle to the module-level routes
+            # (POST /api/v1/dograh/call-state/track|untrack) via the shared
+            # registry, mirroring the get_call_state_holder() accessor. Routes
+            # cannot reach this server instance directly, so we register small
+            # bound callables here. Still dormant: nothing polls until /track.
+            from chatty_commander.integrations.dograh_call_state import (
+                get_poller_registry,
+            )
+
+            get_poller_registry().register(
+                start=self._track_dograh_run,
+                stop=self.stop_dograh_call_poller,
+            )
 
         @self.app.on_event("shutdown")
         async def stop_telemetry_loop() -> None:
@@ -452,6 +465,14 @@ class WebModeServer:
                 except asyncio.CancelledError:
                     pass
             self._telemetry_task = None
+            # Ensure any active call-state poller is torn down and the shared
+            # registry no longer points at this (now-stopped) server.
+            await self.stop_dograh_call_poller()
+            from chatty_commander.integrations.dograh_call_state import (
+                get_poller_registry,
+            )
+
+            get_poller_registry().clear()
 
     async def _telemetry_loop(self) -> None:
         """Background task to broadcast system telemetry.
@@ -1033,6 +1054,25 @@ class WebModeServer:
         poller.start()
         self._dograh_call_poller = poller
         return poller
+
+    async def _track_dograh_run(self, workflow_id: int, run_id: int) -> None:
+        """Start (or replace) the call-state poller for one workflow-run.
+
+        Registered with the module-level poller registry at startup so the
+        POST /api/v1/dograh/call-state/track route can drive it. Constructs
+        a fresh DograhClient from the environment (the route has already
+        verified dograh is configured) and hands it to
+        start_dograh_call_poller. Idempotent in the re-track sense: any
+        existing poller is stopped before the new one starts, so the latest
+        track call wins and only one poller is ever active.
+        """
+        from chatty_commander.integrations.dograh_client import DograhClient
+
+        # Re-track replaces: tear down the previous run's poller first so we
+        # never leak a second polling task or interleave two runs' broadcasts.
+        await self.stop_dograh_call_poller()
+        client = DograhClient()
+        self.start_dograh_call_poller(client, workflow_id, run_id)
 
     async def stop_dograh_call_poller(self) -> None:
         """Cancel any running dograh call-state poller."""

--- a/tests/test_dograh_call_state_track.py
+++ b/tests/test_dograh_call_state_track.py
@@ -1,0 +1,240 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+
+"""Tests for the dograh call-state track/untrack routes and the poller
+lifecycle registry that wires them to the (otherwise dormant) poller.
+
+No real network and no real sleeps: the dograh client is faked and the
+poller is driven via the injectable registry / a manual poll_once.
+
+Contract under test:
+    POST /api/v1/dograh/call-state/track   {workflow_id, run_id}
+        -> 200 {tracking: true, workflow_id, run_id}  (starts poller)
+        -> 503 when dograh is unconfigured
+    POST /api/v1/dograh/call-state/untrack
+        -> 200 {tracking: false}  (stops poller; safe when not tracking)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from chatty_commander.integrations.dograh_call_state import (
+    CALL_STATE_RINGING,
+    CALL_STATE_UNKNOWN,
+    DograhCallState,
+    get_call_state_holder,
+    get_poller_registry,
+)
+from chatty_commander.integrations.dograh_client import DograhUnavailableError
+from chatty_commander.web.routes.dograh import router
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    get_call_state_holder().set(DograhCallState())
+    get_poller_registry().clear()
+    yield
+    get_call_state_holder().set(DograhCallState())
+    get_poller_registry().clear()
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _register_recording_registry() -> dict:
+    """Register fake start/stop callables; return a dict recording calls."""
+    calls: dict = {"started": [], "stopped": 0}
+
+    def _start(workflow_id: int, run_id: int) -> None:
+        calls["started"].append((workflow_id, run_id))
+
+    async def _stop() -> None:
+        calls["stopped"] += 1
+
+    get_poller_registry().register(start=_start, stop=_stop)
+    return calls
+
+
+class TestTrackRoute:
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_track_starts_poller(self, mock_cls):
+        # Configured dograh: probe client constructs fine.
+        mock_cls.return_value = MagicMock()
+        calls = _register_recording_registry()
+
+        r = _client().post(
+            "/api/v1/dograh/call-state/track",
+            json={"workflow_id": 7, "run_id": 11},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"tracking": True, "workflow_id": 7, "run_id": 11}
+        assert calls["started"] == [(7, 11)]
+
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_retrack_replaces(self, mock_cls):
+        mock_cls.return_value = MagicMock()
+        calls = _register_recording_registry()
+
+        c = _client()
+        c.post(
+            "/api/v1/dograh/call-state/track",
+            json={"workflow_id": 1, "run_id": 1},
+        )
+        r = c.post(
+            "/api/v1/dograh/call-state/track",
+            json={"workflow_id": 2, "run_id": 2},
+        )
+        assert r.status_code == 200
+        # Both starts recorded; the server-side _track_dograh_run stops the
+        # previous poller before starting the next (covered by the e2e test).
+        assert calls["started"] == [(1, 1), (2, 2)]
+
+    @patch(
+        "chatty_commander.integrations.dograh_client.DograhConfig.from_env",
+        side_effect=DograhUnavailableError("DOGRAH_BASE_URL not set"),
+    )
+    def test_track_503_when_unconfigured(self, _mock, monkeypatch):
+        monkeypatch.delenv("DOGRAH_BASE_URL", raising=False)
+        monkeypatch.delenv("DOGRAH_API_KEY", raising=False)
+        # Registry registered, but config check fails first -> 503.
+        _register_recording_registry()
+
+        r = _client().post(
+            "/api/v1/dograh/call-state/track",
+            json={"workflow_id": 1, "run_id": 1},
+        )
+        assert r.status_code == 503
+        assert "DOGRAH_BASE_URL" in r.json()["detail"]
+
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_track_503_when_no_lifecycle_registered(self, mock_cls):
+        # Dograh configured but no WebModeServer registered the lifecycle.
+        mock_cls.return_value = MagicMock()
+        # Registry intentionally left cleared by the fixture.
+        r = _client().post(
+            "/api/v1/dograh/call-state/track",
+            json={"workflow_id": 1, "run_id": 1},
+        )
+        assert r.status_code == 503
+
+    def test_track_validates_body(self):
+        # Missing run_id -> 422 from pydantic before any work.
+        r = _client().post(
+            "/api/v1/dograh/call-state/track",
+            json={"workflow_id": 1},
+        )
+        assert r.status_code == 422
+
+
+class TestUntrackRoute:
+    def test_untrack_stops_poller(self):
+        calls = _register_recording_registry()
+        r = _client().post("/api/v1/dograh/call-state/untrack")
+        assert r.status_code == 200
+        assert r.json() == {"tracking": False, "workflow_id": None, "run_id": None}
+        assert calls["stopped"] == 1
+
+    def test_untrack_does_not_require_dograh_configured(self):
+        # No DograhClient patch, no env: untrack never touches the network.
+        _register_recording_registry()
+        r = _client().post("/api/v1/dograh/call-state/untrack")
+        assert r.status_code == 200
+
+    def test_untrack_503_when_no_lifecycle_registered(self):
+        r = _client().post("/api/v1/dograh/call-state/untrack")
+        assert r.status_code == 503
+
+
+class TestEndToEndViaServer:
+    """Exercise the real WebModeServer poller lifecycle through the registry,
+    with a fake DograhClient so no network/sleep occurs."""
+
+    @pytest.mark.asyncio
+    async def test_track_polls_and_broadcasts_mapped_state(self):
+        from chatty_commander.web.web_mode import WebModeServer
+
+        server = WebModeServer.__new__(WebModeServer)
+        server._dograh_call_poller = None
+        broadcast: list = []
+
+        async def fake_broadcast(msg):
+            broadcast.append(msg)
+
+        server._broadcast_message = fake_broadcast  # type: ignore[assignment]
+
+        class FakeClient:
+            def get_workflow_run(self, *_):
+                return {"state": "ringing"}
+
+        with patch(
+            "chatty_commander.integrations.dograh_client.DograhClient",
+            return_value=FakeClient(),
+        ):
+            await server._track_dograh_run(9, 13)
+            poller = server._dograh_call_poller
+            assert poller is not None
+            try:
+                changed = await poller.poll_once()
+                assert changed is True
+                # Holder + broadcast reflect mapped CC call state.
+                snap = get_call_state_holder().get()
+                assert snap.state == CALL_STATE_RINGING
+                assert snap.workflow_id == 9 and snap.run_id == 13
+                assert len(broadcast) == 1
+                assert broadcast[0].type == "dograh_call_state"
+                assert broadcast[0].data["state"] == CALL_STATE_RINGING
+            finally:
+                await server.stop_dograh_call_poller()
+
+    @pytest.mark.asyncio
+    async def test_retrack_replaces_active_poller(self):
+        from chatty_commander.web.web_mode import WebModeServer
+
+        server = WebModeServer.__new__(WebModeServer)
+        server._dograh_call_poller = None
+
+        async def fake_broadcast(msg):
+            pass
+
+        server._broadcast_message = fake_broadcast  # type: ignore[assignment]
+
+        class FakeClient:
+            def get_workflow_run(self, *_):
+                return {"state": "ringing"}
+
+        with patch(
+            "chatty_commander.integrations.dograh_client.DograhClient",
+            return_value=FakeClient(),
+        ):
+            await server._track_dograh_run(1, 1)
+            first = server._dograh_call_poller
+            await server._track_dograh_run(2, 2)
+            second = server._dograh_call_poller
+            try:
+                # A new poller object replaced the first; the first was stopped.
+                assert first is not second
+                assert second is not None
+                assert second.current.workflow_id == 2
+            finally:
+                await server.stop_dograh_call_poller()
+                assert server._dograh_call_poller is None
+
+    @pytest.mark.asyncio
+    async def test_untrack_safe_when_not_tracking(self):
+        from chatty_commander.web.web_mode import WebModeServer
+
+        server = WebModeServer.__new__(WebModeServer)
+        server._dograh_call_poller = None
+        # No poller active: stop is a clean no-op.
+        await server.stop_dograh_call_poller()
+        assert server._dograh_call_poller is None
+        assert get_call_state_holder().get().state == CALL_STATE_UNKNOWN

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -540,10 +540,11 @@ class TestServerImportSafety:
             app = server_module.create_app()
             assert isinstance(app, FastAPI)
             route_count = len(app.routes)
-            # dograh_router stays registered here and now carries three
-            # routes (status, workflows, call-state); the phase-0 call-state
-            # read route bumped the baseline from 12 to 13.
-            assert route_count <= 13
+            # dograh_router stays registered here and now carries five
+            # routes (status, workflows, call-state read, plus the
+            # call-state track/untrack POSTs); the track/untrack routes
+            # bumped the baseline from 13 to 15.
+            assert route_count <= 15
         finally:
             for key, value in original_globals.items():
                 setattr(server_module, key, value)

--- a/webui/frontend/src/components/CallStateBadge.tsx
+++ b/webui/frontend/src/components/CallStateBadge.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { PhoneIncoming, PhoneCall, PhoneOff } from "lucide-react";
+
+export type DograhCallState = "ringing" | "in_call" | "ended" | "unknown";
+
+export interface DograhCallStatePayload {
+  state: DograhCallState;
+  workflow_id: number | null;
+  run_id: number | null;
+}
+
+interface CallStateBadgeProps {
+  call: DograhCallStatePayload | null;
+}
+
+const CONFIG: Record<
+  Exclude<DograhCallState, "unknown">,
+  { label: string; badge: string; text: string; Icon: typeof PhoneCall; pulse: boolean }
+> = {
+  ringing: {
+    label: "Ringing",
+    badge: "badge-warning",
+    text: "text-warning",
+    Icon: PhoneIncoming,
+    pulse: true,
+  },
+  in_call: {
+    label: "In call",
+    badge: "badge-success",
+    text: "text-success",
+    Icon: PhoneCall,
+    pulse: true,
+  },
+  ended: {
+    label: "Call ended",
+    badge: "badge-ghost",
+    text: "text-base-content/60",
+    Icon: PhoneOff,
+    pulse: false,
+  },
+};
+
+/**
+ * Compact live indicator for the Dograh call state broadcast over /ws.
+ *
+ * Reflects whatever the backend broadcasts via the
+ * {type:'dograh_call_state', data:{state, workflow_id, run_id}} message.
+ * When there is no active call (state 'unknown' or no payload yet) the badge
+ * renders nothing so the dashboard stays unobtrusive.
+ */
+const CallStateBadge = React.memo(({ call }: CallStateBadgeProps) => {
+  const state = call?.state ?? "unknown";
+
+  // Idle / no active call: stay out of the way.
+  if (state === "unknown") {
+    return null;
+  }
+
+  const cfg = CONFIG[state];
+  const { Icon } = cfg;
+
+  // motion-safe: prefers-reduced-motion users get a static badge.
+  const animate = cfg.pulse ? "motion-safe:animate-pulse" : "";
+
+  const subtitle =
+    call?.workflow_id != null
+      ? `wf ${call.workflow_id}${call.run_id != null ? ` · run ${call.run_id}` : ""}`
+      : null;
+
+  return (
+    <div
+      className="stats shadow bg-base-100 border border-base-content/10"
+      data-testid="dograh-call-state"
+      data-call-state={state}
+    >
+      <div className="stat">
+        <div className={`stat-figure ${cfg.text} ${animate}`} aria-hidden="true">
+          <Icon size={32} />
+        </div>
+        <div className="stat-title flex items-center gap-2">
+          Dograh Call
+          <span className={`badge ${cfg.badge} badge-sm`}>{cfg.label.toLowerCase()}</span>
+        </div>
+        <div className={`stat-value text-2xl ${cfg.text}`}>{cfg.label}</div>
+        <div className="stat-desc">{subtitle ?? "Live call status"}</div>
+      </div>
+    </div>
+  );
+});
+
+CallStateBadge.displayName = "CallStateBadge";
+
+export default CallStateBadge;

--- a/webui/frontend/src/pages/DashboardPage.callState.test.tsx
+++ b/webui/frontend/src/pages/DashboardPage.callState.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+import DashboardPage from "./DashboardPage";
+
+// A minimal WebSocket stub that lets the test push message frames.
+class FakeWebSocket {
+  listeners: Record<string, ((ev: any) => void)[]> = {};
+  addEventListener(type: string, cb: (ev: any) => void) {
+    (this.listeners[type] ??= []).push(cb);
+  }
+  removeEventListener(type: string, cb: (ev: any) => void) {
+    this.listeners[type] = (this.listeners[type] ?? []).filter((c) => c !== cb);
+  }
+  emit(data: unknown) {
+    const payload = JSON.stringify(data);
+    (this.listeners["message"] ?? []).forEach((cb) => cb({ data: payload }));
+  }
+}
+
+const fakeWs = new FakeWebSocket();
+
+vi.mock("../components/WebSocketProvider", () => ({
+  useWebSocket: () => ({
+    ws: fakeWs,
+    isConnected: true,
+    reconnectAttempt: 0,
+    lastMessageTime: null,
+  }),
+}));
+
+const jsonResponse = (data: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => data,
+});
+
+let callStateSeed: unknown = { state: "unknown", workflow_id: null, run_id: null };
+
+beforeEach(() => {
+  global.fetch = vi.fn(async (input: any) => {
+    const url = String(input);
+    if (url.includes("/dograh/call-state")) {
+      return jsonResponse(callStateSeed);
+    }
+    if (url.includes("/health")) {
+      return jsonResponse({
+        status: "healthy",
+        uptime: "1h",
+        commands_executed: 0,
+        cpu_usage: "1",
+        memory_usage: "1",
+      });
+    }
+    if (url.includes("/dograh/")) {
+      return jsonResponse({ available: false, reason: "not configured", health: null });
+    }
+    return jsonResponse({});
+  }) as any;
+});
+
+function renderDashboard() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <DashboardPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("DashboardPage dograh call state", () => {
+  test("stays hidden when there is no active call (unknown)", async () => {
+    callStateSeed = { state: "unknown", workflow_id: null, run_id: null };
+    renderDashboard();
+
+    await screen.findByText("Healthy");
+    expect(screen.queryByTestId("dograh-call-state")).not.toBeInTheDocument();
+  });
+
+  test("seeds from GET /api/v1/dograh/call-state on mount", async () => {
+    callStateSeed = { state: "ringing", workflow_id: 7, run_id: 99 };
+    renderDashboard();
+
+    const badge = await screen.findByTestId("dograh-call-state");
+    expect(badge).toHaveAttribute("data-call-state", "ringing");
+    expect(screen.getByText("Ringing")).toBeInTheDocument();
+    expect(
+      (global.fetch as any).mock.calls.some((c: any[]) =>
+        String(c[0]).includes("/api/v1/dograh/call-state"),
+      ),
+    ).toBe(true);
+  });
+
+  test("updates live from the dograh_call_state WS frame (ringing -> in_call -> ended)", async () => {
+    callStateSeed = { state: "unknown", workflow_id: null, run_id: null };
+    renderDashboard();
+    await screen.findByText("Healthy");
+
+    act(() => {
+      fakeWs.emit({
+        type: "dograh_call_state",
+        data: { state: "ringing", workflow_id: 1, run_id: 2 },
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("dograh-call-state")).toHaveAttribute("data-call-state", "ringing"),
+    );
+
+    act(() => {
+      fakeWs.emit({
+        type: "dograh_call_state",
+        data: { state: "in_call", workflow_id: 1, run_id: 2 },
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("dograh-call-state")).toHaveAttribute("data-call-state", "in_call"),
+    );
+    expect(screen.getByText("In call")).toBeInTheDocument();
+
+    act(() => {
+      fakeWs.emit({
+        type: "dograh_call_state",
+        data: { state: "ended", workflow_id: 1, run_id: 2 },
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("dograh-call-state")).toHaveAttribute("data-call-state", "ended"),
+    );
+    expect(screen.getByText("Call ended")).toBeInTheDocument();
+  });
+});

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -6,6 +6,7 @@ import { apiService } from "../services/apiService";
 import { fetchAgentStatus, Agent } from "../services/api";
 import { formatTimestamp } from "../utils/formatTime";
 import DograhStatusCard from "../components/DograhStatusCard";
+import CallStateBadge, { DograhCallStatePayload } from "../components/CallStateBadge";
 import type { PerfMetric } from "../components/PerformanceChart";
 
 // Lazy-load the recharts-backed chart so the heavy charting bundle is split out
@@ -96,6 +97,26 @@ const DashboardPage = React.memo(() => {
   const [realtimeStatus, setRealtimeStatus] = useState<any>(null);
   const systemStatus = useMemo(() => ({ ...initialSystemStatus, ...realtimeStatus }), [initialSystemStatus, realtimeStatus]);
 
+  // Live Dograh call state. Seed from the cached snapshot on mount so the badge
+  // reflects the last known state before any WS frame arrives, then let the
+  // 'dograh_call_state' WS message drive subsequent updates.
+  const [callState, setCallState] = useState<DograhCallStatePayload | null>(null);
+  const { data: seededCallState } = useQuery<DograhCallStatePayload | null>({
+    queryKey: ["dograh", "callState"],
+    queryFn: async () => {
+      const res = await fetch("/api/v1/dograh/call-state");
+      if (!res.ok) return null;
+      return (await res.json()) as DograhCallStatePayload;
+    },
+    retry: false,
+  });
+  useEffect(() => {
+    // Only seed while we have not yet received a live WS frame.
+    if (seededCallState) {
+      setCallState((prev) => prev ?? seededCallState);
+    }
+  }, [seededCallState]);
+
   // Update history chart from telemetry
   useEffect(() => {
     if (systemStatus && !isPaused) {
@@ -154,6 +175,14 @@ const DashboardPage = React.memo(() => {
           cpu: msg.data.cpu !== undefined ? `${Number(msg.data.cpu).toFixed(1)}` : prev?.cpu,
           memory: msg.data.memory !== undefined ? `${Number(msg.data.memory).toFixed(1)}` : prev?.memory,
         }));
+        return;
+      }
+      if (msg.type === "dograh_call_state" && msg.data) {
+        setCallState({
+          state: msg.data.state ?? "unknown",
+          workflow_id: msg.data.workflow_id ?? null,
+          run_id: msg.data.run_id ?? null,
+        });
         return;
       }
       // Fallback for non-JSON or other messages
@@ -289,6 +318,8 @@ const DashboardPage = React.memo(() => {
         </div>
 
         <DograhStatusCard />
+
+        <CallStateBadge call={callState} />
       </div>
 
       {/* Real-time Performance History Chart */}


### PR DESCRIPTION
Completes the phase-0 activation roadmap item: the dormant dograh call-state bridge (#680) is now drivable end-to-end and shown live on the dashboard.

## Backend — activation
- `POST /api/v1/dograh/call-state/track {workflow_id, run_id}` starts the poller (idempotent — re-track replaces); `POST .../untrack` stops it (safe when idle).
- Routes reach the WebModeServer poller lifecycle via a new module-level `DograhPollerRegistry` (mirrors the existing `get_call_state_holder` pattern); web_mode registers start/stop at startup, tears down at shutdown.
- track returns **503 when dograh is unconfigured**; default + --no-auth unchanged; nothing polls until track is called.

## Frontend — live consumer
- `CallStateBadge` surfaces the `dograh_call_state` WS broadcast (ringing/in_call/ended; hidden when unknown). DashboardPage seeds from `GET /api/v1/dograh/call-state` on mount, updates live from WS. Pulse gated behind `motion-safe` (respects prefers-reduced-motion).

## Evidence
- pytest green; ruff + mypy clean; vitest **72** (+3); tsc clean; build green
- **Docker-proven**: `/health` 200, `/call-state` → default, `/track` → **503 (unconfigured, gating works)**, `/untrack` → 200

Remaining phase-0 follow-up (needs a live dograh): confirm the run-state field/vocabulary (two constants in `dograh_call_state.py`), then a real call drives the badge automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)