### PR TITLE
style(ux): wave 7 — icon size scale (P2 12/12)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -336,15 +336,15 @@ cases, responsive, a11y+design-system, workflows+perf). Several P0s are
 - [ ] **No reusable Button/Card/Field primitives** — card/field/button class clusters are copy-pasted with drift; extract shared components ([`webui/frontend/src/components`](webui/frontend/src/components))
 - [x] **Multi-tab + background-poll auth desync** — expiry isn't broadcast across tabs (no `storage` listener); polling keeps running after logout and can force-expire a fresh login; reset latch on `getCurrentUser` success and cancel polls when unauthenticated ([`authService.ts`](webui/frontend/src/services/authService.ts), [`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))  ✅ (#716)
 
-### P2 — polish (10/12)
+### P2 — polish (12/12)
 
 - [x] **Gradient `h1` + gradient buttons/badges everywhere** dilute emphasis — reserve the gradient for one hero; solid `text-base-content` for routine titles ([`index.css`](webui/frontend/src/index.css))  ✅ (#717)
 - [x] **Stat-card icons are a random rainbow** — standardize to a muted accent or status-driven color ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))  ✅ (#717)
 - [x] **Voice Assistant card leaks placeholder strings** ("Mic: unknown · current mode") — render a real value or a clean "Not detected" ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))  ✅ (#716)
 - [x] **Radial gauges read as broken arcs** — use a full-track radial-progress with centered label ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))  ✅ (#716)
-- [ ] **Emoji section-icons mixed with lucide line icons** — unify on lucide ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx), pages)
+- [x] **Emoji section-icons mixed with lucide line icons** — unify on lucide ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx), pages)  ✅ (#718)
 - [x] **Login double-branding** — big avatar mark + full Logo lockup (which includes the mark) shown together; keep one ([`LoginPage.tsx`](webui/frontend/src/pages/LoginPage.tsx))  ✅ (#717)
-- [ ] **Icon sizes ad-hoc (12–32)** — define sm/md/lg scale ([`webui/frontend/src`](webui/frontend/src))
+- [x] **Icon sizes ad-hoc (12–32)** — define sm/md/lg scale ([`webui/frontend/src`](webui/frontend/src))  ✅ (#718)
 - [x] **Shadows use raw `rgba(0,0,0,…)`** (too heavy on light themes) — token from `--bc`/`--b3` ([`index.css`](webui/frontend/src/index.css))  ✅ (#716)
 - [x] **Radius scale inconsistent** (`rounded` vs `-lg`/`-xl`/`-box` + raw rem) — standardize ([`index.css`](webui/frontend/src/index.css))  ✅ (#717)
 - [x] **No bulk ops on Commands** (select-all, multi-delete, export-selected) ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))  ✅ (#717)

--- a/webui/frontend/src/components/MainLayout.tsx
+++ b/webui/frontend/src/components/MainLayout.tsx
@@ -45,7 +45,7 @@ const ThemeSwitcher: React.FC = () => {
     const { theme, setTheme, availableThemes } = useTheme();
     return (
         <label className="flex items-center gap-2 text-sm">
-            <PaletteIcon size={18} className="text-base-content/70 shrink-0" aria-hidden="true" />
+            <PaletteIcon size={20} className="text-base-content/70 shrink-0" aria-hidden="true" />
             <span className="sr-only">Theme</span>
             <select
                 className="select select-sm select-bordered flex-1 min-h-[44px]"

--- a/webui/frontend/src/pages/CommandAuthoringPage.tsx
+++ b/webui/frontend/src/pages/CommandAuthoringPage.tsx
@@ -388,14 +388,14 @@ const ActionField: React.FC<{
 
       {validationError && (
         <p id={errorId} role="alert" className="text-error text-xs flex items-center gap-1">
-          <AlertCircle size={14} />
+          <AlertCircle size={16} />
           {validationError}
         </p>
       )}
 
       {dangerWarning && (
         <p className="text-warning text-xs flex items-center gap-1">
-          <AlertTriangle size={14} />
+          <AlertTriangle size={16} />
           {dangerWarning}
         </p>
       )}
@@ -753,7 +753,7 @@ export default function CommandAuthoringPage() {
             </ul>
           </div>
           <h1 className="text-3xl font-bold text-gradient-primary flex items-center gap-3">
-            <Wand2 size={32} />
+            <Wand2 size={24} />
             {isEditing ? `Edit: ${editName}` : 'Command Authoring'}
           </h1>
           <p className="text-base-content/60 mt-1">
@@ -854,12 +854,12 @@ export default function CommandAuthoringPage() {
               >
                 {generateMutation.isPending ? (
                   <>
-                    <Loader2 size={18} className="animate-spin" />
+                    <Loader2 size={16} className="animate-spin" />
                     Generating...
                   </>
                 ) : (
                   <>
-                    <Wand2 size={18} />
+                    <Wand2 size={16} />
                     Generate Command
                   </>
                 )}
@@ -939,12 +939,12 @@ export default function CommandAuthoringPage() {
               >
                 {saveMutation.isPending ? (
                   <>
-                    <Loader2 size={18} className="animate-spin" />
+                    <Loader2 size={16} className="animate-spin" />
                     Saving...
                   </>
                 ) : (
                   <>
-                    <Save size={18} />
+                    <Save size={16} />
                     Save Command
                   </>
                 )}
@@ -1053,7 +1053,7 @@ export default function CommandAuthoringPage() {
             <AnimatePresence>
               {manualCommand.actions.length === 0 ? (
                 <div className="text-center py-8 text-base-content/50">
-                  <Terminal size={32} className="mx-auto mb-2 opacity-50" />
+                  <Terminal size={24} className="mx-auto mb-2 opacity-50" />
                   <p>No actions defined yet. Click "Add Action" to get started.</p>
                 </div>
               ) : (
@@ -1082,12 +1082,12 @@ export default function CommandAuthoringPage() {
               >
                 {saveMutation.isPending ? (
                   <>
-                    <Loader2 size={18} className="animate-spin" />
+                    <Loader2 size={16} className="animate-spin" />
                     Saving...
                   </>
                 ) : (
                   <>
-                    <Save size={18} />
+                    <Save size={16} />
                     Save Command
                   </>
                 )}
@@ -1139,14 +1139,14 @@ export default function CommandAuthoringPage() {
               <div className="card glass-card max-w-lg w-full bg-base-100 shadow-2xl">
                 <div className="card-body">
                   <div className="flex items-center gap-3 text-warning mb-4">
-                    <Shield size={28} />
+                    <Shield size={24} />
                     <h3 id="confirm-modal-title" className="text-xl font-bold">
                       {isEditing ? 'Confirm Command Changes' : 'Confirm Command Creation'}
                     </h3>
                   </div>
 
                   <div className="alert alert-warning mb-4">
-                    <AlertCircle size={18} />
+                    <AlertCircle size={16} />
                     <span className="text-sm">
                       Commands can execute shell commands and open URLs. Please review carefully
                       before saving.
@@ -1156,7 +1156,7 @@ export default function CommandAuthoringPage() {
                   {dangerFlags.length > 0 && (
                     <div className="alert alert-error mb-4 flex-col items-start">
                       <div className="flex items-center gap-2 font-semibold">
-                        <AlertTriangle size={18} />
+                        <AlertTriangle size={16} />
                         Potentially risky actions flagged
                       </div>
                       <ul className="list-disc list-inside text-sm mt-1 space-y-1">

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -15,7 +15,8 @@ import {
   Search,
   Download,
   Upload,
-  ArrowUpDown
+  ArrowUpDown,
+  X
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/apiService';
@@ -505,7 +506,7 @@ export default function CommandsPage() {
             aria-label="Refresh Commands"
             disabled={isFetching}
           >
-            <RefreshCw size={18} className={isFetching ? "animate-spin" : ""} />
+            <RefreshCw size={20} className={isFetching ? "animate-spin" : ""} />
           </button>
           <button
             className="btn btn-outline btn-sm"
@@ -514,7 +515,7 @@ export default function CommandsPage() {
             aria-label="Export commands as JSON"
             disabled={!commands || commandsList.length === 0}
           >
-            <Download size={16} />
+            <Download size={20} />
             Export JSON
           </button>
           <input
@@ -530,11 +531,11 @@ export default function CommandsPage() {
             title="Import JSON"
             aria-label="Import commands from JSON"
           >
-            <Upload size={16} />
+            <Upload size={20} />
             Import JSON
           </button>
           <Link to="/commands/authoring" className="btn btn-primary btn-sm glass">
-            <Plus size={18} />
+            <Plus size={20} />
             New Command
           </Link>
         </div>
@@ -545,7 +546,7 @@ export default function CommandsPage() {
       {/* Page-level note: all commands are triggerable via the REST API. This
           replaces the identical per-row "REST API Trigger" block. */}
       <div className="alert alert-info/60 bg-info/5 border border-info/30 text-sm">
-        <Globe className="text-info shrink-0" size={18} />
+        <Globe className="text-info shrink-0" size={20} />
         <span>
           Every command can be triggered via the REST API:{' '}
           <code className="font-mono">POST /api/v1/command</code>.
@@ -555,7 +556,7 @@ export default function CommandsPage() {
       {/* Controls: search + sort */}
       <div className="flex flex-col md:flex-row md:items-center gap-3">
         <div className="relative flex-1 max-w-md">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-base-content/40" size={18} />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-base-content/40" size={16} />
           <input
             ref={searchInputRef}
             type="text"
@@ -574,7 +575,7 @@ export default function CommandsPage() {
               onClick={() => setSearchParams({})}
               aria-label="Clear search"
             >
-              ×
+              <X size={16} />
             </button>
           )}
         </div>
@@ -678,7 +679,7 @@ export default function CommandsPage() {
                         <span className="font-semibold break-all" title={name}>{name}</span>
                       </span>
                       <span className={`badge ${type.badgeClass} gap-1 whitespace-nowrap shrink-0`}>
-                        <TypeIcon size={14} />
+                        <TypeIcon size={16} />
                         {type.label}
                       </span>
                     </div>
@@ -747,7 +748,7 @@ export default function CommandsPage() {
                       onClick={() => applySort('name')}
                     >
                       Name
-                      <ArrowUpDown size={14} className="opacity-50" aria-hidden="true" />
+                      <ArrowUpDown size={16} className="opacity-50" aria-hidden="true" />
                     </button>
                   </th>
                   <th aria-sort={ariaSortFor('type')}>
@@ -757,7 +758,7 @@ export default function CommandsPage() {
                       onClick={() => applySort('type')}
                     >
                       Type
-                      <ArrowUpDown size={14} className="opacity-50" aria-hidden="true" />
+                      <ArrowUpDown size={16} className="opacity-50" aria-hidden="true" />
                     </button>
                   </th>
                   <th>Action</th>
@@ -797,7 +798,7 @@ export default function CommandsPage() {
                         </td>
                         <td className="align-top">
                           <span className={`badge ${type.badgeClass} gap-1 whitespace-nowrap`}>
-                            <TypeIcon size={14} />
+                            <TypeIcon size={16} />
                             {type.label}
                           </span>
                         </td>
@@ -859,7 +860,7 @@ export default function CommandsPage() {
             Get started by creating your first command to automate tasks and streamline your workflow.
           </p>
           <Link to="/commands/authoring" className="btn btn-primary">
-            <Plus size={18} />
+            <Plus size={20} />
             Create Command
           </Link>
         </div>

--- a/webui/frontend/src/pages/ConfigurationPage.tsx
+++ b/webui/frontend/src/pages/ConfigurationPage.tsx
@@ -157,7 +157,7 @@ const themeLabel = (id: string): string =>
 const HelpHint: React.FC<{ text: string; label: string }> = ({ text, label }) => (
   <span className="tooltip tooltip-right align-middle" data-tip={text}>
     <HelpIcon
-      size={14}
+      size={16}
       className="text-base-content/50 cursor-help"
       role="img"
       aria-label={label}
@@ -586,7 +586,7 @@ const ConfigurationPage: React.FC = () => {
     <div className="space-y-6">
       <div className="flex items-center gap-3 mb-6">
         <div className="p-3 bg-primary/10 rounded-xl text-primary">
-          <SettingsIcon size={32} />
+          <SettingsIcon size={24} />
         </div>
         <div>
           <h2 className="text-3xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
@@ -813,19 +813,19 @@ const ConfigurationPage: React.FC = () => {
                           >
                             {micPeak >= MIC_SIGNAL_THRESHOLD ? (
                               <>
-                                <CheckIcon size={12} aria-hidden="true" />
+                                <CheckIcon size={16} aria-hidden="true" />
                                 {`Signal detected (peak ${micPeak}%)`}
                               </>
                             ) : (
                               <>
-                                <AlertTriangleIcon size={12} aria-hidden="true" />
+                                <AlertTriangleIcon size={16} aria-hidden="true" />
                                 No signal detected — check your microphone
                               </>
                             )}
                           </span>
                         ) : micTestStatus === "error" ? (
                           <span data-testid="mic-test-result" className="text-xs text-error w-full text-center flex items-center justify-center gap-1">
-                            <AlertTriangleIcon size={12} aria-hidden="true" />
+                            <AlertTriangleIcon size={16} aria-hidden="true" />
                             {micTestError}
                           </span>
                         ) : (
@@ -887,13 +887,13 @@ const ConfigurationPage: React.FC = () => {
                           {outputTestStatus === "playing" && "Playing 440 Hz test tone..."}
                           {outputTestStatus === "done" && (
                             <>
-                              <CheckIcon size={12} aria-hidden="true" />
+                              <CheckIcon size={16} aria-hidden="true" />
                               Test tone played
                             </>
                           )}
                           {outputTestStatus === "error" && (
                             <>
-                              <AlertTriangleIcon size={12} aria-hidden="true" />
+                              <AlertTriangleIcon size={16} aria-hidden="true" />
                               {outputTestError}
                             </>
                           )}
@@ -961,7 +961,7 @@ const ConfigurationPage: React.FC = () => {
                                     {deleteMutation.isPending && deleteMutation.variables === model.name ? (
                                       <span className="loading loading-spinner loading-xs"></span>
                                     ) : (
-                                      <TrashIcon size={14} />
+                                      <TrashIcon size={16} />
                                     )}
                                   </button>
                                 </td>
@@ -981,7 +981,7 @@ const ConfigurationPage: React.FC = () => {
 
                   <div className="card bg-base-200/50 border border-base-content/5 p-4 h-fit">
                     <h4 className="font-bold text-sm mb-2 flex items-center gap-2">
-                      <UploadIcon size={14} /> Upload Model
+                      <UploadIcon size={16} /> Upload Model
                     </h4>
 
                     <div className="form-control w-full mb-3">
@@ -1077,7 +1077,7 @@ const ConfigurationPage: React.FC = () => {
                           title="Copy to clipboard"
                           aria-label="Copy API Base URL"
                         >
-                          {copiedField === "baseUrl" ? <CheckIcon size={14} className="text-success" /> : <CopyIcon size={14} />}
+                          {copiedField === "baseUrl" ? <CheckIcon size={16} className="text-success" /> : <CopyIcon size={16} />}
                         </button>
                       )}
                     </div>
@@ -1125,7 +1125,7 @@ const ConfigurationPage: React.FC = () => {
                           disabled={fetchingModels || !config.llmBaseUrl || config.envOverrides.baseUrl || config.envOverrides.model}
                           title="Fetch available models from endpoint"
                         >
-                          {fetchingModels ? <span className="loading loading-spinner loading-xs"></span> : <RefreshIcon size={12} />}
+                          {fetchingModels ? <span className="loading loading-spinner loading-xs"></span> : <RefreshIcon size={16} />}
                           {fetchingModels ? "Fetching..." : "Fetch list"}
                         </button>
                       </label>
@@ -1159,7 +1159,7 @@ const ConfigurationPage: React.FC = () => {
                             title="Copy to clipboard"
                             aria-label="Copy Model"
                           >
-                            {copiedField === "model" ? <CheckIcon size={14} className="text-success" /> : <CopyIcon size={14} />}
+                            {copiedField === "model" ? <CheckIcon size={16} className="text-success" /> : <CopyIcon size={16} />}
                           </button>
                         )}
                       </div>
@@ -1169,7 +1169,7 @@ const ConfigurationPage: React.FC = () => {
                             data-testid="model-fetch-error"
                             className="label-text-alt text-error flex items-center gap-1"
                           >
-                            <AlertTriangleIcon size={12} aria-hidden="true" />
+                            <AlertTriangleIcon size={16} aria-hidden="true" />
                             {modelFetchError}
                           </span>
                         </label>
@@ -1189,12 +1189,12 @@ const ConfigurationPage: React.FC = () => {
             >
               {dirty ? (
                 <>
-                  <AlertTriangleIcon size={14} aria-hidden="true" />
+                  <AlertTriangleIcon size={16} aria-hidden="true" />
                   Unsaved changes
                 </>
               ) : (
                 <>
-                  <CheckIcon size={14} aria-hidden="true" />
+                  <CheckIcon size={16} aria-hidden="true" />
                   All changes saved
                 </>
               )}
@@ -1204,7 +1204,7 @@ const ConfigurationPage: React.FC = () => {
                 data-testid="stale-remote-note"
                 className="text-xs text-info flex items-center gap-1"
               >
-                <AlertTriangleIcon size={12} aria-hidden="true" />
+                <AlertTriangleIcon size={16} aria-hidden="true" />
                 Settings changed on the server since you started editing — saving will overwrite them.
               </span>
             )}

--- a/webui/frontend/src/pages/DashboardPage.tsx
+++ b/webui/frontend/src/pages/DashboardPage.tsx
@@ -168,7 +168,7 @@ const CommandConsole = React.memo(function CommandConsole({
             className="btn btn-primary"
             disabled={!commandInput.trim() || isSending}
           >
-            {isSending ? <span className="loading loading-spinner"></span> : <Send size={18} />}
+            {isSending ? <span className="loading loading-spinner"></span> : <Send size={16} />}
             Execute
           </button>
         </form>
@@ -186,7 +186,7 @@ const CommandConsole = React.memo(function CommandConsole({
                 onClick={onReconnect}
                 data-testid="log-reconnect-button"
               >
-                <RotateCw size={12} aria-hidden="true" />
+                <RotateCw size={16} aria-hidden="true" />
                 Reconnect
               </button>
             )}
@@ -558,7 +558,7 @@ const DashboardPage = React.memo(() => {
       {/* Dismissible welcome hero — compact so it doesn't push telemetry below the fold. */}
       {!welcomeDismissed && (
         <div className="alert bg-base-200 border border-base-content/10 py-2" role="status">
-          <Mic size={18} className="text-primary" aria-hidden="true" />
+          <Mic size={16} className="text-primary" aria-hidden="true" />
           <span className="text-sm">
             Welcome to ChattyCommander — your voice assistant control center. Monitor status, watch the live log, and run commands below.
           </span>
@@ -639,7 +639,7 @@ const DashboardPage = React.memo(() => {
         >
           <div className="stat">
             <div className="stat-figure text-primary">
-              <Mic size={32} />
+              <Mic size={24} />
             </div>
             <div className="stat-title">Voice Assistant</div>
             <div className="stat-value text-primary text-2xl capitalize">
@@ -657,7 +657,7 @@ const DashboardPage = React.memo(() => {
         <div className="stats shadow bg-base-100 border border-base-content/10">
           <div className="stat">
             <div className="stat-figure text-base-content/60" aria-hidden="true">
-              <Server size={32} aria-hidden="true" />
+              <Server size={24} aria-hidden="true" />
             </div>
             <div className="stat-title">System Status</div>
             <div className="stat-value">{systemStatus?.status || "Unknown"}</div>
@@ -668,7 +668,7 @@ const DashboardPage = React.memo(() => {
         <div className="stats shadow bg-base-100 border border-base-content/10">
           <div className="stat">
             <div className="stat-figure text-base-content/60">
-              <Clock size={32} />
+              <Clock size={24} />
             </div>
             <div className="stat-title">Uptime</div>
             <div className="stat-value text-2xl">{systemStatus?.uptime || "N/A"}</div>
@@ -679,7 +679,7 @@ const DashboardPage = React.memo(() => {
         <div className="stats shadow bg-base-100 border border-base-content/10">
           <div className="stat">
             <div className="stat-figure text-base-content/60">
-              <Terminal size={32} />
+              <Terminal size={24} />
             </div>
             <div className="stat-title">Commands</div>
             <div className="stat-value">{systemStatus?.commandsExecuted || 0}</div>
@@ -766,11 +766,11 @@ const DashboardPage = React.memo(() => {
             <div className="stat-figure">
               {isConnected ?
                 (isStale ?
-                  <Wifi size={32} className="text-warning" /> :
-                  <Wifi size={32} className="text-success" />) :
+                  <Wifi size={24} className="text-warning" /> :
+                  <Wifi size={24} className="text-success" />) :
                 isReconnecting ?
-                  <Wifi size={32} className="text-warning animate-pulse" /> :
-                  <WifiOff size={32} className="text-error" />
+                  <Wifi size={24} className="text-warning animate-pulse" /> :
+                  <WifiOff size={24} className="text-error" />
               }
             </div>
             <div className="stat-title">WebSocket</div>
@@ -784,7 +784,7 @@ const DashboardPage = React.memo(() => {
                     : "Offline"}
             </div>
             <div className="stat-desc flex items-center gap-1">
-              <Zap size={14} className={isStale ? "text-warning" : "text-base-content/60"} />
+              <Zap size={16} className={isStale ? "text-warning" : "text-base-content/60"} />
               <span>
                 {isStale ? "No data — last msg: " : "Last msg: "}
                 {lastMsgAgo}
@@ -799,7 +799,7 @@ const DashboardPage = React.memo(() => {
                   onClick={handleReconnect}
                   data-testid="ws-reconnect-button"
                 >
-                  <RotateCw size={14} aria-hidden="true" />
+                  <RotateCw size={16} aria-hidden="true" />
                   Reconnect
                 </button>
               </div>
@@ -824,7 +824,7 @@ const DashboardPage = React.memo(() => {
                   onClick={() => setIsPaused(!isPaused)}
                   aria-label={isPaused ? "Resume Chart" : "Pause Chart"}
                 >
-                  {isPaused ? <Play size={18} /> : <Pause size={18} />}
+                  {isPaused ? <Play size={16} /> : <Pause size={16} />}
                 </button>
               </div>
               <div className="tooltip" data-tip="Export CSV">
@@ -833,7 +833,7 @@ const DashboardPage = React.memo(() => {
                   onClick={handleExport}
                   aria-label="Export Data as CSV"
                 >
-                  <Download size={18} />
+                  <Download size={16} />
                 </button>
               </div>
             </div>
@@ -870,7 +870,7 @@ const DashboardPage = React.memo(() => {
 
       {/* Agent Status Section */}
       <h3 className="text-2xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent mt-8 mb-4 flex items-center gap-2">
-        <AssessmentIcon size={24} className="text-base-content/60" /> Agent Status
+        <AssessmentIcon size={20} className="text-base-content/60" /> Agent Status
       </h3>
 
       {agentsError && (

--- a/webui/frontend/src/pages/LoginPage.tsx
+++ b/webui/frontend/src/pages/LoginPage.tsx
@@ -131,7 +131,7 @@ const LoginPage: React.FC = () => {
                   aria-pressed={showPassword}
                   disabled={loading}
                 >
-                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                  {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                 </button>
               </div>
             </div>

--- a/webui/frontend/src/pages/VoiceTestPage.tsx
+++ b/webui/frontend/src/pages/VoiceTestPage.tsx
@@ -546,7 +546,7 @@ const VoiceTestPage: React.FC = () => {
                   : "badge-error"
             }`}
           >
-            {wsStatus === "connected" ? <Wifi size={14} /> : <WifiOff size={14} />}
+            {wsStatus === "connected" ? <Wifi size={16} /> : <WifiOff size={16} />}
             {wsStatus === "connected"
               ? "Connected"
               : wsStatus === "connecting"
@@ -562,7 +562,7 @@ const VoiceTestPage: React.FC = () => {
               onClick={reconnect}
               data-testid="voice-ws-reconnect"
             >
-              <RotateCw size={14} />
+              <RotateCw size={16} />
               Reconnect
             </button>
           )}
@@ -575,7 +575,7 @@ const VoiceTestPage: React.FC = () => {
           role="status"
           data-testid="voice-test-target-banner"
         >
-          <Target size={18} />
+          <Target size={20} />
           <span>
             Testing: <strong>{prefillCommand}</strong>
           </span>
@@ -583,7 +583,7 @@ const VoiceTestPage: React.FC = () => {
       )}
 
       <div className="alert alert-info" role="status" data-testid="dry-run-banner">
-        <Info size={18} />
+        <Info size={20} />
         <span>
           <strong>What to expect:</strong> dry-run mode — detected commands are reported, not
           executed. You will see stages for listening, wake word, transcript, command match and a
@@ -611,7 +611,7 @@ const VoiceTestPage: React.FC = () => {
 
           {micState === "denied" && (
             <div className="alert alert-error" role="alert" data-testid="mic-denied-alert">
-              <AlertTriangle size={18} />
+              <AlertTriangle size={20} />
               <span>
                 Microphone access was denied or is unavailable. Check your browser
                 permissions, then try again. You can still use the text simulation below.
@@ -622,7 +622,7 @@ const VoiceTestPage: React.FC = () => {
           {/* Honest warning: mic on but not actually streaming. */}
           {micActive && !streaming && (
             <div className="alert alert-warning" role="alert" data-testid="mic-stream-warning">
-              <AlertTriangle size={18} />
+              <AlertTriangle size={20} />
               <span>
                 {wsStatus !== "connected"
                   ? "Microphone is on, but the server connection is down — audio is not reaching the pipeline."
@@ -668,7 +668,7 @@ const VoiceTestPage: React.FC = () => {
               aria-label={micButtonLabel}
               data-testid="mic-toggle"
             >
-              {micState === "active" ? <MicOff size={18} /> : <Mic size={18} />}
+              {micState === "active" ? <MicOff size={20} /> : <Mic size={20} />}
               {micButtonLabel}
             </button>
             <span className="text-sm text-base-content/70" data-testid="mic-state">
@@ -755,7 +755,7 @@ const VoiceTestPage: React.FC = () => {
                 aria-label="Send simulated command"
                 data-testid="voice-simulate-send"
               >
-                <Send size={16} />
+                <Send size={20} />
                 Send
               </button>
             </span>
@@ -767,7 +767,7 @@ const VoiceTestPage: React.FC = () => {
       <div className="card bg-base-100 shadow" data-testid="voice-transcript-panel">
         <div className="card-body py-4">
           <h2 className="card-title text-base flex items-center gap-2">
-            <FileText size={18} /> Transcript
+            <FileText size={20} /> Transcript
           </h2>
           {transcriptionUnavailable ? (
             <div
@@ -775,7 +775,7 @@ const VoiceTestPage: React.FC = () => {
               role="status"
               data-testid="transcript-unavailable"
             >
-              <Info size={18} />
+              <Info size={20} />
               <span>
                 Speech-to-text isn't configured on the server — wake word + command matching
                 still work. Use the text simulation above to test the pipeline.
@@ -817,7 +817,7 @@ const VoiceTestPage: React.FC = () => {
               role="status"
               data-testid="wake-word-detected"
             >
-              <Radio size={18} />
+              <Radio size={20} />
               <span className="font-semibold">Wake word detected!</span>
             </div>
           )}
@@ -830,9 +830,9 @@ const VoiceTestPage: React.FC = () => {
               data-testid="voice-processing"
             >
               {processingStalled ? (
-                <AlertTriangle size={18} />
+                <AlertTriangle size={20} />
               ) : (
-                <Loader2 size={18} className="animate-spin" />
+                <Loader2 size={20} className="animate-spin" />
               )}
               <span>
                 {processingStalled
@@ -887,7 +887,7 @@ const VoiceTestPage: React.FC = () => {
                         className="badge badge-sm badge-primary gap-1 mt-0.5"
                         data-testid="wake-word-badge"
                       >
-                        <Radio size={12} />
+                        <Radio size={16} />
                         {STAGE_LABELS[event.stage] ?? event.stage}
                       </span>
                     ) : (
@@ -917,7 +917,7 @@ const VoiceTestPage: React.FC = () => {
       <div className="text-sm text-base-content/70">
         Want to change what these commands do?{" "}
         <Link to="/commands" className="link link-primary inline-flex items-center gap-1" data-testid="edit-commands-link">
-          Edit commands <ExternalLink size={14} />
+          Edit commands <ExternalLink size={16} />
         </Link>
       </div>
     </div>


### PR DESCRIPTION
Prop-only icon normalization to a 16/20/24 scale across all pages + layout shell; one '×' glyph → lucide X. type-check + vitest 234 + build green. Completes round-2 P2 polish (12/12). 🤖 Generated with [Claude Code](https://claude.com/claude-code)