### PR TITLE
dograh: auto-start call-state poller on call init

### DIFF
--- a/src/chatty_commander/advisors/tools/dograh_call.py
+++ b/src/chatty_commander/advisors/tools/dograh_call.py
@@ -72,6 +72,21 @@ def dograh_place_call_tool(workflow_id: int, phone_number: str) -> str:
     finally:
         client.close()
 
+    # Auto-start the call-state poller so the dashboard CallStateBadge lights
+    # up without a manual /track. No-op unless a web server has registered its
+    # event loop (e.g. pure advisor with no server); never raises or blocks.
+    try:
+        from chatty_commander.integrations.dograh_call_state import (
+            extract_run_id,
+            get_poller_registry,
+        )
+
+        extracted_run_id = extract_run_id(result if isinstance(result, dict) else {})
+        if extracted_run_id is not None:
+            get_poller_registry().request_start(workflow_id, extracted_run_id)
+    except Exception as exc:  # noqa: BLE001 - never fail a successful call
+        logger.debug("dograh call-state auto-start failed: %s", exc)
+
     run_id = result.get("workflow_run_id") or result.get("id")
     return f"Call queued via dograh: workflow_run_id={run_id}"
 

--- a/src/chatty_commander/app/command_executor.py
+++ b/src/chatty_commander/app/command_executor.py
@@ -372,8 +372,39 @@ class CommandExecutor:
             return False
 
         logging.info(f"dograh_call ok: workflow {workflow_id} result={result}")
+
+        # Auto-start the call-state poller so the dashboard CallStateBadge
+        # lights up without a manual /track. This is a no-op unless a web
+        # server has registered its event loop; it never raises or blocks.
+        self._request_dograh_call_state_start(workflow_id, result)
+
         logging.info(f"Completed execution of command: {command_name}")
         return True
+
+    @staticmethod
+    def _request_dograh_call_state_start(workflow_id: int, result: Any) -> None:
+        """Best-effort auto-start of the dograh call-state poller.
+
+        Extracts the run id from the initiate_call result and asks the
+        process-wide poller registry to start polling. Safe no-op when no
+        web server is running. Never raises (the call already succeeded).
+        """
+        try:
+            from chatty_commander.integrations.dograh_call_state import (
+                extract_run_id,
+                get_poller_registry,
+            )
+
+            run_id = extract_run_id(result if isinstance(result, dict) else {})
+            if run_id is None:
+                logging.debug(
+                    "dograh_call: no run id in initiate_call result; "
+                    "skipping call-state auto-start"
+                )
+                return
+            get_poller_registry().request_start(workflow_id, run_id)
+        except Exception as exc:  # noqa: BLE001 - never crash a successful call
+            logging.debug("dograh call-state auto-start failed: %s", exc)
 
     def _execute_custom_message(self, command_name: str, message: str) -> None:
         """Execute a custom message action."""

--- a/src/chatty_commander/cli/dograh_cli.py
+++ b/src/chatty_commander/cli/dograh_cli.py
@@ -166,6 +166,11 @@ def _do_call(
         phone_number=phone_number,
         telephony_configuration_id=telephony_configuration_id,
     )
+    # Intentionally NOT wiring get_poller_registry().request_start here: the
+    # CLI is a short-lived process with no running web server / event loop, so
+    # the trigger would be a guaranteed no-op (nothing registered). Auto-start
+    # only matters for long-lived flows (command_executor / advisor tool) where
+    # a web server may have registered its loop.
     print(json.dumps(result, indent=2, default=str))
     return 0
 

--- a/src/chatty_commander/integrations/dograh_call_state.py
+++ b/src/chatty_commander/integrations/dograh_call_state.py
@@ -121,6 +121,45 @@ def map_run_record(run: dict[str, Any]) -> str:
     return map_dograh_state(extract_run_state(run))
 
 
