### PR TITLE
test: fix latent sys.modules['numpy'] isolation leaks + tick coverage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Progress counts in each section header count top-level checkboxes only; nesting 
 
 - [x] **Python suite green** — the pre-reset backlog of 85+ failing tests (config edge cases, command executor, states, metrics) is resolved; full `uv run pytest` passes on `main`
 - [x] **Frontend unit tests** — `webui/frontend/package.json` has no `test` script at all (only `test:e2e` Playwright). Add Vitest + React Testing Library and cover the providers/components that currently only have e2e coverage.
-- [ ] **Raise Python coverage on thin areas** — web routes sit at 20-38%, `avatar_ws.py` at ~28% per the audit; prioritize routes that now carry auth and preference state
+- [x] **Raise Python coverage on thin areas** — done across several waves: ws.py/llm/manager/lifecycle/avatar routes → ~100% (#671), llm·voice·cli surfaces (#682), and voice self_test/enhanced_processor/orchestrator/transcription (#686). Web routes that carry auth/preferences are now well-covered. A latent `sys.modules['numpy']` test-isolation leak surfaced along the way was also fixed (#687).
 
 ### Documentation (6/6)
 

--- a/tests/test_transcription_comprehensive.py
+++ b/tests/test_transcription_comprehensive.py
@@ -255,22 +255,26 @@ class TestVoiceTranscriber:
         mock_np.frombuffer.return_value = MagicMock()
         mock_np.sqrt.return_value = 100  # Above threshold
         mock_np.mean.return_value = 1000000
-        sys.modules["numpy"] = mock_np
 
-        # Mock time to simulate silence timeout
-        mock_time.time.side_effect = [0, 0.5, 0.6, 1.6]  # Trigger silence timeout
-        mock_time.sleep = MagicMock()
+        # Scope the numpy mock to this test via patch.dict so it is RESTORED on
+        # exit. Assigning sys.modules["numpy"] directly (the previous behaviour)
+        # leaked a MagicMock numpy into every later test, breaking pytest.approx
+        # (its isinstance(val, np.bool_) numpy-detection raises on a MagicMock).
+        with patch.dict(sys.modules, {"numpy": mock_np}):
+            # Mock time to simulate silence timeout
+            mock_time.time.side_effect = [0, 0.5, 0.6, 1.6]  # Trigger silence timeout
+            mock_time.sleep = MagicMock()
 
-        transcriber = VoiceTranscriber(backend="mock")
-        transcriber.silence_timeout = 1.0
+            transcriber = VoiceTranscriber(backend="mock")
+            transcriber.silence_timeout = 1.0
 
-        # Mock stream to return data then empty (silence)
-        mock_stream.read.side_effect = [b"audio_data", b""]
+            # Mock stream to return data then empty (silence)
+            mock_stream.read.side_effect = [b"audio_data", b""]
 
-        result = transcriber._record_audio()
+            result = transcriber._record_audio()
 
-        assert result == b"audio_data"
-        mock_stream.read.assert_called()
+            assert result == b"audio_data"
+            mock_stream.read.assert_called()
 
     @patch("chatty_commander.voice.transcription.AUDIO_DEPS_AVAILABLE", True)
     @patch("chatty_commander.voice.transcription.pyaudio")

--- a/tests/test_wakeword_comprehensive.py
+++ b/tests/test_wakeword_comprehensive.py
@@ -15,7 +15,9 @@ mock_model_mod = types.ModuleType("openwakeword.model")
 mock_model_mod.Model = MagicMock()
 sys.modules["openwakeword.model"] = mock_model_mod
 sys.modules["pyaudio"] = types.ModuleType("pyaudio")
-sys.modules["numpy"] = types.ModuleType("numpy")
+# NOTE: do NOT mock numpy here. numpy is installed, and replacing it with an
+# empty module at import time leaked globally (never restored), breaking
+# pytest.approx's numpy detection in any later test under random ordering.
 
 import importlib  # noqa: E402
 


### PR DESCRIPTION
Follow-up to #686, fixing the **pre-existing** test-isolation bug that batch surfaced.

Two existing files replaced `sys.modules['numpy']` without restoring it, poisoning numpy globally for later tests:
- `test_transcription_comprehensive.py:258` — assigned a **MagicMock** → broke `pytest.approx` (`isinstance() arg 2 must be a type`). Now scoped via `patch.dict` (restores on exit).
- `test_wakeword_comprehensive.py:18` — replaced numpy with an **empty module** at import time → broke `pytest.approx` (`AttributeError` on `np.bool_`). Removed; the mock was unnecessary (numpy is installed).

`pytest-randomly` is active by default, so this could flake **any** approx-using test depending on collection order — exactly how the #686 self_test tests exposed it.

**Proven**: after each ex-leaker, numpy is restored and `pytest.approx(1/3)` works; both files still pass alone; full suite **1483 passed, 1 skipped** under randomized ordering. Also ticks the 'Raise Python coverage on thin areas' roadmap item (covered across #671/#682/#686). Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)