### PR TITLE
Coverage: voice self_test, enhanced_processor, orchestrator, transcription

### DIFF
--- a/tests/test_enhanced_processor_coverage.py
+++ b/tests/test_enhanced_processor_coverage.py
@@ -1,0 +1,739 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+"""Coverage tests for src/chatty_commander/voice/enhanced_processor.py.
+
+All external deps (whisper, speech_recognition, webrtcvad, noisereduce,
+pvporcupine, pyaudio, librosa, scipy) are imported lazily inside methods,
+so we mock them at the import boundary via sys.modules and by overriding
+component attributes after construction. No real models/devices are used.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from chatty_commander.voice.enhanced_processor import (
+    EnhancedVoiceProcessor,
+    VoiceProcessingConfig,
+    VoiceResult,
+    create_enhanced_voice_processor,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bare_processor(**config_kwargs) -> EnhancedVoiceProcessor:
+    """Construct a processor while neutralising the import-heavy init steps.
+
+    Each test that exercises a specific init branch patches it explicitly;
+    here we stub _initialize_components so the object is cheap to build.
+    """
+    config = VoiceProcessingConfig(**config_kwargs)
+    with mock.patch.object(EnhancedVoiceProcessor, "_initialize_components"):
+        return EnhancedVoiceProcessor(config)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults():
+    cfg = VoiceProcessingConfig()
+    assert cfg.sample_rate == 16000
+    assert cfg.chunk_size == 1024
+    assert cfg.confidence_threshold == 0.7
+    assert cfg.voice_activity_detection is True
+
+
+def test_voice_result_optional_fields():
+    r = VoiceResult(text="hi", confidence=0.5, duration=1.0, timestamp=datetime.now())
+    assert r.language is None
+    assert r.intent is None
+    assert r.wake_word_detected is False
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def test_factory_maps_config_keys():
+    with mock.patch.object(EnhancedVoiceProcessor, "_initialize_components"):
+        proc = create_enhanced_voice_processor(
+            {
+                "sample_rate": 8000,
+                "chunk_size": 512,
+                "noise_reduction": False,
+                "vad": False,
+                "confidence_threshold": 0.4,
+                "silence_timeout": 1.5,
+                "max_duration": 10.0,
+            }
+        )
+    assert proc.config.sample_rate == 8000
+    assert proc.config.chunk_size == 512
+    assert proc.config.noise_reduction_enabled is False
+    assert proc.config.voice_activity_detection is False
+    assert proc.config.confidence_threshold == 0.4
+    assert proc.config.silence_timeout == 1.5
+    assert proc.config.max_recording_duration == 10.0
+
+
+def test_factory_uses_defaults_for_empty_config():
+    with mock.patch.object(EnhancedVoiceProcessor, "_initialize_components"):
+        proc = create_enhanced_voice_processor({})
+    assert proc.config.sample_rate == 16000
+    assert proc.config.noise_reduction_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# _initialize_components orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_components_calls_enabled_subinits():
+    cfg = VoiceProcessingConfig(
+        noise_reduction_enabled=True, voice_activity_detection=True
+    )
+    with (
+        mock.patch.object(EnhancedVoiceProcessor, "_initialize_noise_reduction") as nr,
+        mock.patch.object(EnhancedVoiceProcessor, "_initialize_vad") as vad,
+        mock.patch.object(EnhancedVoiceProcessor, "_initialize_transcription") as tr,
+        mock.patch.object(
+            EnhancedVoiceProcessor, "_initialize_wake_word_detection"
+        ) as ww,
+    ):
+        EnhancedVoiceProcessor(cfg)
+    nr.assert_called_once()
+    vad.assert_called_once()
+    tr.assert_called_once()
+    ww.assert_called_once()
+
+
+def test_initialize_components_skips_disabled_features():
+    cfg = VoiceProcessingConfig(
+        noise_reduction_enabled=False, voice_activity_detection=False
+    )
+    with (
+        mock.patch.object(EnhancedVoiceProcessor, "_initialize_noise_reduction") as nr,
+        mock.patch.object(EnhancedVoiceProcessor, "_initialize_vad") as vad,
+        mock.patch.object(EnhancedVoiceProcessor, "_initialize_transcription"),
+        mock.patch.object(EnhancedVoiceProcessor, "_initialize_wake_word_detection"),
+    ):
+        EnhancedVoiceProcessor(cfg)
+    nr.assert_not_called()
+    vad.assert_not_called()
+
+
+def test_initialize_components_swallows_exceptions():
+    cfg = VoiceProcessingConfig()
+    with mock.patch.object(
+        EnhancedVoiceProcessor,
+        "_initialize_noise_reduction",
+        side_effect=RuntimeError("boom"),
+    ):
+        # Should not raise; error path logs and returns.
+        proc = EnhancedVoiceProcessor(cfg)
+    assert isinstance(proc, EnhancedVoiceProcessor)
+
+
+# ---------------------------------------------------------------------------
+# _initialize_noise_reduction
+# ---------------------------------------------------------------------------
+
+
+def test_noise_reduction_uses_noisereduce_when_available():
+    proc = _bare_processor()
+    fake_nr = types.ModuleType("noisereduce")
+    with mock.patch.dict(sys.modules, {"noisereduce": fake_nr}):
+        proc._initialize_noise_reduction()
+    assert proc.noise_reducer is fake_nr
+
+
+def test_noise_reduction_falls_back_on_import_error():
+    proc = _bare_processor()
+    with mock.patch.dict(sys.modules, {"noisereduce": None}):
+        proc._initialize_noise_reduction()
+    assert proc.noise_reducer == proc._basic_noise_reduction
+
+
+# ---------------------------------------------------------------------------
+# _initialize_vad
+# ---------------------------------------------------------------------------
+
+
+def test_vad_uses_webrtcvad_when_available():
+    proc = _bare_processor()
+    fake_mod = types.ModuleType("webrtcvad")
+    sentinel = object()
+    fake_mod.Vad = mock.Mock(return_value=sentinel)
+    with mock.patch.dict(sys.modules, {"webrtcvad": fake_mod}):
+        proc._initialize_vad()
+    assert proc.vad is sentinel
+    fake_mod.Vad.assert_called_once_with(2)
+
+
+def test_vad_falls_back_on_import_error():
+    proc = _bare_processor()
+    with mock.patch.dict(sys.modules, {"webrtcvad": None}):
+        proc._initialize_vad()
+    assert proc.vad == proc._energy_based_vad
+
+
+def test_vad_falls_back_on_generic_exception():
+    proc = _bare_processor()
+    fake_mod = types.ModuleType("webrtcvad")
+    fake_mod.Vad = mock.Mock(side_effect=RuntimeError("device error"))
+    with mock.patch.dict(sys.modules, {"webrtcvad": fake_mod}):
+        proc._initialize_vad()
+    assert proc.vad == proc._energy_based_vad
+
+
+# ---------------------------------------------------------------------------
+# _initialize_transcription
+# ---------------------------------------------------------------------------
+
+
+def test_transcription_prefers_whisper():
+    proc = _bare_processor()
+    fake_whisper = types.ModuleType("whisper")
+    model = object()
+    fake_whisper.load_model = mock.Mock(return_value=model)
+    with mock.patch.dict(sys.modules, {"whisper": fake_whisper}):
+        proc._initialize_transcription()
+    assert proc.transcription_method == "whisper"
+    assert proc.transcriber is model
+    fake_whisper.load_model.assert_called_once_with("base")
+
+
+def test_transcription_falls_back_to_speech_recognition():
+    proc = _bare_processor()
+    fake_sr = types.ModuleType("speech_recognition")
+    rec = object()
+    fake_sr.Recognizer = mock.Mock(return_value=rec)
+    with mock.patch.dict(
+        sys.modules, {"whisper": None, "speech_recognition": fake_sr}
+    ):
+        proc._initialize_transcription()
+    assert proc.transcription_method == "speech_recognition"
+    assert proc.transcriber is rec
+
+
+def test_transcription_ultimate_fallback_none():
+    proc = _bare_processor()
+    with mock.patch.dict(
+        sys.modules, {"whisper": None, "speech_recognition": None}
+    ):
+        proc._initialize_transcription()
+    assert proc.transcription_method == "none"
+    assert proc.transcriber is None
+
+
+# ---------------------------------------------------------------------------
+# _initialize_wake_word_detection
+# ---------------------------------------------------------------------------
+
+
+def test_wake_word_uses_porcupine_when_spec_found():
+    proc = _bare_processor()
+    with mock.patch("importlib.util.find_spec", return_value=object()):
+        proc._initialize_wake_word_detection()
+    assert proc.wake_word_detector == "porcupine"
+
+
+def test_wake_word_falls_back_to_simple_when_spec_missing():
+    proc = _bare_processor()
+    with mock.patch("importlib.util.find_spec", return_value=None):
+        proc._initialize_wake_word_detection()
+    assert proc.wake_word_detector == "simple"
+
+
+# ---------------------------------------------------------------------------
+# _basic_noise_reduction
+# ---------------------------------------------------------------------------
+
+
+def test_basic_noise_reduction_filters_audio():
+    # scipy.signal is imported lazily inside the method. Mock it at the import
+    # boundary so this test is hermetic and independent of the real scipy/numpy
+    # module state (which sibling test files may patch in sys.modules).
+    proc = _bare_processor(sample_rate=16000)
+    audio = np.zeros(2048, dtype=np.float64)
+
+    fake_scipy = types.ModuleType("scipy")
+    fake_signal = types.ModuleType("scipy.signal")
+    fake_signal.butter = mock.Mock(return_value=("b", "a"))
+    fake_signal.filtfilt = mock.Mock(return_value=audio)
+    fake_scipy.signal = fake_signal
+    with mock.patch.dict(
+        sys.modules, {"scipy": fake_scipy, "scipy.signal": fake_signal}
+    ):
+        out = proc._basic_noise_reduction(audio)
+
+    fake_signal.butter.assert_called_once_with(
+        4, 300, btype="high", fs=proc.config.sample_rate
+    )
+    fake_signal.filtfilt.assert_called_once()
+    assert out.shape == audio.shape
+
+
+# ---------------------------------------------------------------------------
+# _energy_based_vad
+# ---------------------------------------------------------------------------
+
+
+def test_energy_based_vad_detects_speech_above_threshold():
+    proc = _bare_processor()
+    loud = (np.ones(320, dtype=np.int16) * 5000).tobytes()
+    assert proc._energy_based_vad(loud) is True
+
+
+def test_energy_based_vad_silence_below_threshold():
+    proc = _bare_processor()
+    quiet = np.zeros(320, dtype=np.int16).tobytes()
+    assert proc._energy_based_vad(quiet) is False
+
+
+# ---------------------------------------------------------------------------
+# _detect_wake_words
+# ---------------------------------------------------------------------------
+
+
+def test_detect_wake_words_matches_multiple():
+    proc = _bare_processor()
+    detected = proc._detect_wake_words("Hey Chatty, wake the COMPUTER")
+    assert "hey chatty" in detected
+    assert "chatty" in detected
+    assert "computer" in detected
+
+
+def test_detect_wake_words_none_present():
+    proc = _bare_processor()
+    assert proc._detect_wake_words("just some unrelated words") == []
+
+
+# ---------------------------------------------------------------------------
+# _transcribe_audio
+# ---------------------------------------------------------------------------
+
+
+def test_transcribe_audio_whisper_path():
+    proc = _bare_processor()
+    proc.transcription_method = "whisper"
+    proc.transcriber = mock.Mock()
+    proc.transcriber.transcribe.return_value = {
+        "text": "  hey chatty  ",
+        "language": "en",
+    }
+    result = proc._transcribe_audio(np.zeros(16000, dtype=np.float32))
+    assert result.text == "hey chatty"
+    assert result.confidence == 0.9
+    assert result.language == "en"
+    assert result.wake_word_detected is True
+
+
+def test_transcribe_audio_whisper_missing_language_defaults_en():
+    proc = _bare_processor()
+    proc.transcription_method = "whisper"
+    proc.transcriber = mock.Mock()
+    proc.transcriber.transcribe.return_value = {"text": "nothing special"}
+    result = proc._transcribe_audio(np.zeros(10, dtype=np.float32))
+    assert result.language == "en"
+    assert result.wake_word_detected is False
+
+
+def test_transcribe_audio_speech_recognition_success():
+    proc = _bare_processor()
+    proc.transcription_method = "speech_recognition"
+    recognizer = mock.Mock()
+    recognizer.recognize_google.return_value = "computer listen"
+    proc.transcriber = recognizer
+
+    fake_sr = types.ModuleType("speech_recognition")
+    fake_sr.AudioData = mock.Mock(return_value="audio-obj")
+    fake_sr.UnknownValueError = type("UnknownValueError", (Exception,), {})
+    fake_sr.RequestError = type("RequestError", (Exception,), {})
+    with mock.patch.dict(sys.modules, {"speech_recognition": fake_sr}):
+        result = proc._transcribe_audio(np.zeros(10, dtype=np.int16))
+    assert result.text == "computer listen"
+    assert result.confidence == 0.8
+    assert result.wake_word_detected is True
+
+
+def test_transcribe_audio_speech_recognition_unknown_value():
+    proc = _bare_processor()
+    proc.transcription_method = "speech_recognition"
+    fake_sr = types.ModuleType("speech_recognition")
+    fake_sr.AudioData = mock.Mock(return_value="audio-obj")
+    fake_sr.UnknownValueError = type("UnknownValueError", (Exception,), {})
+    fake_sr.RequestError = type("RequestError", (Exception,), {})
+    recognizer = mock.Mock()
+    recognizer.recognize_google.side_effect = fake_sr.UnknownValueError()
+    proc.transcriber = recognizer
+    with mock.patch.dict(sys.modules, {"speech_recognition": fake_sr}):
+        result = proc._transcribe_audio(np.zeros(10, dtype=np.int16))
+    assert result.text == ""
+    assert result.confidence == 0.0
+    assert result.language is None
+
+
+def test_transcribe_audio_speech_recognition_request_error():
+    proc = _bare_processor()
+    proc.transcription_method = "speech_recognition"
+    fake_sr = types.ModuleType("speech_recognition")
+    fake_sr.AudioData = mock.Mock(return_value="audio-obj")
+    fake_sr.UnknownValueError = type("UnknownValueError", (Exception,), {})
+    fake_sr.RequestError = type("RequestError", (Exception,), {})
+    recognizer = mock.Mock()
+    recognizer.recognize_google.side_effect = fake_sr.RequestError("api down")
+    proc.transcriber = recognizer
+    with mock.patch.dict(sys.modules, {"speech_recognition": fake_sr}):
+        result = proc._transcribe_audio(np.zeros(10, dtype=np.int16))
+    assert result.text == ""
+    assert result.confidence == 0.0
+
+
+def test_transcribe_audio_no_engine():
+    proc = _bare_processor()
+    proc.transcription_method = "none"
+    proc.transcriber = None
+    result = proc._transcribe_audio(np.zeros(10, dtype=np.float32))
+    assert result.text == "[Transcription not available]"
+    assert result.confidence == 0.0
+
+
+def test_transcribe_audio_exception_returns_empty_result():
+    proc = _bare_processor()
+    proc.transcription_method = "whisper"
+    proc.transcriber = mock.Mock()
+    proc.transcriber.transcribe.side_effect = RuntimeError("model blew up")
+    result = proc._transcribe_audio(np.zeros(10, dtype=np.float32))
+    assert result.text == ""
+    assert result.confidence == 0.0
+    assert result.duration == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _process_audio_chunk
+# ---------------------------------------------------------------------------
+
+
+def _chunk(value: int = 0, n: int = 32) -> bytes:
+    return (np.ones(n, dtype=np.int16) * value).tobytes()
+
+
+def test_process_chunk_callable_noise_reducer_and_speech_start():
+    proc = _bare_processor()
+    proc.noise_reducer = lambda a: a
+    proc.config.noise_reduction_enabled = True
+    proc.vad_enabled = True
+    proc.vad = lambda chunk: True  # speech detected
+    started = []
+    proc.on_speech_start = lambda: started.append(True)
+
+    result = proc._process_audio_chunk(_chunk(100))
+    assert result is None  # speech started, no transcription yet
+    assert proc.speech_detected is True
+    assert proc.silence_counter == 0
+    assert started == [True]
+
+
+def test_process_chunk_noisereduce_library_object_branch():
+    proc = _bare_processor()
+    nr_lib = mock.Mock()  # not callable as a plain func -> use .reduce_noise
+    nr_lib.reduce_noise.return_value = np.zeros(32, dtype=np.float32)
+    # Force the non-callable branch: a Mock is callable, so simulate a
+    # library object by making callable() return False via a real object.
+
+    class FakeNR:
+        def reduce_noise(self, y, sr):
+            return y
+
+    proc.noise_reducer = FakeNR()
+    proc.config.noise_reduction_enabled = True
+    proc.vad_enabled = False
+    result = proc._process_audio_chunk(_chunk(0))
+    assert result is None
+
+
+def test_process_chunk_webrtcvad_object_branch_silence_triggers_transcription():
+    proc = _bare_processor(silence_timeout=0.0)  # threshold becomes 0
+    proc.noise_reducer = None
+    proc.config.noise_reduction_enabled = False
+    proc.vad_enabled = True
+
+    class FakeVad:
+        def is_speech(self, chunk, rate):
+            return False  # silence
+
+    proc.vad = FakeVad()
+    proc.speech_detected = True  # was speaking, now silence ends it
+    ended = []
+    proc.on_speech_end = lambda: ended.append(True)
+    proc._transcribe_audio = mock.Mock(
+        return_value=VoiceResult(
+            text="done", confidence=0.9, duration=0.1, timestamp=datetime.now()
+        )
+    )
+    result = proc._process_audio_chunk(_chunk(0))
+    assert ended == [True]
+    assert proc.speech_detected is False
+    assert result is not None and result.text == "done"
+
+
+def test_process_chunk_silence_below_timeout_no_transcription():
+    proc = _bare_processor(silence_timeout=100.0)  # very high threshold
+    proc.noise_reducer = None
+    proc.config.noise_reduction_enabled = False
+    proc.vad_enabled = True
+    proc.vad = lambda chunk: False  # silence
+    proc.speech_detected = True
+    result = proc._process_audio_chunk(_chunk(0))
+    assert result is None
+    assert proc.silence_counter == 1
+    assert proc.speech_detected is True  # not enough silence yet
+
+
+def test_process_chunk_vad_disabled_returns_none():
+    proc = _bare_processor()
+    proc.noise_reducer = None
+    proc.config.noise_reduction_enabled = False
+    proc.vad_enabled = False
+    assert proc._process_audio_chunk(_chunk(50)) is None
+
+
+def test_process_chunk_exception_returns_none():
+    proc = _bare_processor()
+    proc.noise_reducer = mock.Mock(side_effect=RuntimeError("nr fail"))
+    proc.config.noise_reduction_enabled = True
+    proc.vad_enabled = False
+    assert proc._process_audio_chunk(_chunk(10)) is None
+
+
+# ---------------------------------------------------------------------------
+# start_listening / stop_listening lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_start_listening_spawns_thread_and_is_idempotent():
+    proc = _bare_processor()
+    with mock.patch.object(proc, "_audio_processing_loop"):
+        proc.start_listening()
+        assert proc.is_listening is True
+        thread = proc.processing_thread
+        assert thread is not None
+        # Second call is a no-op (already listening).
+        proc.start_listening()
+        assert proc.processing_thread is thread
+    proc.is_listening = False
+    if proc.processing_thread:
+        proc.processing_thread.join(timeout=1.0)
+
+
+def test_stop_listening_joins_thread():
+    proc = _bare_processor()
+    fake_thread = mock.Mock()
+    proc.processing_thread = fake_thread
+    proc.is_listening = True
+    proc.stop_listening()
+    assert proc.is_listening is False
+    fake_thread.join.assert_called_once_with(timeout=1.0)
+
+
+def test_stop_listening_without_thread():
+    proc = _bare_processor()
+    proc.processing_thread = None
+    proc.is_listening = True
+    proc.stop_listening()  # should not raise
+    assert proc.is_listening is False
+
+
+# ---------------------------------------------------------------------------
+# _audio_processing_loop
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_pyaudio(chunks, read_side_effect=None):
+    fake_pyaudio = types.ModuleType("pyaudio")
+    fake_pyaudio.paInt16 = 8
+    stream = mock.Mock()
+    if read_side_effect is not None:
+        stream.read.side_effect = read_side_effect
+    else:
+        stream.read.side_effect = chunks
+    pa_instance = mock.Mock()
+    pa_instance.open.return_value = stream
+    fake_pyaudio.PyAudio = mock.Mock(return_value=pa_instance)
+    return fake_pyaudio, pa_instance, stream
+
+
+def test_audio_loop_dispatches_callbacks_and_cleans_up():
+    proc = _bare_processor(confidence_threshold=0.5)
+
+    result = VoiceResult(
+        text="hey chatty",
+        confidence=0.9,
+        duration=0.1,
+        timestamp=datetime.now(),
+        wake_word_detected=True,
+    )
+
+    def fake_process(chunk):
+        proc.is_listening = False  # exit loop after one iteration
+        return result
+
+    proc._process_audio_chunk = fake_process
+    transcriptions = []
+    wake_words = []
+    proc.on_transcription = transcriptions.append
+    proc.on_wake_word = wake_words.append
+    proc.is_listening = True
+
+    fake_pyaudio, pa_instance, stream = _install_fake_pyaudio([b"\x00\x00"])
+    with mock.patch.dict(sys.modules, {"pyaudio": fake_pyaudio}):
+        proc._audio_processing_loop()
+
+    assert transcriptions == [result]
+    assert wake_words == ["hey chatty"]
+    stream.stop_stream.assert_called_once()
+    stream.close.assert_called_once()
+    pa_instance.terminate.assert_called_once()
+
+
+def test_audio_loop_skips_low_confidence_results():
+    proc = _bare_processor(confidence_threshold=0.9)
+    low = VoiceResult(
+        text="meh", confidence=0.1, duration=0.1, timestamp=datetime.now()
+    )
+
+    def fake_process(chunk):
+        proc.is_listening = False
+        return low
+
+    proc._process_audio_chunk = fake_process
+    transcriptions = []
+    proc.on_transcription = transcriptions.append
+    proc.is_listening = True
+
+    fake_pyaudio, _, _ = _install_fake_pyaudio([b"\x00\x00"])
+    with mock.patch.dict(sys.modules, {"pyaudio": fake_pyaudio}):
+        proc._audio_processing_loop()
+    assert transcriptions == []
+
+
+def test_audio_loop_inner_exception_continues_then_exits():
+    proc = _bare_processor()
+    calls = {"n": 0}
+
+    def read(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("overflow")
+        proc.is_listening = False
+        return b"\x00\x00"
+
+    proc._process_audio_chunk = mock.Mock(return_value=None)
+    proc.is_listening = True
+    fake_pyaudio, _, stream = _install_fake_pyaudio(None, read_side_effect=read)
+    with mock.patch.dict(sys.modules, {"pyaudio": fake_pyaudio}):
+        proc._audio_processing_loop()
+    assert calls["n"] >= 2
+    stream.close.assert_called_once()
+
+
+def test_audio_loop_outer_exception_swallowed():
+    proc = _bare_processor()
+    proc.is_listening = True
+    fake_pyaudio = types.ModuleType("pyaudio")
+    fake_pyaudio.paInt16 = 8
+    fake_pyaudio.PyAudio = mock.Mock(side_effect=RuntimeError("no audio device"))
+    with mock.patch.dict(sys.modules, {"pyaudio": fake_pyaudio}):
+        proc._audio_processing_loop()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# process_audio_file
+# ---------------------------------------------------------------------------
+
+
+def test_process_audio_file_callable_noise_reducer():
+    proc = _bare_processor()
+    proc.noise_reducer = lambda a: a
+    proc.config.noise_reduction_enabled = True
+    proc._transcribe_audio = mock.Mock(
+        return_value=VoiceResult(
+            text="file text", confidence=0.9, duration=0.2, timestamp=datetime.now()
+        )
+    )
+    fake_librosa = types.ModuleType("librosa")
+    fake_librosa.load = mock.Mock(
+        return_value=(np.zeros(16000, dtype=np.float32), 16000)
+    )
+    with mock.patch.dict(sys.modules, {"librosa": fake_librosa}):
+        result = proc.process_audio_file("/tmp/whatever.wav")
+    assert result.text == "file text"
+    fake_librosa.load.assert_called_once()
+
+
+def test_process_audio_file_library_noise_reducer():
+    proc = _bare_processor()
+
+    class FakeNR:
+        def __init__(self):
+            self.called = False
+
+        def reduce_noise(self, y, sr):
+            self.called = True
+            return y
+
+    nr = FakeNR()
+    proc.noise_reducer = nr
+    proc.config.noise_reduction_enabled = True
+    proc._transcribe_audio = mock.Mock(
+        return_value=VoiceResult(
+            text="ok", confidence=0.9, duration=0.2, timestamp=datetime.now()
+        )
+    )
+    fake_librosa = types.ModuleType("librosa")
+    fake_librosa.load = mock.Mock(
+        return_value=(np.zeros(100, dtype=np.float32), 16000)
+    )
+    with mock.patch.dict(sys.modules, {"librosa": fake_librosa}):
+        result = proc.process_audio_file("/tmp/x.wav")
+    assert nr.called is True
+    assert result.text == "ok"
+
+
+def test_process_audio_file_error_returns_empty_result():
+    proc = _bare_processor()
+    fake_librosa = types.ModuleType("librosa")
+    fake_librosa.load = mock.Mock(side_effect=FileNotFoundError("missing"))
+    with mock.patch.dict(sys.modules, {"librosa": fake_librosa}):
+        result = proc.process_audio_file("/does/not/exist.wav")
+    assert result.text == ""
+    assert result.confidence == 0.0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_orchestrator_coverage.py
+++ b/tests/test_orchestrator_coverage.py
@@ -1,0 +1,419 @@
+"""Coverage for src/chatty_commander/app/orchestrator.py uncovered branches.
+
+Complements tests/test_main_orchestrator.py without duplicating it. Focuses on:
+- TextInputAdapter.feed gating (started/not-started)
+- DummyAdapter lifecycle
+- OpenWakeWordAdapter start/stop/callback (with VOICE deps mocked at the
+  orchestrator import boundary)
+- select_adapters branches: gui, computer_vision, openwakeword (VOICE on/off,
+  construction-error fallback), discord bridge with advisors disabled
+- ModeOrchestrator.start auto-select, stop() swallowing adapter errors
+- _dispatch_command, _handle_wake_word success/fallback/total-failure paths
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import chatty_commander.app.orchestrator as orch_mod
+from chatty_commander.app.orchestrator import (
+    DiscordBridgeAdapter,
+    DummyAdapter,
+    ModeOrchestrator,
+    OpenWakeWordAdapter,
+    OrchestratorFlags,
+    TextInputAdapter,
+)
+
+
+class _CommandSink:
+    def __init__(self, raise_on=None):
+        self.executed = []
+        self._raise_on = raise_on or set()
+
+    def execute_command(self, command_name: str):
+        self.executed.append(command_name)
+        if command_name in self._raise_on:
+            raise RuntimeError(f"no command {command_name}")
+        return f"ran:{command_name}"
+
+
+class _ConfigAdvisorsOff:
+    advisors = {"enabled": False}
+
+
+class _ConfigAdvisorsOn:
+    advisors = {"enabled": True}
+
+
+# ── TextInputAdapter ─────────────────────────────────────────────────────
+
+
+class TestTextInputAdapter:
+    def test_feed_before_start_is_noop(self):
+        received = []
+        adapter = TextInputAdapter(on_command=received.append)
+        adapter.feed("ignored")
+        assert received == []
+
+    def test_feed_after_start_dispatches(self):
+        received = []
+        adapter = TextInputAdapter(on_command=received.append)
+        adapter.start()
+        adapter.feed("hello")
+        assert received == ["hello"]
+
+    def test_feed_after_stop_is_noop_again(self):
+        received = []
+        adapter = TextInputAdapter(on_command=received.append)
+        adapter.start()
+        adapter.stop()
+        adapter.feed("nope")
+        assert received == []
+
+
+# ── DummyAdapter ─────────────────────────────────────────────────────────
+
+
+class TestDummyAdapter:
+    def test_name_and_lifecycle(self):
+        adapter = DummyAdapter("gui")
+        assert adapter.name == "gui"
+        assert adapter._started is False
+        adapter.start()
+        assert adapter._started is True
+        adapter.stop()
+        assert adapter._started is False
+
+
+# ── OpenWakeWordAdapter ──────────────────────────────────────────────────
+
+
+class _FakeDetector:
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        self.callbacks = []
+        self.listening = False
+
+    def add_callback(self, cb):
+        self.callbacks.append(cb)
+
+    def start_listening(self):
+        self.listening = True
+
+    def stop_listening(self):
+        self.listening = False
+
+
+class TestOpenWakeWordAdapter:
+    def test_start_raises_when_voice_unavailable(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", False)
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None)
+        try:
+            adapter.start()
+            raised = False
+        except ImportError as e:
+            raised = True
+            assert "Voice dependencies" in str(e)
+        assert raised
+
+    def test_start_uses_real_detector_with_config(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        monkeypatch.setattr(orch_mod, "WakeWordDetector", _FakeDetector)
+        monkeypatch.setattr(orch_mod, "MockWakeWordDetector", _FakeDetector)
+        config = SimpleNamespace(
+            wake_words=["computer"], wake_word_threshold=0.7
+        )
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None, config=config)
+        adapter.start()
+        assert adapter._started is True
+        assert isinstance(adapter._detector, _FakeDetector)
+        assert adapter._detector.kwargs["wake_words"] == ["computer"]
+        assert adapter._detector.kwargs["threshold"] == 0.7
+        assert adapter._detector.listening is True
+
+    def test_start_defaults_when_config_missing_attrs(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        monkeypatch.setattr(orch_mod, "WakeWordDetector", _FakeDetector)
+        monkeypatch.setattr(orch_mod, "MockWakeWordDetector", _FakeDetector)
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None, config=None)
+        adapter.start()
+        assert adapter._detector.kwargs["wake_words"] == ["hey_jarvis", "alexa"]
+        assert adapter._detector.kwargs["threshold"] == 0.5
+
+    def test_start_falls_back_to_mock_on_real_detector_error(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+
+        class _Boom:
+            def __init__(self, *a, **k):
+                raise RuntimeError("no audio device")
+
+        monkeypatch.setattr(orch_mod, "WakeWordDetector", _Boom)
+        monkeypatch.setattr(orch_mod, "MockWakeWordDetector", _FakeDetector)
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None)
+        adapter.start()
+        assert isinstance(adapter._detector, _FakeDetector)
+        assert adapter._detector.listening is True
+
+    def test_start_no_detector_when_classes_none(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        monkeypatch.setattr(orch_mod, "WakeWordDetector", None)
+        monkeypatch.setattr(orch_mod, "MockWakeWordDetector", None)
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None)
+        adapter.start()
+        assert adapter._detector is None
+        assert adapter._started is True
+
+    def test_start_is_idempotent_when_already_started(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        monkeypatch.setattr(orch_mod, "WakeWordDetector", _FakeDetector)
+        monkeypatch.setattr(orch_mod, "MockWakeWordDetector", _FakeDetector)
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None)
+        adapter.start()
+        first_detector = adapter._detector
+        adapter.start()  # second call returns early
+        assert adapter._detector is first_detector
+
+    def test_stop_calls_detector_stop_listening(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        monkeypatch.setattr(orch_mod, "WakeWordDetector", _FakeDetector)
+        monkeypatch.setattr(orch_mod, "MockWakeWordDetector", _FakeDetector)
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None)
+        adapter.start()
+        detector = adapter._detector
+        adapter.stop()
+        assert adapter._started is False
+        assert detector.listening is False
+
+    def test_stop_without_start_is_safe(self):
+        adapter = OpenWakeWordAdapter(on_wake_word=lambda w, c: None)
+        adapter.stop()  # _detector is None / not started
+        assert adapter._started is False
+
+    def test_handle_wake_word_invokes_callback(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        monkeypatch.setattr(orch_mod, "WakeWordDetector", _FakeDetector)
+        monkeypatch.setattr(orch_mod, "MockWakeWordDetector", _FakeDetector)
+        calls = []
+        adapter = OpenWakeWordAdapter(
+            on_wake_word=lambda w, c: calls.append((w, c))
+        )
+        adapter.start()
+        # The registered callback is _handle_wake_word; invoke it.
+        adapter._detector.callbacks[0]("hey_jarvis", 0.91)
+        assert calls == [("hey_jarvis", 0.91)]
+
+
+# ── select_adapters: gui / cv / openwakeword branches ────────────────────
+
+
+class TestSelectAdaptersBranches:
+    def _orch(self, flags, config=None, advisor_sink=None):
+        return ModeOrchestrator(
+            config=config or _ConfigAdvisorsOff(),
+            command_sink=_CommandSink(),
+            advisor_sink=advisor_sink,
+            flags=flags,
+        )
+
+    def test_gui_only(self):
+        orch = self._orch(OrchestratorFlags(enable_gui=True))
+        assert orch.select_adapters() == ["gui"]
+        assert isinstance(orch.adapters[0], DummyAdapter)
+
+    def test_computer_vision_only(self):
+        orch = self._orch(OrchestratorFlags(enable_computer_vision=True))
+        assert orch.select_adapters() == ["computer_vision"]
+
+    def test_openwakeword_dummy_when_voice_unavailable(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", False)
+        orch = self._orch(OrchestratorFlags(enable_openwakeword=True))
+        assert orch.select_adapters() == ["openwakeword"]
+        assert isinstance(orch.adapters[0], DummyAdapter)
+
+    def test_openwakeword_real_adapter_when_voice_available(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        orch = self._orch(OrchestratorFlags(enable_openwakeword=True))
+        assert orch.select_adapters() == ["openwakeword"]
+        assert isinstance(orch.adapters[0], OpenWakeWordAdapter)
+
+    def test_openwakeword_falls_back_to_dummy_on_construction_error(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+
+        def _boom(*a, **k):
+            raise RuntimeError("ctor failure")
+
+        monkeypatch.setattr(orch_mod, "OpenWakeWordAdapter", _boom)
+        orch = self._orch(OrchestratorFlags(enable_openwakeword=True))
+        assert orch.select_adapters() == ["openwakeword"]
+        assert isinstance(orch.adapters[0], DummyAdapter)
+
+    def test_discord_bridge_not_selected_when_advisors_disabled(self):
+        # Flag on but config.advisors.enabled is False -> bridge skipped entirely.
+        orch = self._orch(
+            OrchestratorFlags(enable_discord_bridge=True),
+            config=_ConfigAdvisorsOff(),
+            advisor_sink=MagicMock(),
+        )
+        assert orch.select_adapters() == []
+
+    def test_discord_bridge_skipped_when_config_has_no_advisors_attr(self):
+        orch = ModeOrchestrator(
+            config=SimpleNamespace(),  # no .advisors -> getattr default {}
+            command_sink=_CommandSink(),
+            advisor_sink=MagicMock(),
+            flags=OrchestratorFlags(enable_discord_bridge=True),
+        )
+        assert orch.select_adapters() == []
+
+    def test_all_flags_combination(self, monkeypatch):
+        monkeypatch.setattr(orch_mod, "VOICE_AVAILABLE", True)
+        orch = ModeOrchestrator(
+            config=_ConfigAdvisorsOn(),
+            command_sink=_CommandSink(),
+            advisor_sink=_RecordingAdvisorSink(),
+            flags=OrchestratorFlags(
+                enable_text=True,
+                enable_gui=True,
+                enable_web=True,
+                enable_openwakeword=True,
+                enable_computer_vision=True,
+                enable_discord_bridge=True,
+            ),
+        )
+        names = orch.select_adapters()
+        assert set(names) == {
+            "text",
+            "gui",
+            "web",
+            "openwakeword",
+            "computer_vision",
+            "discord_bridge",
+        }
+
+
+# ── start / stop lifecycle ───────────────────────────────────────────────
+
+
+class _RecordingAdvisorSink:
+    def __init__(self):
+        self.messages = []
+
+    def handle_message(self, message):
+        self.messages.append(message)
+        return "reply"
+
+
+class TestStartStopLifecycle:
+    def test_start_auto_selects_when_no_adapters(self):
+        orch = ModeOrchestrator(
+            config=_ConfigAdvisorsOff(),
+            command_sink=_CommandSink(),
+            flags=OrchestratorFlags(enable_text=True),
+        )
+        # select_adapters not called yet
+        assert orch.adapters == []
+        names = orch.start()
+        assert names == ["text"]
+        assert orch.adapters[0]._started is True
+
+    def test_start_does_not_reselect_when_adapters_present(self):
+        orch = ModeOrchestrator(
+            config=_ConfigAdvisorsOff(),
+            command_sink=_CommandSink(),
+            flags=OrchestratorFlags(enable_text=True),
+        )
+        orch.select_adapters()
+        existing = orch.adapters[0]
+        orch.start()
+        assert orch.adapters[0] is existing
+
+    def test_stop_swallows_adapter_exceptions(self):
+        orch = ModeOrchestrator(
+            config=_ConfigAdvisorsOff(),
+            command_sink=_CommandSink(),
+            flags=OrchestratorFlags(),
+        )
+
+        class _Boom:
+            name = "boom"
+
+            def start(self):
+                pass
+
+            def stop(self):
+                raise RuntimeError("stop failed")
+
+        good = DummyAdapter("good")
+        good.start()
+        orch.adapters = [_Boom(), good]
+        # Should not raise despite first adapter throwing.
+        orch.stop()
+        assert good._started is False
+
+
+# ── routing: _dispatch_command and _handle_wake_word ─────────────────────
+
+
+class TestDispatchAndWakeWord:
+    def _orch(self, command_sink):
+        return ModeOrchestrator(
+            config=_ConfigAdvisorsOff(),
+            command_sink=command_sink,
+            flags=OrchestratorFlags(),
+        )
+
+    def test_dispatch_command_forwards_to_sink(self):
+        sink = _CommandSink()
+        orch = self._orch(sink)
+        assert orch._dispatch_command("ping") == "ran:ping"
+        assert sink.executed == ["ping"]
+
+    def test_handle_wake_word_dispatches_specific_command(self):
+        sink = _CommandSink()
+        orch = self._orch(sink)
+        orch._handle_wake_word("jarvis", 0.8)
+        assert sink.executed == ["wake_word_jarvis"]
+
+    def test_handle_wake_word_falls_back_to_generic_wake(self):
+        # Specific command raises -> falls back to "wake".
+        sink = _CommandSink(raise_on={"wake_word_jarvis"})
+        orch = self._orch(sink)
+        orch._handle_wake_word("jarvis", 0.8)
+        assert sink.executed == ["wake_word_jarvis", "wake"]
+
+    def test_handle_wake_word_logs_when_both_fail(self, caplog):
+        sink = _CommandSink(raise_on={"wake_word_jarvis", "wake"})
+        orch = self._orch(sink)
+        with caplog.at_level(
+            "WARNING", logger="chatty_commander.app.orchestrator"
+        ):
+            orch._handle_wake_word("jarvis", 0.42)
+        assert sink.executed == ["wake_word_jarvis", "wake"]
+        assert any(
+            "Failed to dispatch wake word" in r.getMessage()
+            for r in caplog.records
+        )
+
+
+# ── DiscordBridgeAdapter direct unit coverage ────────────────────────────
+
+
+class TestDiscordBridgeAdapter:
+    def test_feed_before_start_returns_none(self):
+        adapter = DiscordBridgeAdapter(on_message=lambda m: "handled")
+        assert adapter.feed("msg") is None
+
+    def test_feed_after_start_returns_handler_result(self):
+        adapter = DiscordBridgeAdapter(on_message=lambda m: f"handled:{m}")
+        adapter.start()
+        assert adapter.feed("msg") == "handled:msg"
+
+    def test_feed_after_stop_returns_none(self):
+        adapter = DiscordBridgeAdapter(on_message=lambda m: "handled")
+        adapter.start()
+        adapter.stop()
+        assert adapter.feed("msg") is None

--- a/tests/test_transcription_coverage.py
+++ b/tests/test_transcription_coverage.py
@@ -1,0 +1,393 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction.
+
+"""Coverage-focused tests for chatty_commander.voice.transcription.
+
+These tests target uncovered error/branch/lifecycle paths not exercised by
+tests/test_transcription_comprehensive.py. External dependencies (whisper,
+openai, pyaudio, numpy) are mocked at the import boundary so the suite is
+hermetic and fast. In this environment ``AUDIO_DEPS_AVAILABLE`` is False
+(pyaudio/numpy not installed), so the module-level globals ``np`` and
+``pyaudio`` are ``None`` and must be patched where exercised.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import chatty_commander.voice.transcription as tmod
+from chatty_commander.voice.transcription import (
+    MockTranscriptionBackend,
+    VoiceTranscriber,
+    WhisperAPIBackend,
+    WhisperLocalBackend,
+)
+
+
+# ---------------------------------------------------------------------------
+# WhisperLocalBackend: init + transcribe error/availability branches
+# ---------------------------------------------------------------------------
+class TestWhisperLocalBranches:
+    def test_initialize_model_import_error(self):
+        """ImportError during model load leaves _model as None (line 85-88)."""
+        # Ensure 'whisper' is absent so `import whisper` raises ImportError.
+        with patch.dict(sys.modules, {"whisper": None}):
+            backend = WhisperLocalBackend()
+        assert backend._model is None
+        assert backend.is_available() is False
+
+    def test_initialize_model_generic_exception(self):
+        """A non-import error from load_model is caught (lines 89-90)."""
+        fake_whisper = MagicMock()
+        fake_whisper.load_model.side_effect = RuntimeError("gpu boom")
+        with patch.dict(sys.modules, {"whisper": fake_whisper}):
+            backend = WhisperLocalBackend(model_size="small")
+        # Exception swallowed; model never set.
+        assert backend._model is None
+        assert backend.is_available() is False
+
+    def test_transcribe_internal_exception_returns_empty(self):
+        """If transcription raises, returns '' (lines 110-112)."""
+        backend = WhisperLocalBackend.__new__(WhisperLocalBackend)
+        backend.model_size = "base"
+        mock_model = MagicMock()
+        mock_model.transcribe.side_effect = RuntimeError("decode fail")
+        backend._model = mock_model
+
+        mock_np = MagicMock()
+        mock_np.frombuffer.return_value.astype.return_value.__truediv__ = MagicMock(
+            return_value=MagicMock()
+        )
+        with patch.object(tmod, "np", mock_np):
+            result = backend.transcribe(b"\x00\x01")
+        assert result == ""
+
+    def test_transcribe_strips_and_returns_text(self):
+        """Happy path strips whitespace from result text (lines 99-108)."""
+        backend = WhisperLocalBackend.__new__(WhisperLocalBackend)
+        backend.model_size = "base"
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "  spoken words  "}
+        backend._model = mock_model
+
+        mock_np = MagicMock()
+        arr = MagicMock()
+        mock_np.frombuffer.return_value = arr
+        arr.astype.return_value = arr
+        arr.__truediv__ = MagicMock(return_value=arr)
+        with patch.object(tmod, "np", mock_np):
+            result = backend.transcribe(b"\x00\x01", sample_rate=8000)
+        assert result == "spoken words"
+
+    def test_transcribe_missing_text_key(self):
+        """result.get('text') default '' when key absent (line 105)."""
+        backend = WhisperLocalBackend.__new__(WhisperLocalBackend)
+        backend.model_size = "base"
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {}
+        backend._model = mock_model
+
+        mock_np = MagicMock()
+        arr = MagicMock()
+        mock_np.frombuffer.return_value = arr
+        arr.astype.return_value = arr
+        arr.__truediv__ = MagicMock(return_value=arr)
+        with patch.object(tmod, "np", mock_np):
+            result = backend.transcribe(b"\x00\x01")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# WhisperAPIBackend: init error branches + full transcribe path
+# ---------------------------------------------------------------------------
+class TestWhisperAPIBranches:
+    def test_initialize_client_import_error(self):
+        """ImportError -> client stays None (lines 133-136)."""
+        with patch.dict(sys.modules, {"openai": None}):
+            backend = WhisperAPIBackend(api_key="k")
+        assert backend._client is None
+        assert backend.is_available() is False
+
+    def test_initialize_client_generic_exception(self):
+        """Non-import error from OpenAI() is caught (lines 137-138)."""
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.side_effect = RuntimeError("bad creds")
+        with patch.dict(sys.modules, {"openai": fake_openai}):
+            backend = WhisperAPIBackend(api_key="k")
+        assert backend._client is None
+
+    def test_transcribe_happy_path_writes_wav_and_cleans_up(self, tmp_path):
+        """Full transcribe path: writes temp wav, calls API, strips, unlinks.
+
+        Covers lines 145-166 and the finally-block cleanup (171-177).
+        """
+        backend = WhisperAPIBackend.__new__(WhisperAPIBackend)
+        backend.api_key = None
+        mock_client = MagicMock()
+        transcript = MagicMock()
+        transcript.text = "  api result  "
+        mock_client.audio.transcriptions.create.return_value = transcript
+        backend._client = mock_client
+
+        captured = {}
+        real_unlink = tmod.os.unlink
+
+        def spy_unlink(path):
+            captured["unlinked"] = path
+            return real_unlink(path)
+
+        # Provide valid 16-bit PCM frames so wave.writeframes succeeds.
+        audio = b"\x00\x01" * 10
+        with patch.object(tmod.os, "unlink", side_effect=spy_unlink):
+            result = backend.transcribe(audio, sample_rate=16000)
+
+        assert result == "api result"
+        mock_client.audio.transcriptions.create.assert_called_once()
+        _, kwargs = mock_client.audio.transcriptions.create.call_args
+        assert kwargs["model"] == "whisper-1"
+        # Temp file was cleaned up.
+        assert "unlinked" in captured
+        assert not tmod.os.path.exists(captured["unlinked"])
+
+    def test_transcribe_api_error_returns_empty_and_cleans_up(self):
+        """API exception -> returns '' and still unlinks temp file (168-177)."""
+        backend = WhisperAPIBackend.__new__(WhisperAPIBackend)
+        backend.api_key = None
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.side_effect = RuntimeError("503")
+        backend._client = mock_client
+
+        captured = {}
+
+        def spy_unlink(path):
+            captured["unlinked"] = path
+            return tmod.os.path.exists(path) and None
+
+        with patch.object(tmod.os, "unlink", side_effect=spy_unlink):
+            result = backend.transcribe(b"\x00\x01" * 5)
+        assert result == ""
+        assert "unlinked" in captured
+
+    def test_transcribe_unlink_oserror_swallowed(self):
+        """OSError during cleanup is swallowed (lines 176-177)."""
+        backend = WhisperAPIBackend.__new__(WhisperAPIBackend)
+        backend.api_key = None
+        mock_client = MagicMock()
+        transcript = MagicMock()
+        transcript.text = "ok"
+        mock_client.audio.transcriptions.create.return_value = transcript
+        backend._client = mock_client
+
+        with patch.object(tmod.os, "unlink", side_effect=OSError("gone")):
+            result = backend.transcribe(b"\x00\x01" * 5)
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# VoiceTranscriber: record_and_transcribe and _record_audio branches
+# ---------------------------------------------------------------------------
+class TestRecordAndTranscribe:
+    def test_record_and_transcribe_no_audio_deps(self):
+        """When AUDIO_DEPS_AVAILABLE is False, falls back to backend transcribe
+        on empty bytes (lines 260-262)."""
+        with patch.object(tmod, "AUDIO_DEPS_AVAILABLE", False):
+            t = VoiceTranscriber(backend="mock")
+            result = t.record_and_transcribe()
+        # Mock backend returns its first canned response.
+        assert result == "hello world"
+
+    def test_record_and_transcribe_happy_path(self):
+        """audio_data present -> transcribe_audio_data invoked (lines 266-267)."""
+        with patch.object(tmod, "AUDIO_DEPS_AVAILABLE", True):
+            t = VoiceTranscriber(backend="mock")
+            with patch.object(t, "_record_audio", return_value=b"frames"):
+                result = t.record_and_transcribe()
+        assert result == "hello world"
+
+    def test_record_and_transcribe_empty_recording_returns_empty(self):
+        """Empty recorded bytes -> returns '' (line 268)."""
+        with patch.object(tmod, "AUDIO_DEPS_AVAILABLE", True):
+            t = VoiceTranscriber(backend="mock")
+            with patch.object(t, "_record_audio", return_value=b""):
+                result = t.record_and_transcribe()
+        assert result == ""
+
+    def test_record_audio_no_audio_deps_returns_empty(self):
+        """_record_audio short-circuits to b'' without deps (line 276)."""
+        with patch.object(tmod, "AUDIO_DEPS_AVAILABLE", False):
+            t = VoiceTranscriber(backend="mock")
+        with patch.object(tmod, "AUDIO_DEPS_AVAILABLE", False):
+            assert t._record_audio() == b""
+
+    def test_record_audio_silence_timeout_break(self):
+        """Loud chunk resets silence, then quiet chunks trip silence timeout
+        and break the loop (lines 301-309, 311)."""
+        mock_pyaudio = MagicMock()
+        mock_audio_instance = MagicMock()
+        mock_stream = MagicMock()
+        mock_audio_instance.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio_instance
+        mock_pyaudio.paInt16 = 8
+        mock_stream.read.return_value = b"\x00\x01\x02\x03"
+
+        mock_np = MagicMock()
+        # astype() result must support len() for the volume divisor.
+        audio_array = MagicMock()
+        audio_array.__len__ = MagicMock(return_value=4)
+        mock_np.frombuffer.return_value.astype.return_value = audio_array
+        mock_np.dot.return_value = 1.0
+        # First chunk loud (else branch line 311 resets silence_start),
+        # then a quiet chunk below threshold sets silence_start, then another
+        # quiet chunk trips the silence timeout (lines 304-309).
+        mock_np.sqrt.side_effect = [1000.0, 10.0, 10.0, 10.0]
+
+        # Drive time.time() with a list + clamped index so the loop can call it
+        # a variable number of times without raising StopIteration.
+        seq = [0.0, 0.1, 0.2, 0.3, 0.5, 0.6, 5.0, 5.1, 5.2, 5.3]
+        state = {"i": 0}
+
+        def fake_time():
+            i = state["i"]
+            state["i"] = min(i + 1, len(seq) - 1)
+            return seq[i]
+
+        with (
+            patch.object(tmod, "AUDIO_DEPS_AVAILABLE", True),
+            patch.object(tmod, "pyaudio", mock_pyaudio),
+            patch.object(tmod, "np", mock_np),
+            patch.object(tmod.time, "time", fake_time),
+        ):
+            t = VoiceTranscriber(backend="mock")
+            t.silence_timeout = 0.0  # any elapsed silence triggers break
+            t.silence_threshold = 500.0
+            t.record_timeout = 100.0
+            result = t._record_audio()
+
+        assert isinstance(result, bytes)
+        mock_stream.read.assert_called()
+
+    def test_record_audio_record_timeout_break(self):
+        """Loud audio that never goes silent breaks on record_timeout
+        (lines 304/311 else + 314-316)."""
+        mock_pyaudio = MagicMock()
+        mock_audio_instance = MagicMock()
+        mock_stream = MagicMock()
+        mock_audio_instance.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio_instance
+        mock_pyaudio.paInt16 = 8
+        mock_stream.read.return_value = b"\x00\x01\x02\x03"
+
+        mock_np = MagicMock()
+        audio_array = MagicMock()
+        audio_array.__len__ = MagicMock(return_value=4)
+        mock_np.frombuffer.return_value.astype.return_value = audio_array
+        mock_np.sqrt.return_value = 99999.0  # always loud
+        mock_np.dot.return_value = 1.0
+
+        # Monotonic-ish clock: starts at 0, jumps past record_timeout after a
+        # couple of calls. A list + index avoids StopIteration if the loop body
+        # calls time.time() a varying number of times.
+        seq = [0.0, 0.1, 0.2, 999.0]
+        state = {"i": 0}
+
+        def fake_time():
+            i = state["i"]
+            state["i"] = min(i + 1, len(seq) - 1)
+            return seq[i]
+
+        with (
+            patch.object(tmod, "AUDIO_DEPS_AVAILABLE", True),
+            patch.object(tmod, "pyaudio", mock_pyaudio),
+            patch.object(tmod, "np", mock_np),
+            patch.object(tmod.time, "time", fake_time),
+        ):
+            t = VoiceTranscriber(backend="mock")
+            t.silence_timeout = 100.0
+            t.record_timeout = 1.0
+            result = t._record_audio()
+
+        assert isinstance(result, bytes)
+
+    def test_record_audio_inner_read_exception_breaks(self):
+        """Exception inside loop is caught and breaks (lines 318-320), then
+        cleanup runs in finally."""
+        mock_pyaudio = MagicMock()
+        mock_audio_instance = MagicMock()
+        mock_stream = MagicMock()
+        mock_audio_instance.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio_instance
+        mock_pyaudio.paInt16 = 8
+        mock_stream.read.side_effect = RuntimeError("overflow")
+
+        with (
+            patch.object(tmod, "AUDIO_DEPS_AVAILABLE", True),
+            patch.object(tmod, "pyaudio", mock_pyaudio),
+            patch.object(tmod, "np", MagicMock()),
+            patch.object(tmod.time, "time", lambda: 0.0),
+        ):
+            t = VoiceTranscriber(backend="mock")
+            result = t._record_audio()
+
+        assert result == b""
+        mock_stream.stop_stream.assert_called_once()
+        mock_audio_instance.terminate.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# VoiceTranscriber._cleanup_audio: exception handling branches
+# ---------------------------------------------------------------------------
+class TestCleanupAudio:
+    def test_cleanup_stream_close_exception_swallowed(self):
+        """Stream close raising is logged and swallowed (lines 336-337)."""
+        t = VoiceTranscriber(backend="mock")
+        mock_stream = MagicMock()
+        mock_stream.stop_stream.side_effect = RuntimeError("dead")
+        t._stream = mock_stream
+        t._audio = None
+
+        t._cleanup_audio()  # should not raise
+        assert t._stream is None
+
+    def test_cleanup_audio_terminate_exception_swallowed(self):
+        """Audio terminate raising is logged and swallowed (lines 344-345)."""
+        t = VoiceTranscriber(backend="mock")
+        mock_audio = MagicMock()
+        mock_audio.terminate.side_effect = RuntimeError("dead")
+        t._stream = None
+        t._audio = mock_audio
+
+        t._cleanup_audio()  # should not raise
+        assert t._audio is None
+
+    def test_cleanup_audio_noop_when_nothing_setup(self):
+        """No stream/audio -> cleanup is a harmless no-op."""
+        t = VoiceTranscriber(backend="mock")
+        t._stream = None
+        t._audio = None
+        t._cleanup_audio()
+        assert t._stream is None and t._audio is None
+
+
+# ---------------------------------------------------------------------------
+# Backend selection / availability dispatch
+# ---------------------------------------------------------------------------
+class TestBackendSelection:
+    def test_unknown_backend_raises(self):
+        t = VoiceTranscriber(backend="mock")
+        with pytest.raises(ValueError, match="Unknown transcription backend: bogus"):
+            t._create_backend("bogus")
+
+    def test_audio_deps_unavailable_forces_mock(self):
+        """Requesting whisper_local without deps coerces to mock backend."""
+        with patch.object(tmod, "AUDIO_DEPS_AVAILABLE", False):
+            t = VoiceTranscriber(backend="whisper_api")
+        assert isinstance(t._backend, MockTranscriptionBackend)
+
+    def test_mock_backend_is_always_available(self):
+        assert MockTranscriptionBackend().is_available() is True

--- a/tests/test_voice_self_test_coverage.py
+++ b/tests/test_voice_self_test_coverage.py
@@ -1,0 +1,723 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Tests for src/chatty_commander/voice/self_test.py
+#
+# These tests mock the VoiceTranscriber import boundary and the optional
+# pyttsx3 / openai dependencies so nothing real (whisper, audio HW, network,
+# LLM) is loaded. They exercise argument handling, each check/step of the
+# self-test harness, success + failure/exception reporting, and output.
+
+from __future__ import annotations
+
+import argparse
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import chatty_commander.voice.self_test as st
+from chatty_commander.voice.self_test import (
+    VoiceSelfTester,
+    add_self_test_commands,
+    create_self_improvement_loop,
+    handle_self_test_command,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_transcriber():
+    """A transcriber whose transcribe_audio_data echoes a canned string."""
+    t = MagicMock()
+    t.transcribe_audio_data.return_value = "hello world"
+    return t
+
+
+def make_tester(transcriber, **kwargs):
+    """Construct a VoiceSelfTester without touching real TTS/transcriber init."""
+    # Pass an explicit transcriber so VoiceTranscriber() is never constructed.
+    return VoiceSelfTester(transcriber=transcriber, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# __init__ / TTS initialization
+# ---------------------------------------------------------------------------
+
+
+def test_init_uses_provided_transcriber_and_default_phrases(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    assert tester.transcriber is fake_transcriber
+    assert tester.openai_client is None
+    # default phrases populated
+    assert len(tester.test_phrases) > 0
+    assert "hello world" in tester.test_phrases
+    assert tester._tts_engine is None  # TTS unavailable -> not initialized
+
+
+def test_init_custom_phrases_override_defaults(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber, test_phrases=["only this"])
+    assert tester.test_phrases == ["only this"]
+
+
+def test_init_constructs_default_transcriber_when_none():
+    # When no transcriber is passed, VoiceTranscriber(...) is invoked.
+    fake = MagicMock()
+    with patch.object(st, "VoiceTranscriber", return_value=fake) as ctor, patch.object(
+        st, "TTS_AVAILABLE", False
+    ):
+        tester = VoiceSelfTester()
+    ctor.assert_called_once_with(backend="whisper_local")
+    assert tester.transcriber is fake
+
+
+def test_init_builds_openai_client_when_available_and_key(fake_transcriber):
+    fake_client = MagicMock()
+    with patch.object(st, "TTS_AVAILABLE", False), patch.object(
+        st, "OPENAI_AVAILABLE", True
+    ), patch.object(st, "OpenAI", return_value=fake_client) as ctor:
+        tester = make_tester(fake_transcriber, openai_api_key="sk-test")
+    ctor.assert_called_once_with(api_key="sk-test")
+    assert tester.openai_client is fake_client
+
+
+def test_init_no_openai_client_when_key_missing(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False), patch.object(
+        st, "OPENAI_AVAILABLE", True
+    ):
+        tester = make_tester(fake_transcriber, openai_api_key=None)
+    assert tester.openai_client is None
+
+
+def test_initialize_tts_success_selects_female_voice(fake_transcriber):
+    female_voice = SimpleNamespace(name="Samantha", id="voice-samantha")
+    male_voice = SimpleNamespace(name="Fred", id="voice-fred")
+    engine = MagicMock()
+    engine.getProperty.return_value = [male_voice, female_voice]
+    fake_pyttsx3 = MagicMock()
+    fake_pyttsx3.init.return_value = engine
+
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "pyttsx3", fake_pyttsx3
+    ):
+        tester = make_tester(fake_transcriber)
+
+    assert tester._tts_engine is engine
+    engine.setProperty.assert_any_call("rate", 150)
+    engine.setProperty.assert_any_call("volume", 0.9)
+    # female/samantha voice chosen
+    engine.setProperty.assert_any_call("voice", "voice-samantha")
+
+
+def test_initialize_tts_no_voices(fake_transcriber):
+    engine = MagicMock()
+    engine.getProperty.return_value = []  # falsy -> skip voice selection
+    fake_pyttsx3 = MagicMock()
+    fake_pyttsx3.init.return_value = engine
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "pyttsx3", fake_pyttsx3
+    ):
+        tester = make_tester(fake_transcriber)
+    assert tester._tts_engine is engine
+
+
+def test_initialize_tts_exception_sets_engine_none(fake_transcriber):
+    fake_pyttsx3 = MagicMock()
+    fake_pyttsx3.init.side_effect = RuntimeError("no audio device")
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "pyttsx3", fake_pyttsx3
+    ):
+        tester = make_tester(fake_transcriber)
+    assert tester._tts_engine is None
+
+
+# ---------------------------------------------------------------------------
+# generate_audio_from_text
+# ---------------------------------------------------------------------------
+
+
+def test_generate_audio_returns_none_when_no_engine(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    assert tester.generate_audio_from_text("hi") is None
+
+
+def test_generate_audio_success_reads_and_unlinks(fake_transcriber, tmp_path):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    engine = MagicMock()
+    tester._tts_engine = engine
+
+    audio_bytes = b"RIFFfakeaudio"
+
+    # Make save_to_file actually write the bytes the function later reads.
+    def _save(text, name):
+        with open(name, "wb") as f:
+            f.write(audio_bytes)
+
+    engine.save_to_file.side_effect = _save
+
+    unlinked = []
+    real_unlink = st.os.unlink
+
+    def _track_unlink(p):
+        unlinked.append(p)
+        real_unlink(p)
+
+    with patch.object(st.os, "unlink", side_effect=_track_unlink):
+        result = tester.generate_audio_from_text("hello")
+
+    assert result == audio_bytes
+    engine.runAndWait.assert_called_once()
+    assert len(unlinked) == 1  # temp file cleaned up
+
+
+def test_generate_audio_exception_returns_none_and_cleans_up(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    engine = MagicMock()
+    engine.save_to_file.side_effect = RuntimeError("tts boom")
+    tester._tts_engine = engine
+
+    with patch.object(st.os, "unlink") as unlink:
+        result = tester.generate_audio_from_text("hello")
+    assert result is None
+    # finally block still attempts unlink of the created temp path
+    assert unlink.called
+
+
+def test_generate_audio_unlink_oserror_swallowed(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    engine = MagicMock()
+    engine.save_to_file.side_effect = RuntimeError("boom")
+    tester._tts_engine = engine
+    with patch.object(st.os, "unlink", side_effect=OSError("gone")):
+        # Should not raise despite unlink failure.
+        assert tester.generate_audio_from_text("x") is None
+
+
+# ---------------------------------------------------------------------------
+# test_transcription_accuracy
+# ---------------------------------------------------------------------------
+
+
+def test_transcription_accuracy_no_audio_returns_empty(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    # No TTS engine -> generate_audio_from_text returns None
+    text, acc = tester.test_transcription_accuracy("hello world")
+    assert text == ""
+    assert acc == 0.0
+    fake_transcriber.transcribe_audio_data.assert_not_called()
+
+
+def test_transcription_accuracy_with_audio(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    with patch.object(tester, "generate_audio_from_text", return_value=b"aud"):
+        text, acc = tester.test_transcription_accuracy("hello world")
+    assert text == "hello world"
+    assert acc == 1.0  # perfect overlap
+    fake_transcriber.transcribe_audio_data.assert_called_once_with(b"aud")
+
+
+# ---------------------------------------------------------------------------
+# _calculate_accuracy
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_accuracy_perfect(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    assert tester._calculate_accuracy("hello world", "hello world") == 1.0
+
+
+def test_calculate_accuracy_partial(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    # original={a,b}, transcribed={a,c}; intersection=1, union=3
+    score = tester._calculate_accuracy("a b", "a c")
+    # Plain float tolerance (not pytest.approx) so the assertion is immune to
+    # sibling tests that leave a MagicMock 'numpy' in sys.modules — approx's
+    # numpy detection (isinstance(val, np.bool_)) raises under that pollution.
+    assert abs(score - 1 / 3) < 1e-9
+
+
+def test_calculate_accuracy_empty_original_empty_transcribed(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    assert tester._calculate_accuracy("", "") == 1.0
+
+
+def test_calculate_accuracy_empty_original_nonempty_transcribed(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    assert tester._calculate_accuracy("", "junk") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# llm_judge_transcription
+# ---------------------------------------------------------------------------
+
+
+def test_llm_judge_no_client_falls_back_to_basic(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    result = tester.llm_judge_transcription("hello world", "hello world")
+    assert result["score"] == 1.0
+    assert result["feedback"] == "LLM judge not available"
+    assert result["suggestions"] == []
+
+
+def test_llm_judge_success_parses_json(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    payload = {"score": 0.9, "feedback": "good", "suggestions": ["x"]}
+    msg = SimpleNamespace(content=json.dumps(payload))
+    choice = SimpleNamespace(message=msg)
+    response = SimpleNamespace(choices=[choice])
+    client = MagicMock()
+    client.chat.completions.create.return_value = response
+    tester.openai_client = client
+
+    result = tester.llm_judge_transcription("orig", "trans")
+    assert result == payload
+    client.chat.completions.create.assert_called_once()
+
+
+def test_llm_judge_none_content_yields_empty_dict(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    msg = SimpleNamespace(content=None)
+    response = SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+    client = MagicMock()
+    client.chat.completions.create.return_value = response
+    tester.openai_client = client
+    assert tester.llm_judge_transcription("a", "a") == {}
+
+
+def test_llm_judge_exception_falls_back(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    client = MagicMock()
+    client.chat.completions.create.side_effect = RuntimeError("api down")
+    tester.openai_client = client
+    result = tester.llm_judge_transcription("hello world", "hello world")
+    assert result["score"] == 1.0
+    assert "LLM error" in result["feedback"]
+    assert result["suggestions"] == []
+
+
+# ---------------------------------------------------------------------------
+# _categorize_phrase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phrase,expected",
+    [
+        ("def fibonacci function", "programming"),
+        ("class inheritance method", "programming"),
+        ("hey computer turn on the lights", "voice_commands"),
+        ("create a python tool", "creation_commands"),
+        ("hello world", "simple"),  # <= 3 words, no keyword
+        ("the quick brown fox jumps over", "complex"),
+    ],
+)
+def test_categorize_phrase(fake_transcriber, phrase, expected):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    assert tester._categorize_phrase(phrase) == expected
+
+
+# ---------------------------------------------------------------------------
+# run_comprehensive_test
+# ---------------------------------------------------------------------------
+
+
+def test_run_comprehensive_test_aggregates(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(
+            fake_transcriber,
+            test_phrases=["hello world", "def fibonacci function"],
+        )
+
+    # Force deterministic transcription accuracy + llm judge.
+    with patch.object(
+        tester, "test_transcription_accuracy", return_value=("trans", 0.5)
+    ), patch.object(
+        tester,
+        "llm_judge_transcription",
+        return_value={
+            "score": 0.8,
+            "feedback": "ok",
+            "suggestions": ["improve a", "improve a", "improve b"],
+            "error_pattern": "ep",
+            "semantic_preservation": False,
+        },
+    ):
+        results = tester.run_comprehensive_test()
+
+    assert results["total_tests"] == 2
+    assert len(results["individual_results"]) == 2
+    assert abs(results["summary"]["average_accuracy"] - 0.8) < 1e-9
+    # two categories: simple + programming, both average 0.8 -> max/min still set
+    assert results["summary"]["best_category"] in {"simple", "programming"}
+    assert results["summary"]["worst_category"] in {"simple", "programming"}
+    # suggestion aggregation sorted by frequency desc
+    suggestions = results["summary"]["improvement_suggestions"]
+    assert suggestions[0]["frequency"] >= suggestions[-1]["frequency"]
+    first = results["individual_results"][0]
+    assert first["transcription"] == "trans"
+    assert first["basic_accuracy"] == 0.5
+    assert first["llm_score"] == 0.8
+    assert first["semantic_preservation"] is False
+
+
+def test_init_empty_phrase_list_falls_back_to_defaults(fake_transcriber):
+    # NOTE: current behavior — an empty list is falsy, so `test_phrases or
+    # self._get_default_test_phrases()` substitutes the defaults. Callers
+    # cannot force "zero phrases" via the constructor argument.
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber, test_phrases=[])
+    assert tester.test_phrases == tester._get_default_test_phrases()
+
+
+def test_run_comprehensive_test_empty_phrases(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber, test_phrases=["x"])
+    # Set to an empty list post-construction to drive the no-results branches.
+    tester.test_phrases = []
+    results = tester.run_comprehensive_test()
+    assert results["total_tests"] == 0
+    assert results["summary"]["average_accuracy"] == 0.0
+    assert results["summary"]["best_category"] == ""
+    assert results["summary"]["worst_category"] == ""
+
+
+def test_run_comprehensive_test_missing_suggestions_key(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber, test_phrases=["hello world"])
+    with patch.object(
+        tester, "test_transcription_accuracy", return_value=("t", 0.4)
+    ), patch.object(
+        tester, "llm_judge_transcription", return_value={"score": 0.6}
+    ):
+        results = tester.run_comprehensive_test()
+    # No "suggestions" key -> no aggregation, llm_score taken from result.
+    assert results["summary"]["improvement_suggestions"] == []
+    assert results["individual_results"][0]["llm_score"] == 0.6
+
+
+# ---------------------------------------------------------------------------
+# suggest_improvements
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_improvements_low_accuracy(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    results = {
+        "summary": {
+            "average_accuracy": 0.5,
+            "worst_category": "programming",
+            "improvement_suggestions": [
+                {"suggestion": "s1", "frequency": 3},
+                {"suggestion": "s2", "frequency": 2},
+                {"suggestion": "s3", "frequency": 1},
+                {"suggestion": "s4", "frequency": 1},
+            ],
+        }
+    }
+    suggestions = tester.suggest_improvements(results)
+    text = "\n".join(suggestions)
+    assert "higher-quality transcription backend" in text
+    assert "domain-specific vocabulary" in text  # < 0.9 branch
+    assert "programming" in text
+    # only top 3 llm suggestions
+    assert "Frequent issue: s1" in text
+    assert "Frequent issue: s4" not in text
+
+
+def test_suggest_improvements_high_accuracy_minimal(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    results = {"summary": {"average_accuracy": 0.95}}
+    suggestions = tester.suggest_improvements(results)
+    # >= 0.9 and no worst_category, no llm suggestions -> empty list
+    assert suggestions == []
+
+
+def test_suggest_improvements_mid_accuracy(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    results = {"summary": {"average_accuracy": 0.8}}
+    suggestions = tester.suggest_improvements(results)
+    # >=0.7 so no backend switch; <0.9 so vocabulary suggestion present
+    assert any("domain-specific vocabulary" in s for s in suggestions)
+    assert not any("higher-quality transcription backend" in s for s in suggestions)
+
+
+# ---------------------------------------------------------------------------
+# auto_tune_parameters
+# ---------------------------------------------------------------------------
+
+
+def test_auto_tune_low_accuracy_switches_backend(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    rec = tester.auto_tune_parameters({"summary": {"average_accuracy": 0.5}})
+    assert rec["transcription_backend"] == "whisper_api"
+
+
+def test_auto_tune_high_accuracy_keeps_current(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    rec = tester.auto_tune_parameters({"summary": {"average_accuracy": 0.95}})
+    assert rec["transcription_backend"] == "current"
+
+
+def test_auto_tune_timeout_and_preprocessing(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    results = {
+        "summary": {"average_accuracy": 0.95},
+        "individual_results": [
+            {"feedback": "timeout occurred, too much noise"},
+            {"feedback": "volume too quiet and fast speed"},
+            {"feedback": "fine"},
+        ],
+    }
+    rec = tester.auto_tune_parameters(results)
+    # 1 of 3 timeout issues = 33% > 20%
+    assert rec["record_timeout"] == "increase"
+    assert rec["silence_timeout"] == "increase"
+    pre = set(rec["preprocessing"])
+    assert {"noise_reduction", "volume_normalization", "speed_normalization"} <= pre
+
+
+def test_auto_tune_no_timeout_issues(fake_transcriber):
+    with patch.object(st, "TTS_AVAILABLE", False):
+        tester = make_tester(fake_transcriber)
+    results = {
+        "summary": {"average_accuracy": 0.95},
+        "individual_results": [{"feedback": "fine"}],
+    }
+    rec = tester.auto_tune_parameters(results)
+    assert rec["record_timeout"] == "current"
+    assert rec["silence_timeout"] == "current"
+    assert rec["preprocessing"] == []
+
+
+# ---------------------------------------------------------------------------
+# create_self_improvement_loop
+# ---------------------------------------------------------------------------
+
+
+def test_create_self_improvement_loop(fake_transcriber):
+    fake_results = {
+        "summary": {
+            "average_accuracy": 0.7,
+            "best_category": "simple",
+            "worst_category": "programming",
+        }
+    }
+    with patch.object(st, "VoiceSelfTester") as Tester, patch.object(
+        st.time, "sleep"
+    ) as sleep:
+        inst = Tester.return_value
+        inst.run_comprehensive_test.return_value = fake_results
+        inst.suggest_improvements.return_value = ["s"]
+        inst.auto_tune_parameters.return_value = {"transcription_backend": "current"}
+
+        out = create_self_improvement_loop(
+            transcriber=fake_transcriber, iterations=2
+        )
+
+    assert out["total_iterations"] == 2
+    assert len(out["improvement_history"]) == 2
+    assert out["final_accuracy"] == 0.7
+    assert out["accuracy_trend"] == [0.7, 0.7]
+    assert sleep.call_count == 2
+
+
+def test_create_self_improvement_loop_zero_iterations(fake_transcriber):
+    with patch.object(st, "VoiceSelfTester"), patch.object(st.time, "sleep"):
+        out = create_self_improvement_loop(
+            transcriber=fake_transcriber, iterations=0
+        )
+    assert out["total_iterations"] == 0
+    assert out["improvement_history"] == []
+    assert out["final_accuracy"] == 0.0
+    assert out["accuracy_trend"] == []
+
+
+# ---------------------------------------------------------------------------
+# add_self_test_commands (CLI wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_add_self_test_commands_parses_run():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    add_self_test_commands(subparsers)
+    args = parser.parse_args(
+        ["self-test", "run", "--openai-key", "k", "--phrases", "a", "b"]
+    )
+    assert args.command == "self-test"
+    assert args.test_command == "run"
+    assert args.openai_key == "k"
+    assert args.phrases == ["a", "b"]
+
+
+def test_add_self_test_commands_parses_improve_and_benchmark():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    add_self_test_commands(subparsers)
+
+    improve = parser.parse_args(["self-test", "improve", "--iterations", "7"])
+    assert improve.test_command == "improve"
+    assert improve.iterations == 7
+
+    bench = parser.parse_args(
+        ["self-test", "benchmark", "--save-results", "/tmp/x.json"]
+    )
+    assert bench.test_command == "benchmark"
+    assert bench.save_results == "/tmp/x.json"
+
+
+# ---------------------------------------------------------------------------
+# handle_self_test_command (dispatch + output)
+# ---------------------------------------------------------------------------
+
+
+def test_handle_no_test_command(capsys):
+    handle_self_test_command(SimpleNamespace(test_command=None))
+    out = capsys.readouterr().out
+    assert "No self-test command specified" in out
+
+
+def test_handle_missing_attribute(capsys):
+    # args without test_command attribute at all
+    handle_self_test_command(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert "No self-test command specified" in out
+
+
+def test_handle_tts_unavailable(capsys):
+    args = SimpleNamespace(test_command="run")
+    with patch.object(st, "TTS_AVAILABLE", False):
+        handle_self_test_command(args)
+    out = capsys.readouterr().out
+    assert "TTS not available" in out
+
+
+def test_handle_run_success(capsys):
+    args = SimpleNamespace(test_command="run", openai_key=None, phrases=["hello world"])
+    fake_results = {
+        "summary": {
+            "average_accuracy": 0.85,
+            "best_category": "simple",
+            "worst_category": "complex",
+        }
+    }
+    fake_tester = MagicMock()
+    fake_tester.run_comprehensive_test.return_value = fake_results
+    fake_tester.suggest_improvements.return_value = ["do x", "do y"]
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "VoiceSelfTester", return_value=fake_tester
+    ) as Tester:
+        handle_self_test_command(args)
+    Tester.assert_called_once_with(openai_api_key=None, test_phrases=["hello world"])
+    out = capsys.readouterr().out
+    assert "Running voice self-test" in out
+    assert "85" in out
+    assert "do x" in out
+
+
+def test_handle_run_no_suggestions(capsys):
+    args = SimpleNamespace(test_command="run", openai_key=None, phrases=None)
+    fake_tester = MagicMock()
+    fake_tester.run_comprehensive_test.return_value = {
+        "summary": {
+            "average_accuracy": 0.99,
+            "best_category": "simple",
+            "worst_category": "simple",
+        }
+    }
+    fake_tester.suggest_improvements.return_value = []
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "VoiceSelfTester", return_value=fake_tester
+    ):
+        handle_self_test_command(args)
+    out = capsys.readouterr().out
+    assert "Improvement suggestions" not in out
+
+
+def test_handle_improve(capsys):
+    args = SimpleNamespace(test_command="improve", openai_key="k", iterations=2)
+    loop_result = {"final_accuracy": 0.77, "accuracy_trend": [0.7, 0.77]}
+    fake_transcriber = MagicMock()
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "VoiceTranscriber", return_value=fake_transcriber
+    ) as VT, patch.object(
+        st, "create_self_improvement_loop", return_value=loop_result
+    ) as loop:
+        handle_self_test_command(args)
+    VT.assert_called_once_with(backend="whisper_local")
+    loop.assert_called_once_with(
+        transcriber=fake_transcriber, openai_api_key="k", iterations=2
+    )
+    out = capsys.readouterr().out
+    assert "Improvement Results" in out
+    assert "77" in out
+
+
+def test_handle_benchmark_with_save(capsys, tmp_path):
+    save_path = tmp_path / "results.json"
+    args = SimpleNamespace(
+        test_command="benchmark", openai_key=None, save_results=str(save_path)
+    )
+    fake_results = {"summary": {"average_accuracy": 0.9}}
+    fake_tester = MagicMock()
+    fake_tester.run_comprehensive_test.return_value = fake_results
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "VoiceSelfTester", return_value=fake_tester
+    ):
+        handle_self_test_command(args)
+    out = capsys.readouterr().out
+    assert "Benchmark complete" in out
+    assert "saved to" in out
+    assert json.loads(save_path.read_text())["summary"]["average_accuracy"] == 0.9
+
+
+def test_handle_benchmark_no_save(capsys):
+    args = SimpleNamespace(test_command="benchmark", openai_key=None, save_results=None)
+    fake_tester = MagicMock()
+    fake_tester.run_comprehensive_test.return_value = {
+        "summary": {"average_accuracy": 0.6}
+    }
+    with patch.object(st, "TTS_AVAILABLE", True), patch.object(
+        st, "VoiceSelfTester", return_value=fake_tester
+    ):
+        handle_self_test_command(args)
+    out = capsys.readouterr().out
+    assert "Benchmark complete" in out
+    assert "saved to" not in out
+
+
+def test_handle_unknown_command_no_output(capsys):
+    # An unrecognized test_command falls through all branches silently.
+    args = SimpleNamespace(test_command="bogus")
+    with patch.object(st, "TTS_AVAILABLE", True):
+        handle_self_test_command(args)
+    out = capsys.readouterr().out
+    assert out == ""


### PR DESCRIPTION
Four hermetic, **test-only** suites (no production source changed).

| Module | Before | After |
|---|---|---|
| voice/self_test.py | 0% | **98%** |
| voice/enhanced_processor.py | 0% | **100%** |
| app/orchestrator.py | 65% | **~97%** (with existing) |
| voice/transcription.py | 72% | raised |

Real branches — lazy-import fallbacks, VAD/noise reduction, transcription error paths, adapter lifecycle/selection, advisor dispatch, the TTS→STT→LLM-judge self-test loop — all deps mocked at the import boundary (no models/devices/network). **No production bugs found.**

## ⚠️ Pre-existing test-isolation bug surfaced (NOT fixed here)
Two existing files leave a MagicMock `numpy` in `sys.modules` **unrestored** — `test_transcription_comprehensive.py:258` and `test_wakeword_comprehensive.py:18` (module-level). That breaks `pytest.approx` (its `isinstance(val, np.bool_)` numpy-detection) for any later test. My self_test accuracy assertions use plain float tolerance instead of `pytest.approx` so they're immune regardless of ordering. **Recommend a follow-up** to make those two files restore `sys.modules` (monkeypatch/patch.dict) so the leak can't bite future `pytest.approx` users.

Full suite **1483 passed, 1 skipped**; ruff clean. Test-only — Docker image unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)