+# --- UNVERIFIED initiate_call RESULT run-id assumptions ------------------
+#
+# The shape of the dict returned by ``DograhClient.initiate_call`` is not
+# known without a live dograh instance. To auto-start the poller right after
+# a call begins we must pull the *run id* out of that result. We probe these
+# candidate locations in order and use the first that yields an int-coercible
+# value. The workflow id is always known (it's the call arg), so only the run
+# id needs extraction.
+#
+# This mirrors the _RUN_STATE_FIELDS pattern above: a single isolated place
+# to correct once the real result shape is confirmed against a live dograh.
+#   * top-level keys: workflow_run_id / run_id / id
+#   * nested:         run.id
+def extract_run_id(result: dict[str, Any]) -> int | None:
+    """Pull the run id from an ``initiate_call`` result dict, if present.
+
+    Returns the first int-coercible value among the assumed candidate
+    locations, or ``None`` if none is present / coercible. Never raises.
+    """
+    if not isinstance(result, dict):
+        return None
+    candidates: list[Any] = [
+        result.get("workflow_run_id"),
+        result.get("run_id"),
+        result.get("id"),
+    ]
+    run = result.get("run")
+    if isinstance(run, dict):
+        candidates.append(run.get("id"))
+    for value in candidates:
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
 class _RunFetcher(Protocol):
     """Structural type for the bit of DograhClient the poller needs."""
 
@@ -322,14 +361,28 @@ class DograhPollerRegistry:
     def __init__(self) -> None:
         self._start: StartPoller | None = None
         self._stop: StopPoller | None = None
+        # The event loop the start/stop callables belong to. Captured by
+        # web_mode at FastAPI startup (asyncio.get_running_loop()) so that
+        # SYNC callers (command_executor / advisor tool / CLI) — which have
+        # no event-loop handle of their own — can schedule the async
+        # start/stop onto the web server's loop via run_coroutine_threadsafe.
+        self._loop: asyncio.AbstractEventLoop | None = None
 
