### PR TITLE
AuthZ phase 3: scoped service-to-service API keys

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -139,7 +139,7 @@ Spike + feasibility: [`docs/developer/WEBRTC_BRIDGE_SPIKE.md`](docs/developer/WE
 - [x] **Secrets validation at startup** — fail fast when required env vars are missing; document all of them in `.env.example`
 - [ ] **AuthN/AuthZ depth** — implementing [`docs/developer/AUTHZ_DESIGN.md`](docs/developer/AUTHZ_DESIGN.md) phase by phase (opt-in; default/`--no-auth` unchanged throughout):
   - [x] **Phase 1 — token refresh + jti revocation** (#690): login also returns a refresh token, `POST /api/v1/auth/refresh` rotates, in-memory self-pruning denylist (sqlite seam left for later), logout revokes
-  - [ ] **Phase 2 — role-based access** (admin/user/readonly via a `require_role` dependency)
+  - [x] **Phase 2 — role-based access** (admin/user/readonly via a `require_role` dependency) (#692) — additive, pass-through when auth inactive; guards PUT /config (admin) + POST /command (user)
   - [ ] **Phase 3 — scoped service-to-service API keys**
   - [ ] **Phase 4 — optional persistent (sqlite) revocation store**
   Two gaps surfaced during the survey, both already fixed:

--- a/src/chatty_commander/utils/security.py
+++ b/src/chatty_commander/utils/security.py
@@ -48,6 +48,7 @@ _SENSITIVE_KEY_PATTERNS = frozenset(
         "accesstoken",
         "authtoken",
         "bridgetoken",
+        "keyhash",
         "password",
         "passwd",
         "secret",

--- a/src/chatty_commander/web/deps/auth.py
+++ b/src/chatty_commander/web/deps/auth.py
@@ -73,7 +73,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import jwt
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, Header, HTTPException, Request
 
 from ..revocation import InMemoryRevocationStore, RevocationStore
 
@@ -346,5 +346,133 @@ def require_role(minimum: str) -> Callable[..., Principal]:
         if principal.max_rank < needed:
             raise HTTPException(status_code=403, detail="Insufficient role")
         return principal
+
+    return _dep
+
+
+# ── scope-based service-key guard (design §5) ───────────────────────────────
+
+
+def request_scopes(request: Request) -> list[str] | None:
+    """Return the X-API-Key scopes the middleware attached, or ``None``.
+
+    The Phase-3 ``AuthMiddleware`` sets ``request.state.scopes`` to the resolved
+    scope list (``["*"]`` for the legacy wildcard key, or a service key's
+    configured scopes) only when it actively validated an X-API-Key. ``None``
+    means the coarse gate did not run for this request — i.e. ``--no-auth`` mode
+    or no API key configured at all — which is the pass-through signal for
+    :func:`require_scope` (the same degradation rule as :func:`require_role`).
+    """
+    scopes = getattr(request.state, "scopes", None)
+    if isinstance(scopes, list):
+        return [s for s in scopes if isinstance(s, str)]
+    return None
+
+
+def has_scope(scopes: list[str] | None, required: str) -> bool:
+    """True if ``scopes`` grants ``required`` (wildcard ``"*"`` satisfies any)."""
+    if not scopes:
+        return False
+    return "*" in scopes or required in scopes
+
+
+def require_scope(scope: str) -> Callable[..., list[str] | None]:
+    """Build a dependency requiring the X-API-Key to carry ``scope``.
+
+    Additive + opt-in, mirroring :func:`require_role`'s degradation rule:
+
+    * When the coarse X-API-Key gate did **not** run (``--no-auth`` mode, or no
+      API key configured at all), ``request.state.scopes`` is unset and this
+      guard is a **pass-through** — default / ``--no-auth`` flows are unchanged.
+    * When the gate **did** run, the request already presented a valid key. The
+      wildcard legacy key (scopes ``["*"]``) satisfies any required scope; a
+      named service key must list ``scope`` explicitly, else 403.
+
+    Returns the resolved scope list (or ``None`` on the pass-through path) so a
+    route can introspect it if needed.
+    """
+
+    def _dep(request: Request) -> list[str] | None:
+        scopes = request_scopes(request)
+        if scopes is None:
+            # Coarse gate did not run (no_auth / no key config): pass-through.
+            return None
+        if not has_scope(scopes, scope):
+            raise HTTPException(status_code=403, detail="Insufficient scope")
+        return scopes
+
+    return _dep
+
+
+def soft_principal(authorization: str | None) -> Principal:
+    """Resolve a :class:`Principal` *without* hard-failing on a missing token.
+
+    Like :func:`current_principal` but tailored for the role-OR-scope
+    composition: when user auth is inactive it returns :data:`ANONYMOUS`; when
+    auth is active and **no** ``Authorization`` header is present it *still*
+    returns :data:`ANONYMOUS` (so a service-key-only caller is not 401'd before
+    the scope axis is consulted). A header that *is* present but malformed /
+    expired / revoked / wrong-type still raises 401 — a broken token is an
+    error, not a silent fall-through.
+    """
+    ctx = get_auth_context()
+    if not ctx.is_auth_active():
+        return ANONYMOUS
+    secret = jwt_secret_for(ctx.config_manager)
+    if not secret:  # pragma: no cover - is_auth_active already checked this
+        return ANONYMOUS
+    if not authorization:
+        return ANONYMOUS
+    claims = decode_access_token(
+        bearer_token(authorization), secret, store=ctx.revocation_store
+    )
+    sub = claims.get("sub")
+    return Principal(
+        sub=sub if isinstance(sub, str) else None,
+        roles=roles_from(claims.get("roles", [])),
+    )
+
+
+def require_role_or_scope(*, role: str, scope: str) -> Callable[..., None]:
+    """Build a guard satisfied by EITHER a user ``role`` OR a service ``scope``.
+
+    This is the design §5 composition for machine-facing endpoints that should
+    accept both an interactive user (Bearer token carrying ``role``) **and** a
+    service-to-service caller (X-API-Key carrying ``scope``). It is strictly
+    *more permissive* than the previous bare ``require_role(role)`` guard — any
+    request that would have passed before still passes — so it is non-breaking.
+
+    Degradation: if *both* axes are inactive the request is allowed, preserving
+    the default / ``--no-auth`` behavior. Otherwise the request must satisfy at
+    least one *active* axis, else 403. A missing Bearer token does not 401 here
+    (the scope axis may carry the request); a present-but-broken token still
+    401s via :func:`soft_principal`.
+    """
+    if role not in ROLE_RANK:
+        raise ValueError(f"unknown role: {role!r}")
+    needed = ROLE_RANK[role]
+
+    def _dep(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> None:
+        principal = soft_principal(authorization)
+        scopes = request_scopes(request)
+        role_active = not principal.anonymous
+        scope_active = scopes is not None
+
+        # Both axes inactive → pure pass-through (default / --no-auth), allow.
+        if not role_active and not scope_active:
+            return
+
+        # Otherwise the request must satisfy at least one *active* axis. An
+        # inactive axis cannot satisfy (its mechanism issued no credential), so
+        # e.g. a readonly Bearer user on a key-less deployment is still denied
+        # exactly as require_role("user") would have denied it (non-breaking).
+        if role_active and principal.max_rank >= needed:
+            return
+        if scope_active and has_scope(scopes, scope):
+            return
+        raise HTTPException(status_code=403, detail="Insufficient role or scope")
 
     return _dep

--- a/src/chatty_commander/web/middleware/auth.py
+++ b/src/chatty_commander/web/middleware/auth.py
@@ -32,6 +32,7 @@ from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from chatty_commander.utils.security import constant_time_compare
+from chatty_commander.web.middleware.service_keys import resolve_service_key_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -131,12 +132,23 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 f"API request to {path}, API key present: {api_key is not None}"
             )
 
-            # Get expected API key from env (preferred) or config.
+            # Get expected legacy single key from env (preferred) or config.
             expected_key = resolve_expected_api_key(self.config_manager)
             logger.debug("Expected API key resolved: present=%s", bool(expected_key))
 
-            # Check if API key is valid
-            if not constant_time_compare(api_key, expected_key):
+            # Phase 3 (design §5): the X-API-Key is valid if it matches the
+            # legacy single key (→ wildcard scope ['*']) OR any *active* named
+            # service key (→ that key's configured scopes). The legacy key is
+            # checked first so its byte-for-byte behavior is unchanged; service
+            # keys are opt-in and only consulted when an `auth.service_keys`
+            # block exists (resolve_service_key_scopes returns None otherwise).
+            scopes: list[str] | None = None
+            if constant_time_compare(api_key, expected_key):
+                scopes = ["*"]
+            else:
+                scopes = resolve_service_key_scopes(self.config_manager, api_key)
+
+            if scopes is None:
                 logger.debug("Auth failed for %s - API key mismatch or missing", path)
                 # Return 401 response directly instead of raising exception
                 from fastapi.responses import JSONResponse
@@ -145,6 +157,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     status_code=401, content={"detail": "Invalid or missing API key"}
                 )
 
-            logger.debug("Authentication successful")
+            # Attach the resolved scopes so per-route require_scope dependencies
+            # (web/deps/auth.py) can authorize without re-validating the key.
+            request.state.scopes = scopes
+            logger.debug("Authentication successful (scopes=%s)", scopes)
 
         return await call_next(request)  # type: ignore[no-any-return]

--- a/src/chatty_commander/web/middleware/service_keys.py
+++ b/src/chatty_commander/web/middleware/service_keys.py
@@ -1,0 +1,140 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Named, scoped service-to-service API keys (AUTHZ_DESIGN.md §5, Phase 3).
+
+This is the **opt-in** registry layer that lets the coarse global ``X-API-Key``
+gate accept more than one key. Config shape (extends the same ``auth`` dict the
+middleware already reads)::
+
+    "auth": {
+      "api_key": "legacy-single-key",          # STILL honored → scope ["*"]
+      "service_keys": {
+        "discord-bridge":  {"key_hash": "$2b$…", "scopes": ["command:write"], "active": true},
+        "metrics-scraper": {"key_hash": "$2b$…", "scopes": ["status:read"],   "active": true}
+      }
+    }
+
+Back-compat contract
+---------------------
+* When **no** ``auth.service_keys`` block is configured, :func:`resolve_service_key_scopes`
+  returns ``None`` for every input — the registry is effectively absent and the
+  middleware falls back to the legacy single-key path byte-for-byte.
+* The legacy plaintext ``auth.api_key`` is handled entirely by the middleware
+  and is treated as a **wildcard** key (scopes ``["*"]``); this module never
+  sees it.
+
+Lookup
+------
+Service keys are stored **bcrypt-hashed**. A presented plaintext key is checked
+with :func:`bcrypt.checkpw` against each *active* candidate's ``key_hash``. We
+iterate the full active candidate set (no short-circuit on first failure) so the
+work — and timing — does not depend on *which* key matched, mirroring the
+constant-time intent already used for the legacy key compare. The first active
+key whose hash verifies wins and its configured scopes are returned.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import bcrypt
+
+logger = logging.getLogger(__name__)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def service_keys_config(config_manager: Any) -> dict[str, Any]:
+    """Return the ``auth.service_keys`` mapping from either Config shape.
+
+    Mirrors the middleware's dual lookup: ``config_manager.auth`` (DummyConfig /
+    test objects) or ``config_manager.config["auth"]`` (the real ``Config``).
+    Returns an empty dict when no service keys are configured.
+    """
+    if config_manager is None:
+        return {}
+    auth_attr = getattr(config_manager, "auth", None)
+    if isinstance(auth_attr, dict):
+        auth = auth_attr
+    else:
+        cfg = getattr(config_manager, "config", None)
+        auth = _as_dict(cfg.get("auth")) if isinstance(cfg, dict) else {}
+    return _as_dict(auth.get("service_keys"))
+
+
+def _verify_key_hash(provided: str, key_hash: Any) -> bool:
+    """Constant-time bcrypt check; tolerant of malformed/empty hashes.
+
+    Mirrors ``routes/auth.py:_verify_password`` so the codebase has a single
+    bcrypt-verify idiom.
+    """
+    if not isinstance(key_hash, str) or not key_hash:
+        return False
+    try:
+        return bcrypt.checkpw(provided.encode("utf-8"), key_hash.encode("utf-8"))
+    except (ValueError, TypeError):
+        return False
+
+
+def _scopes_from(raw: Any) -> list[str]:
+    return [s for s in raw if isinstance(s, str)] if isinstance(raw, list) else []
+
+
+def resolve_service_key_scopes(
+    config_manager: Any, provided_key: str | None
+) -> list[str] | None:
+    """Resolve a presented X-API-Key to its service-key scopes.
+
+    Returns the matched **active** service key's scopes (possibly an empty list
+    if the key declares none). Returns ``None`` when:
+
+    * no ``auth.service_keys`` block is configured (registry absent), or
+    * ``provided_key`` is blank/missing, or
+    * no active service key's ``key_hash`` verifies against ``provided_key``.
+
+    Inactive keys (``"active": false`` or missing/non-true) are never
+    candidates, so a rotated-out key is rejected even though its hash is still
+    on file.
+    """
+    if not provided_key:
+        return None
+    registry = service_keys_config(config_manager)
+    if not registry:
+        return None
+
+    matched_scopes: list[str] | None = None
+    # Iterate every active candidate (no early break) so timing does not reveal
+    # which named key matched.
+    for name, spec in registry.items():
+        if not isinstance(spec, dict):
+            continue
+        if spec.get("active") is not True:
+            continue
+        if _verify_key_hash(provided_key, spec.get("key_hash")):
+            if matched_scopes is None:
+                logger.debug("Service key matched: %s", name)
+                matched_scopes = _scopes_from(spec.get("scopes"))
+    return matched_scopes

--- a/src/chatty_commander/web/routes/core.py
+++ b/src/chatty_commander/web/routes/core.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from chatty_commander.utils.security import mask_sensitive_data
-from chatty_commander.web.deps.auth import require_role
+from chatty_commander.web.deps.auth import require_role, require_scope
 
 logger = logging.getLogger(__name__)
 
@@ -490,7 +490,16 @@ def include_core_routes(
             timestamp=get_last_state_change().isoformat(),
         )
 
-    @router.post("/api/v1/state")
+    @router.post(
+        "/api/v1/state",
+        # Phase-3 scopes (design §5): this is a machine-facing state change, so
+        # a service-to-service caller must present an X-API-Key carrying the
+        # ``state:write`` scope (the legacy wildcard key ['*'] satisfies it).
+        # Additive + opt-in — pass-through when the coarse X-API-Key gate did
+        # not run (--no-auth / no key configured), so default flows are
+        # unchanged. A named service key WITHOUT this scope gets 403.
+        dependencies=[Depends(require_scope("state:write"))],
+    )
     async def change_state(request: StateChangeRequest):
         counters["state_post"] += 1
         try:

--- a/tests/test_require_scope.py
+++ b/tests/test_require_scope.py
@@ -1,0 +1,210 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Phase-3 ``require_scope`` dependency + role-OR-scope composition (§5).
+
+Unit-level: the scope guard behavior in isolation, and the helper predicates.
+The simulated ``request.state.scopes`` mirrors what the Phase-3 AuthMiddleware
+attaches.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+from chatty_commander.web.deps.auth import (
+    JWT_ALGORITHM,
+    configure_auth_context,
+    get_auth_context,
+    has_scope,
+    request_scopes,
+    require_role_or_scope,
+    require_scope,
+)
+
+SECRET = "scope-test-secret"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.delenv("CHATTY_JWT_SECRET", raising=False)
+    monkeypatch.delenv("CHATTY_API_KEY", raising=False)
+    get_auth_context().reset()
+    yield
+    get_auth_context().reset()
+
+
+def _req(scopes):
+    """A stand-in Request whose ``.state.scopes`` mimics the middleware."""
+    state = SimpleNamespace()
+    if scopes is not _UNSET:
+        state.scopes = scopes
+    return SimpleNamespace(state=state)
+
+
+_UNSET = object()
+
+
+# ── predicate helpers ───────────────────────────────────────────────────────
+
+
+def test_has_scope_matching():
+    assert has_scope(["status:read", "command:write"], "command:write") is True
+
+
+def test_has_scope_wildcard():
+    assert has_scope(["*"], "anything:goes") is True
+
+
+def test_has_scope_missing():
+    assert has_scope(["status:read"], "command:write") is False
+
+
+def test_has_scope_none_or_empty():
+    assert has_scope(None, "x") is False
+    assert has_scope([], "x") is False
+
+
+def test_request_scopes_unset_is_none():
+    assert request_scopes(_req(_UNSET)) is None
+
+
+def test_request_scopes_reads_state():
+    assert request_scopes(_req(["a", "b"])) == ["a", "b"]
+
+
+# ── require_scope ────────────────────────────────────────────────────────────
+
+
+def test_require_scope_allows_matching():
+    dep = require_scope("command:write")
+    assert dep(_req(["command:write"])) == ["command:write"]
+
+
+def test_require_scope_allows_wildcard():
+    dep = require_scope("command:write")
+    assert dep(_req(["*"])) == ["*"]
+
+
+def test_require_scope_forbids_without_scope():
+    dep = require_scope("command:write")
+    with pytest.raises(HTTPException) as exc:
+        dep(_req(["status:read"]))
+    assert exc.value.status_code == 403
+
+
+def test_require_scope_passthrough_when_gate_inactive():
+    # No scopes on request.state => coarse gate did not run (no_auth / no key
+    # configured) => pass-through (returns None, no raise).
+    dep = require_scope("command:write")
+    assert dep(_req(_UNSET)) is None
+
+
+# ── require_role_or_scope composition ────────────────────────────────────────
+
+
+def _token(roles):
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "sub": "u",
+            "roles": roles,
+            "type": "access",
+            "jti": "jti-" + "-".join(roles),
+            "iat": now,
+            "exp": now + 600,
+        },
+        SECRET,
+        algorithm=JWT_ALGORITHM,
+    )
+
+
+def _activate_role_auth():
+    cfg = SimpleNamespace(
+        config={
+            "auth": {
+                "jwt_secret": SECRET,
+                "users": {"u": {"password_hash": "x", "roles": ["user"]}},
+            }
+        }
+    )
+    configure_auth_context(config_manager=cfg, no_auth=False)
+    assert get_auth_context().is_auth_active() is True
+
+
+def _req2(scopes, authorization=None):
+    state = SimpleNamespace()
+    if scopes is not _UNSET:
+        state.scopes = scopes
+    return SimpleNamespace(state=state), authorization
+
+
+def test_role_or_scope_both_inactive_passthrough():
+    # Role auth inactive AND no scopes attached => pure pass-through.
+    dep = require_role_or_scope(role="user", scope="command:write")
+    req, authz = _req2(_UNSET, None)
+    assert dep(req, authz) is None
+
+
+def test_role_or_scope_allows_sufficient_role():
+    _activate_role_auth()
+    dep = require_role_or_scope(role="user", scope="command:write")
+    req, authz = _req2(_UNSET, f"Bearer {_token(['user'])}")
+    assert dep(req, authz) is None  # role axis satisfies
+
+
+def test_role_or_scope_allows_matching_scope_without_token():
+    # Service caller: no Bearer token but an X-API-Key carried command:write.
+    # Even with role auth active, the scope axis satisfies and no 401 is raised.
+    _activate_role_auth()
+    dep = require_role_or_scope(role="user", scope="command:write")
+    req, authz = _req2(["command:write"], None)
+    assert dep(req, authz) is None
+
+
+def test_role_or_scope_denies_when_neither_satisfies():
+    _activate_role_auth()
+    dep = require_role_or_scope(role="user", scope="command:write")
+    # readonly role (insufficient) and a non-matching scope.
+    req, authz = _req2(["status:read"], f"Bearer {_token(['readonly'])}")
+    with pytest.raises(HTTPException) as exc:
+        dep(req, authz)
+    assert exc.value.status_code == 403
+
+
+def test_role_or_scope_broken_token_still_401s():
+    _activate_role_auth()
+    dep = require_role_or_scope(role="user", scope="command:write")
+    req, authz = _req2(_UNSET, "Bearer garbage")
+    with pytest.raises(HTTPException) as exc:
+        dep(req, authz)
+    assert exc.value.status_code == 401
+
+
+def test_require_scope_unknown_role_rejected_for_composition():
+    with pytest.raises(ValueError):
+        require_role_or_scope(role="superuser", scope="x")

--- a/tests/test_service_keys.py
+++ b/tests/test_service_keys.py
@@ -1,0 +1,240 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Phase-3 service-key registry + middleware coexistence (AUTHZ_DESIGN.md §5).
+
+Covers the registry/lookup unit surface and the AuthMiddleware integration that
+makes the coarse X-API-Key gate accept the legacy single key (→ wildcard scope)
+OR any active named service key (→ that key's scopes), attaching the resolved
+scopes to ``request.state``.
+"""
+
+from __future__ import annotations
+
+import bcrypt
+import pytest
+
+try:
+    from fastapi import FastAPI, Request
+    from fastapi.testclient import TestClient
+except ImportError:  # pragma: no cover
+    pytest.skip("FastAPI not available", allow_module_level=True)
+
+from chatty_commander.web.middleware.auth import AuthMiddleware
+from chatty_commander.web.middleware.service_keys import (
+    resolve_service_key_scopes,
+    service_keys_config,
+)
+
+
+def _hash(secret: str) -> str:
+    return bcrypt.hashpw(secret.encode(), bcrypt.gensalt(rounds=4)).decode()
+
+
+class _Cfg:
+    """Minimal Config-shaped object: ``.config['auth']`` dict lookup."""
+
+    def __init__(self, auth: dict) -> None:
+        self.config = {"auth": auth}
+
+
+@pytest.fixture(autouse=True)
+def _no_env_key(monkeypatch):
+    monkeypatch.delenv("CHATTY_API_KEY", raising=False)
+    yield
+
+
+# ── registry / lookup unit tests ────────────────────────────────────────────
+
+
+def test_no_service_keys_block_returns_none():
+    cfg = _Cfg({"api_key": "legacy"})
+    assert service_keys_config(cfg) == {}
+    assert resolve_service_key_scopes(cfg, "anything") is None
+
+
+def test_active_service_key_resolves_its_scopes():
+    cfg = _Cfg(
+        {
+            "service_keys": {
+                "scraper": {
+                    "key_hash": _hash("scraper-secret"),
+                    "scopes": ["status:read"],
+                    "active": True,
+                }
+            }
+        }
+    )
+    assert resolve_service_key_scopes(cfg, "scraper-secret") == ["status:read"]
+
+
+def test_inactive_service_key_is_rejected():
+    cfg = _Cfg(
+        {
+            "service_keys": {
+                "old": {
+                    "key_hash": _hash("old-secret"),
+                    "scopes": ["command:write"],
+                    "active": False,
+                }
+            }
+        }
+    )
+    # The hash is on file but the key is rotated out: no match.
+    assert resolve_service_key_scopes(cfg, "old-secret") is None
+
+
+def test_wrong_secret_does_not_match():
+    cfg = _Cfg(
+        {
+            "service_keys": {
+                "bridge": {
+                    "key_hash": _hash("right-secret"),
+                    "scopes": ["command:write"],
+                    "active": True,
+                }
+            }
+        }
+    )
+    assert resolve_service_key_scopes(cfg, "wrong-secret") is None
+
+
+def test_blank_or_missing_key_returns_none():
+    cfg = _Cfg(
+        {"service_keys": {"x": {"key_hash": _hash("s"), "scopes": [], "active": True}}}
+    )
+    assert resolve_service_key_scopes(cfg, None) is None
+    assert resolve_service_key_scopes(cfg, "") is None
+
+
+def test_active_key_with_no_scopes_resolves_empty_list():
+    cfg = _Cfg({"service_keys": {"x": {"key_hash": _hash("s"), "active": True}}})
+    # Distinguishable from None (no match): an empty list means "matched, no scopes".
+    assert resolve_service_key_scopes(cfg, "s") == []
+
+
+def test_malformed_spec_is_skipped():
+    cfg = _Cfg(
+        {
+            "service_keys": {
+                "bad": "not-a-dict",
+                "good": {
+                    "key_hash": _hash("good-secret"),
+                    "scopes": ["status:read"],
+                    "active": True,
+                },
+            }
+        }
+    )
+    assert resolve_service_key_scopes(cfg, "good-secret") == ["status:read"]
+
+
+# ── AuthMiddleware coexistence (legacy key OR service key) ───────────────────
+
+
+def _app(auth: dict) -> TestClient:
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware, config_manager=_Cfg(auth))
+
+    @app.get("/api/echo-scopes")
+    async def echo(request: Request):
+        return {"scopes": getattr(request.state, "scopes", None)}
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_legacy_key_authenticates_with_wildcard_scope():
+    client = _app({"api_key": "legacy"})
+    r = client.get("/api/echo-scopes", headers={"X-API-Key": "legacy"})
+    assert r.status_code == 200
+    assert r.json()["scopes"] == ["*"]
+
+
+def test_service_key_authenticates_and_carries_scopes():
+    client = _app(
+        {
+            "service_keys": {
+                "scraper": {
+                    "key_hash": _hash("scraper-secret"),
+                    "scopes": ["status:read"],
+                    "active": True,
+                }
+            }
+        }
+    )
+    r = client.get("/api/echo-scopes", headers={"X-API-Key": "scraper-secret"})
+    assert r.status_code == 200
+    assert r.json()["scopes"] == ["status:read"]
+
+
+def test_legacy_and_service_keys_coexist():
+    client = _app(
+        {
+            "api_key": "legacy",
+            "service_keys": {
+                "bridge": {
+                    "key_hash": _hash("bridge-secret"),
+                    "scopes": ["command:write"],
+                    "active": True,
+                }
+            },
+        }
+    )
+    # Legacy key → wildcard.
+    r1 = client.get("/api/echo-scopes", headers={"X-API-Key": "legacy"})
+    assert r1.status_code == 200 and r1.json()["scopes"] == ["*"]
+    # Service key → its scopes.
+    r2 = client.get("/api/echo-scopes", headers={"X-API-Key": "bridge-secret"})
+    assert r2.status_code == 200 and r2.json()["scopes"] == ["command:write"]
+
+
+def test_inactive_service_key_rejected_by_middleware():
+    client = _app(
+        {
+            "service_keys": {
+                "old": {
+                    "key_hash": _hash("old-secret"),
+                    "scopes": ["command:write"],
+                    "active": False,
+                }
+            }
+        }
+    )
+    r = client.get("/api/echo-scopes", headers={"X-API-Key": "old-secret"})
+    assert r.status_code == 401
+
+
+def test_unknown_key_rejected_when_keys_configured():
+    client = _app(
+        {
+            "api_key": "legacy",
+            "service_keys": {
+                "bridge": {
+                    "key_hash": _hash("bridge-secret"),
+                    "scopes": ["command:write"],
+                    "active": True,
+                }
+            },
+        }
+    )
+    r = client.get("/api/echo-scopes", headers={"X-API-Key": "nope"})
+    assert r.status_code == 401

--- a/tests/test_service_keys_endpoints.py
+++ b/tests/test_service_keys_endpoints.py
@@ -1,0 +1,189 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Phase-3 end-to-end through the real app factory (AUTHZ_DESIGN.md §5).
+
+Proves the guarded service-oriented endpoint POST /api/v1/state honors scopes,
+and — critically — that the back-compat contract holds: the legacy single key
+(wildcard scope) still authenticates; with NO service_keys configured behavior
+is identical to today; and DEFAULT / --no-auth flows are byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+import bcrypt
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+except ImportError:  # pragma: no cover
+    pytest.skip("FastAPI not available", allow_module_level=True)
+
+from chatty_commander.app.config import Config
+from chatty_commander.web.deps.auth import get_auth_context
+from chatty_commander.web.web_mode import create_app
+
+
+def _hash(secret: str) -> str:
+    return bcrypt.hashpw(secret.encode(), bcrypt.gensalt(rounds=4)).decode()
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.delenv("CHATTY_JWT_SECRET", raising=False)
+    monkeypatch.delenv("CHATTY_API_KEY", raising=False)
+    get_auth_context().reset()
+    yield
+    get_auth_context().reset()
+
+
+def _make_config(auth: dict | None) -> Config:
+    cfg = Config(config_file="")
+    # Populate state_models so a state change actually succeeds (200); with the
+    # empty default the StateManager raises and the handler returns 400, which
+    # would mask the auth behavior we are testing.
+    cfg.state_models = {"idle": [], "computer": [], "chatty": []}
+    if auth is not None:
+        cfg.config["auth"] = auth
+    return cfg
+
+
+def _client(auth: dict | None) -> TestClient:
+    app = create_app(config=_make_config(auth), no_auth=False)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── back-compat: DEFAULT / --no-auth unchanged ──────────────────────────────
+
+
+def test_no_key_configured_auth_on_still_401s_unchanged():
+    # auth on (no_auth=False) but NO key configured anywhere: the coarse gate
+    # cannot authenticate ANY request, exactly as today (constant_time_compare
+    # of None vs None is False). require_scope never runs. Back-compat: a
+    # service_keys-less server with auth on behaves byte-for-byte as before.
+    client = _client(None)
+    r = client.post("/api/v1/state", json={"state": "computer"})
+    assert r.status_code == 401
+
+
+def test_no_auth_flag_state_unchanged():
+    app = create_app(config=_make_config(None), no_auth=True)
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.post("/api/v1/state", json={"state": "computer"})
+    assert r.status_code == 200
+
+
+def test_no_service_keys_configured_identical_to_today():
+    # Only a legacy api_key, no service_keys block: the wildcard key authenticates
+    # and satisfies the state:write scope, exactly as a single global key would.
+    client = _client({"api_key": "legacy"})
+    r = client.post(
+        "/api/v1/state", json={"state": "computer"}, headers={"X-API-Key": "legacy"}
+    )
+    assert r.status_code == 200
+    # Wrong/absent key still 401 (coarse gate unchanged).
+    assert client.post("/api/v1/state", json={"state": "computer"}).status_code == 401
+
+
+# ── legacy single key → wildcard scope passes the scope guard ────────────────
+
+
+def test_legacy_key_wildcard_satisfies_scope_guard():
+    client = _client(
+        {
+            "api_key": "legacy",
+            "service_keys": {
+                "scraper": {
+                    "key_hash": _hash("scraper-secret"),
+                    "scopes": ["status:read"],
+                    "active": True,
+                }
+            },
+        }
+    )
+    r = client.post(
+        "/api/v1/state", json={"state": "computer"}, headers={"X-API-Key": "legacy"}
+    )
+    assert r.status_code == 200
+
+
+# ── service key scope enforcement on the guarded endpoint ────────────────────
+
+
+def test_service_key_with_state_write_allowed():
+    client = _client(
+        {
+            "service_keys": {
+                "controller": {
+                    "key_hash": _hash("ctrl-secret"),
+                    "scopes": ["state:write"],
+                    "active": True,
+                }
+            }
+        }
+    )
+    r = client.post(
+        "/api/v1/state",
+        json={"state": "computer"},
+        headers={"X-API-Key": "ctrl-secret"},
+    )
+    assert r.status_code == 200
+
+
+def test_service_key_without_state_write_forbidden():
+    client = _client(
+        {
+            "service_keys": {
+                "scraper": {
+                    "key_hash": _hash("scraper-secret"),
+                    "scopes": ["status:read"],
+                    "active": True,
+                }
+            }
+        }
+    )
+    # Authenticates (valid key) but lacks state:write => 403, not 401.
+    r = client.post(
+        "/api/v1/state",
+        json={"state": "computer"},
+        headers={"X-API-Key": "scraper-secret"},
+    )
+    assert r.status_code == 403
+
+
+def test_inactive_service_key_rejected_at_gate():
+    client = _client(
+        {
+            "service_keys": {
+                "old": {
+                    "key_hash": _hash("old-secret"),
+                    "scopes": ["state:write"],
+                    "active": False,
+                }
+            }
+        }
+    )
+    r = client.post(
+        "/api/v1/state", json={"state": "computer"}, headers={"X-API-Key": "old-secret"}
+    )
+    # Inactive key never authenticates => coarse 401 (never reaches scope guard).
+    assert r.status_code == 401


### PR DESCRIPTION
Final AuthZ phase (AUTHZ_DESIGN.md §5) — named, scoped machine keys, fully back-compatible.

## What
- New `web/middleware/service_keys.py`: `auth.service_keys` config (bcrypt `key_hash` + `scopes` + `active`), constant-time lookup over active candidates.
- X-API-Key middleware now accepts the **legacy single key** (→ wildcard `['*']`, checked first) **or** any active service key (→ its scopes), attaching `request.state.scopes`. 401 path / `/auth/*` exemption / `no_auth` bypass / path hardening unchanged.
- `require_scope()` dependency (same pass-through degradation as `require_role`); guards `POST /api/v1/state` with `state:write`. Ships `require_role_or_scope()` as a tested composition primitive (not applied to `/command` — would break phase-2's missing-Bearer→401 contract; follow-up).
- `key_hash` masked in config dumps.
- **Opt-in**: no `service_keys` configured → identical to today.

## Evidence
- **1600 passed, 1 skipped**; ruff + mypy clean (105 files). Phase-1/2 suites unchanged.
- **Docker-proven**: legacy `CHATTY_API_KEY` → 401 without / 200 with on `/status`; wildcard key **passes** the `state:write` guard on `POST /state` (422 body-validation from the handler, i.e. auth+scope admitted it — not a 401/403).

Completes AuthZ phases 1–3. Phase 4 (optional persistent sqlite revocation store) remains deferred as low-value. Also ticks the phase-2 roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)