### PR TITLE
docs(roadmap): UX backlog round 2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -302,6 +302,57 @@ P2 = polish.
 
 ---
 
+## UX backlog — round 2 (from 2026-06-19 re-audit of the post-wave-4 UI)
+
+Deeper pass over the improved UI (5 agents: aesthetics, deep interaction/edge
+cases, responsive, a11y+design-system, workflows+perf). Several P0s are
+**regressions the fix-waves introduced** — fix first.
+
+### P0 — regressions & broken (0/9)
+
+- [ ] **Theme switcher shows raw token names** — `THEME_LABELS` (MainLayout) still maps the removed `cyberpunk`/`synthwave`, so `corporate/business/emerald/nord` fall through to lowercase ids; key the labels to `AVAILABLE_THEMES` + title-case fallback ([`MainLayout.tsx`](webui/frontend/src/components/MainLayout.tsx))
+- [ ] **Config "General" theme `<select>` lists dead themes** — it hardcodes `dark/light/cyberpunk/synthwave`; picking cyberpunk/synthwave sets a non-existent `data-theme`, and the 4 real themes are missing. Drive the options from `AVAILABLE_THEMES`/`useTheme()` ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **Duplicate page title (two `h1`s)** — the sticky desktop header `h1` duplicates each page's own hero `h1`/`h2` directly below it (visual + heading-order a11y); make the header the single source of truth (hide page hero title on `lg`, or demote) ([`MainLayout.tsx`](webui/frontend/src/components/MainLayout.tsx) + pages)
+- [ ] **Duplicate breadcrumb on desktop** — Breadcrumbs render in the sticky header AND again in the page body on `lg`; render one instance ([`MainLayout.tsx`](webui/frontend/src/components/MainLayout.tsx))
+- [ ] **author→test deep-link is a no-op** — Commands "Test this command" links to `/voice-test?command=<name>` but VoiceTest never reads the param; read it and prefill/auto-send + a "Testing: <name>" banner ([`VoiceTestPage.tsx`](webui/frontend/src/pages/VoiceTestPage.tsx))
+- [ ] **WS reconnect-exhausted is dead state** — `WebSocketProvider` exposes `reconnectExhausted`/`reconnect()` but no UI consumes them; after 10 attempts the user is dead-ended. Surface a "Reconnect" button in the dashboard WS card + command-log offline notice ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+- [ ] **Commands table has no mobile fallback** — only `overflow-x-auto`; at ~375px the Actions column scrolls off-screen. Add a stacked-card list `md:hidden`, table at `md+` ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Config tabs overflow on mobile** — `tabs tabs-bordered` non-wrapping row clips "LLM" at ~360px; add `overflow-x-auto`/scroll or a `max-sm` `<select>` ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **Expiry mid-form destroys unsaved edits** — a 401 (incl. background polling) clears auth and unmounts the form via ProtectedRoute with no guard; defer redirect when a dirty form/modal is open, or stash a returnTo+draft ([`useAuth.tsx`](webui/frontend/src/hooks/useAuth.tsx), [`apiService.js`](webui/frontend/src/services/apiService.js))
+
+### P1 — quality (0/13)
+
+- [ ] **VoiceTest brand inconsistency** — its sidebar/header shows a stacked "Chatty / Voice Commander" lockup instead of the shared `Logo` ([`VoiceTestPage.tsx`](webui/frontend/src/pages/VoiceTestPage.tsx))
+- [ ] **Config & Authoring tabs miss the APG keyboard pattern** — `role=tab` present but no roving `tabIndex` / Arrow/Home/End handling ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx), [`CommandAuthoringPage.tsx`](webui/frontend/src/pages/CommandAuthoringPage.tsx))
+- [ ] **`:focus-visible` ring uses `--p` (primary)** — invisible on `bg-primary` surfaces (active nav, primary buttons, active tab); use `--bc`/contrasting halo + offset ([`index.css`](webui/frontend/src/index.css))
+- [ ] **Config tab state not persisted/deep-linkable**; back `?tab=` (and persist Commands `?sort=`) via `useSearchParams` ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx), [`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Mic test stream leaks on tab/route change** — leaving the Audio tab doesn't stop an in-progress `getUserMedia` test; clean up on tab change/unmount ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **Config seeds once → stale-write risk** — never re-seeds baseline on refetch/refocus, so it can show "All saved" against stale data and clobber a newer remote config; re-seed when clean, warn when dirty ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **`handleFetchModels` swallows errors** — a thrown fetch (bad URL/key/CORS) shows nothing; add catch→toast/error state ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **Commands sortable-looking headers are inert** — make Name/Type `<th>` buttons with `aria-sort`; add table `<caption>`/aria-label + `aria-live` on the "Showing N of M" count ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Dashboard double data source** — polls `/health` every 5s AND consumes WS push for the same CPU/mem/mode; suspend polling when WS is fresh, fall back when stale ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+- [ ] **Dashboard re-renders whole tree on every telemetry/log frame** — split telemetry + command-log + chart into memoized children / bail on unchanged values; `React.memo` PerformanceChart ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+- [ ] **Command table not virtualized + animates every row** — windowing for large sets; drop `motion.tr` past the stagger cap ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **No reusable Button/Card/Field primitives** — card/field/button class clusters are copy-pasted with drift; extract shared components ([`webui/frontend/src/components`](webui/frontend/src/components))
+- [ ] **Multi-tab + background-poll auth desync** — expiry isn't broadcast across tabs (no `storage` listener); polling keeps running after logout and can force-expire a fresh login; reset latch on `getCurrentUser` success and cancel polls when unauthenticated ([`authService.ts`](webui/frontend/src/services/authService.ts), [`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+
+### P2 — polish (0/12)
+
+- [ ] **Gradient `h1` + gradient buttons/badges everywhere** dilute emphasis — reserve the gradient for one hero; solid `text-base-content` for routine titles ([`index.css`](webui/frontend/src/index.css))
+- [ ] **Stat-card icons are a random rainbow** — standardize to a muted accent or status-driven color ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+- [ ] **Voice Assistant card leaks placeholder strings** ("Mic: unknown · current mode") — render a real value or a clean "Not detected" ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+- [ ] **Radial gauges read as broken arcs** — use a full-track radial-progress with centered label ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+- [ ] **Emoji section-icons mixed with lucide line icons** — unify on lucide ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx), pages)
+- [ ] **Login double-branding** — big avatar mark + full Logo lockup (which includes the mark) shown together; keep one ([`LoginPage.tsx`](webui/frontend/src/pages/LoginPage.tsx))
+- [ ] **Icon sizes ad-hoc (12–32)** — define sm/md/lg scale ([`webui/frontend/src`](webui/frontend/src))
+- [ ] **Shadows use raw `rgba(0,0,0,…)`** (too heavy on light themes) — token from `--bc`/`--b3` ([`index.css`](webui/frontend/src/index.css))
+- [ ] **Radius scale inconsistent** (`rounded` vs `-lg`/`-xl`/`-box` + raw rem) — standardize ([`index.css`](webui/frontend/src/index.css))
+- [ ] **No bulk ops on Commands** (select-all, multi-delete, export-selected) ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Dead `.menu li>a.active` CSS** (component opts out) — delete ([`index.css`](webui/frontend/src/index.css))
+- [ ] **Onboarding never reappears** when the user returns to a true empty state; re-show on `hasNoCommands` or add a "show getting started" affordance ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))
+
+---
+
 ## Done (recent)
 
 2026-06-11 (continued):


### PR DESCRIPTION
Round-2 re-audit of the post-wave-4 UI — 34 items (9 P0 incl. wave-introduced regressions, 13 P1, 12 P2). 🤖 Generated with [Claude Code](https://claude.com/claude-code)