### PR TITLE
test(e2e): deterministic media for chromium (fix mic-test flake)

### DIFF
--- a/webui/frontend/playwright.config.ts
+++ b/webui/frontend/playwright.config.ts
@@ -28,7 +28,20 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        // Make getUserMedia deterministic so audio/mic-test specs don't flake
+        // under parallel worker contention: a synthetic media stream, the
+        // permission prompt auto-accepted, and the mic permission pre-granted.
+        permissions: ["microphone"],
+        launchOptions: {
+          args: [
+            "--use-fake-device-for-media-stream",
+            "--use-fake-ui-for-media-stream",
+            "--autoplay-policy=no-user-gesture-required",
+          ],
+        },
+      },
     },
   ],
 


### PR DESCRIPTION
The Configuration mic-test flaked under full-suite parallel load (nondeterministic getUserMedia). Adds fake-device media flags + microphone permission to the chromium project. Full top-level suite now 138 passed / 0 flaky (only the pre-existing external-dograh-service specs remain). 🤖 Generated with [Claude Code](https://claude.com/claude-code)