-    def register(self, *, start: StartPoller, stop: StopPoller) -> None:
+    def register(
+        self,
+        *,
+        start: StartPoller,
+        stop: StopPoller,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
         self._start = start
         self._stop = stop
+        self._loop = loop
 
     def clear(self) -> None:
         self._start = None
         self._stop = None
+        self._loop = None
 
     def is_registered(self) -> bool:
         return self._start is not None and self._stop is not None
@@ -347,6 +400,59 @@ class DograhPollerRegistry:
         result = self._stop()
         if asyncio.iscoroutine(result):
             await result
+
+    # --- SYNC, thread-safe triggers for non-async callers ----------------
+    #
+    # Calls into dograh are initiated from SYNC code (command_executor,
+    # advisor tool, CLI) that has no reference to the web server's event
+    # loop. These helpers bridge sync -> async safely:
+    #
+    #   * If a lifecycle AND its loop are registered (a web server is
+    #     running), schedule the async start/stop on that loop via
+    #     ``asyncio.run_coroutine_threadsafe`` and return immediately —
+    #     never block on the result.
+    #   * If nothing is registered (pure CLI / advisor with no web server),
+    #     it's a safe no-op (debug log).
+    #
+    # They NEVER raise and NEVER block the caller, so wiring them into a
+    # call-initiation path can't crash or hang the call.
+
+    def request_start(self, workflow_id: int, run_id: int) -> None:
+        """Schedule poller start on the registered loop, or no-op.
+
+        Safe to call from any (sync) thread. Returns immediately.
+        """
+        loop = self._loop
+        if not self.is_registered() or loop is None:
+            logger.debug(
+                "dograh request_start: no lifecycle/loop registered; no-op "
+                "(workflow_id=%s run_id=%s)",
+                workflow_id,
+                run_id,
+            )
+            return
+        coro = self.start(workflow_id, run_id)
+        try:
+            asyncio.run_coroutine_threadsafe(coro, loop)
+        except Exception as exc:  # noqa: BLE001 - never crash the call path
+            coro.close()  # don't leak the un-scheduled coroutine
+            logger.debug("dograh request_start scheduling failed: %s", exc)
+
+    def request_stop(self) -> None:
+        """Schedule poller stop on the registered loop, or no-op.
+
+        Safe to call from any (sync) thread. Returns immediately.
+        """
+        loop = self._loop
+        if not self.is_registered() or loop is None:
+            logger.debug("dograh request_stop: no lifecycle/loop registered; no-op")
+            return
+        coro = self.stop()
+        try:
+            asyncio.run_coroutine_threadsafe(coro, loop)
+        except Exception as exc:  # noqa: BLE001 - never crash the call path
+            coro.close()  # don't leak the un-scheduled coroutine
+            logger.debug("dograh request_stop scheduling failed: %s", exc)
 
 
 # Module-level singleton mirroring _HOLDER.

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -453,6 +453,11 @@ class WebModeServer:
             get_poller_registry().register(
                 start=self._track_dograh_run,
                 stop=self.stop_dograh_call_poller,
+                # Capture the running loop so SYNC callers (command_executor,
+                # advisor tool) can schedule auto-start onto it via
+                # request_start/request_stop. Without a registered loop those
+                # triggers are a safe no-op (pure CLI / no web server).
+                loop=asyncio.get_running_loop(),
             )
 
         @self.app.on_event("shutdown")

--- a/tests/test_dograh_call_state_autostart.py
+++ b/tests/test_dograh_call_state_autostart.py
@@ -1,0 +1,280 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+
+"""Tests for auto-starting the dograh call-state poller when a call begins.
+
+Covers the SYNC -> async bridge added to ``DograhPollerRegistry``
+(``request_start`` / ``request_stop``), the isolated run-id extraction
+helper (``extract_run_id``), and the two long-lived call-initiation sites
+that wire it (command_executor + advisor tool).
+
+Everything is mocked: no network, no real event loops where avoidable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from chatty_commander.integrations.dograh_call_state import (
+    DograhPollerRegistry,
+    extract_run_id,
+    get_poller_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    get_poller_registry().clear()
+    yield
+    get_poller_registry().clear()
+
+
+class TestExtractRunId:
+    def test_workflow_run_id_key(self):
+        assert extract_run_id({"workflow_run_id": 17}) == 17
+
+    def test_run_id_key(self):
+        assert extract_run_id({"run_id": 8}) == 8
+
+    def test_top_level_id_key(self):
+        assert extract_run_id({"id": 99}) == 99
+
+    def test_nested_run_id(self):
+        assert extract_run_id({"run": {"id": 42}}) == 42
+
+    def test_precedence_workflow_run_id_first(self):
+        assert extract_run_id({"workflow_run_id": 1, "id": 2}) == 1
+
+    def test_missing_returns_none(self):
+        assert extract_run_id({"unrelated": "x"}) is None
+
+    def test_empty_returns_none(self):
+        assert extract_run_id({}) is None
+
+    def test_non_dict_returns_none(self):
+        assert extract_run_id(None) is None  # type: ignore[arg-type]
+        assert extract_run_id("nope") is None  # type: ignore[arg-type]
+
+    def test_string_coercible_value(self):
+        assert extract_run_id({"id": "55"}) == 55
+
+    def test_non_coercible_value_falls_through(self):
+        # A non-coercible top-level id falls through to the nested run.id.
+        assert extract_run_id({"id": "abc", "run": {"id": 7}}) == 7
+
+
+class _FakeLoop:
+    """Minimal stand-in for an event loop; records scheduled coroutines."""
+
+    def __init__(self):
+        self.scheduled = []
+
+
+class TestRequestStartStop:
+    def test_request_start_schedules_on_registered_loop(self):
+        reg = DograhPollerRegistry()
+        start = MagicMock()
+        stop = MagicMock()
+        loop = _FakeLoop()
+        reg.register(start=start, stop=stop, loop=loop)  # type: ignore[arg-type]
+
+        captured = {}
+
+        def fake_rct(coro, the_loop):
+            captured["loop"] = the_loop
+            captured["coro"] = coro
+            coro.close()  # avoid "coroutine never awaited" warning
+            return MagicMock()
+
+        with patch(
+            "chatty_commander.integrations.dograh_call_state.asyncio.run_coroutine_threadsafe",
+            side_effect=fake_rct,
+        ) as rct:
+            reg.request_start(5, 9)
+
+        rct.assert_called_once()
+        assert captured["loop"] is loop
+
+    def test_request_start_noop_when_nothing_registered(self):
+        reg = DograhPollerRegistry()
+        with patch(
+            "chatty_commander.integrations.dograh_call_state.asyncio.run_coroutine_threadsafe"
+        ) as rct:
+            reg.request_start(1, 1)  # must not raise
+        rct.assert_not_called()
+
+    def test_request_start_noop_when_registered_without_loop(self):
+        reg = DograhPollerRegistry()
+        reg.register(start=MagicMock(), stop=MagicMock(), loop=None)
+        with patch(
+            "chatty_commander.integrations.dograh_call_state.asyncio.run_coroutine_threadsafe"
+        ) as rct:
+            reg.request_start(1, 1)
+        rct.assert_not_called()
+
+    def test_request_stop_schedules_on_registered_loop(self):
+        reg = DograhPollerRegistry()
+        loop = _FakeLoop()
+        reg.register(start=MagicMock(), stop=MagicMock(), loop=loop)  # type: ignore[arg-type]
+
+        def fake_rct(coro, the_loop):
+            coro.close()
+            return MagicMock()
+
+        with patch(
+            "chatty_commander.integrations.dograh_call_state.asyncio.run_coroutine_threadsafe",
+            side_effect=fake_rct,
+        ) as rct:
+            reg.request_stop()
+        rct.assert_called_once()
+
+    def test_request_stop_noop_when_nothing_registered(self):
+        reg = DograhPollerRegistry()
+        with patch(
+            "chatty_commander.integrations.dograh_call_state.asyncio.run_coroutine_threadsafe"
+        ) as rct:
+            reg.request_stop()
+        rct.assert_not_called()
+
+    def test_request_start_never_raises_on_scheduling_error(self):
+        reg = DograhPollerRegistry()
+        reg.register(start=MagicMock(), stop=MagicMock(), loop=_FakeLoop())  # type: ignore[arg-type]
+        with patch(
+            "chatty_commander.integrations.dograh_call_state.asyncio.run_coroutine_threadsafe",
+            side_effect=RuntimeError("loop closed"),
+        ):
+            reg.request_start(1, 1)  # swallowed, no raise
+
+
+class TestCommandExecutorAutoStart:
+    @pytest.fixture
+    def executor(self):
+        from chatty_commander.app.command_executor import CommandExecutor
+
+        config = MagicMock()
+        config.model_actions = {
+            "call_support": {
+                "action": "dograh_call",
+                "workflow_id": 42,
+                "phone_number": "+15555550100",
+            },
+        }
+        return CommandExecutor(config, MagicMock(), MagicMock())
+
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_request_start_called_after_successful_call(
+        self, mock_client_cls, executor
+    ):
+        instance = MagicMock()
+        instance.initiate_call.return_value = {"workflow_run_id": 9}
+        mock_client_cls.return_value.__enter__.return_value = instance
+
+        reg = get_poller_registry()
+        req_start = MagicMock()
+        with patch.object(reg, "request_start", req_start):
+            assert executor.execute_command("call_support") is True
+        req_start.assert_called_once_with(42, 9)
+
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_request_start_not_called_when_no_run_id(
+        self, mock_client_cls, executor
+    ):
+        instance = MagicMock()
+        instance.initiate_call.return_value = {"unrelated": "x"}
+        mock_client_cls.return_value.__enter__.return_value = instance
+
+        reg = get_poller_registry()
+        req_start = MagicMock()
+        with patch.object(reg, "request_start", req_start):
+            assert executor.execute_command("call_support") is True
+        req_start.assert_not_called()
+
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_request_start_not_called_when_call_fails(
+        self, mock_client_cls, executor
+    ):
+        from chatty_commander.integrations.dograh_client import DograhError
+
+        instance = MagicMock()
+        instance.initiate_call.side_effect = DograhError("boom")
+        mock_client_cls.return_value.__enter__.return_value = instance
+
+        reg = get_poller_registry()
+        req_start = MagicMock()
+        with patch.object(reg, "request_start", req_start):
+            assert executor.execute_command("call_support") is False
+        req_start.assert_not_called()
+
+
+class TestAdvisorToolAutoStart:
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_request_start_called_after_successful_call(self, mock_cls):
+        from chatty_commander.advisors.tools.dograh_call import dograh_place_call_tool
+
+        instance = MagicMock()
+        instance.initiate_call.return_value = {"workflow_run_id": 17}
+        mock_cls.return_value = instance
+
+        reg = get_poller_registry()
+        req_start = MagicMock()
+        with patch.object(reg, "request_start", req_start):
+            out = dograh_place_call_tool(42, "+15555550100")
+        assert "17" in out
+        req_start.assert_called_once_with(42, 17)
+
+    @patch("chatty_commander.integrations.dograh_client.DograhClient")
+    def test_request_start_not_called_when_call_fails(self, mock_cls):
+        from chatty_commander.advisors.tools.dograh_call import dograh_place_call_tool
+
+        instance = MagicMock()
+        instance.initiate_call.side_effect = RuntimeError("boom")
+        mock_cls.return_value = instance
+
+        reg = get_poller_registry()
+        req_start = MagicMock()
+        with patch.object(reg, "request_start", req_start):
+            dograh_place_call_tool(42, "+15555550100")
+        req_start.assert_not_called()
+
+
+class TestWebModeRegistersLoop:
+    """The FastAPI startup handler must register the running loop so that
+    sync callers can schedule auto-start onto it."""
+
+    @pytest.mark.asyncio
+    async def test_startup_registers_running_loop(self):
+        import asyncio
+
+        from chatty_commander.app.config import Config
+        from chatty_commander.web.web_mode import WebModeServer
+
+        cfg = Config(config_file="")
+        from chatty_commander.app.model_manager import ModelManager
+        from chatty_commander.app.state_manager import StateManager
+
+        sm = StateManager(cfg)
+        mm = ModelManager(cfg)
+        from chatty_commander.app.command_executor import CommandExecutor
+
+        ce = CommandExecutor(cfg, mm, sm)
+        server = WebModeServer(cfg, sm, mm, ce, no_auth=True)
+
+        # Manually fire the registered startup handlers (TestClient would do
+        # this, but we want the running-loop capture in an async context).
+        for handler in server.app.router.on_startup:
+            res = handler()
+            if asyncio.iscoroutine(res):
+                await res
+        try:
+            reg = get_poller_registry()
+            assert reg.is_registered()
+            # The captured loop is the one running this test.
+            assert reg._loop is asyncio.get_running_loop()
+        finally:
+            for handler in server.app.router.on_shutdown:
+                res = handler()
+                if asyncio.iscoroutine(res):
+                    await res


### PR DESCRIPTION
Makes the phase-0 bridge (#680/#684) light up the dashboard automatically — no manual `/track` needed.

- New thread-safe `DograhPollerRegistry.request_start/request_stop` bridges the **sync** call-initiation paths into the web server's event loop (`run_coroutine_threadsafe`); safe **no-op** when no server loop is registered (CLI/advisor-without-server). web_mode captures its loop at startup.
- Wired after a successful `initiate_call` in command_executor + the advisor tool; CLI intentionally skipped (short-lived, no loop).
- Run-id pulled from the `initiate_call` result via `extract_run_id()`.

## ⚠️ Assumption to confirm against a live dograh
The result key for the run id is unverified — probed in order `workflow_run_id` / `run_id` / `id` / `run.id`, isolated in one helper with a flagged comment (same pattern as the run-state-field constants). No id → safe no-op.

## Evidence
- **1506 passed, 1 skipped**; ruff + mypy clean; CLI `--help` runs. Default/--no-auth/non-web flows unchanged, can't crash/hang. Python-only — no Docker rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)