### PR TITLE
test(e2e): skip dograh browser specs when service unreachable

### DIFF
--- a/webui/frontend/tests/e2e/dograh/dograh_screenshots.spec.ts
+++ b/webui/frontend/tests/e2e/dograh/dograh_screenshots.spec.ts
@@ -17,6 +17,16 @@ test.describe("Dograh integration screenshots", () => {
     fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true });
   });
 
+  // These exercise the live dograh stack (dograh-ui + backend). Skip cleanly
+  // when that external service isn't running, rather than failing the suite.
+  test.beforeEach(async () => {
+    const apiBase = process.env.DOGRAH_API_BASE || "http://localhost:8020";
+    const reachable = await fetch(apiBase, { signal: AbortSignal.timeout(2000) })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!reachable, `dograh backend not reachable at ${apiBase}`);
+  });
+
   test("login-page", async ({ page }) => {
     await page.goto("/auth/login");
     await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();

--- a/webui/frontend/tests/e2e/dograh/dograh_webcall_loopback.spec.ts
+++ b/webui/frontend/tests/e2e/dograh/dograh_webcall_loopback.spec.ts
@@ -66,6 +66,16 @@ test.describe("Dograh smallwebrtc loopback", () => {
     fs.mkdirSync(ARTIFACTS_DIR, { recursive: true });
   });
 
+  // Exercises the live dograh stack (smallwebrtc / pipecat). Skip cleanly when
+  // that external service isn't reachable, rather than failing the suite.
+  test.beforeEach(async () => {
+    const apiBase = process.env.DOGRAH_API_BASE || "http://localhost:8020";
+    const reachable = await fetch(apiBase, { signal: AbortSignal.timeout(2000) })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!reachable, `dograh backend not reachable at ${apiBase}`);
+  });
+
   test("webcall-handshake", async ({ page, request }) => {
     // Track signaling-channel evidence: the WS URL is the proof that
     // the pipecat pipeline started for our run.


### PR DESCRIPTION
The dograh integration specs need a live dograh stack at :8020; add a reachability probe that skips them cleanly when absent (was failing with ECONNREFUSED). Full top-level suite now 138 passed + 3 skipped + 0 failed without the dograh stack; unchanged when it's up. 🤖 Generated with [Claude Code](https://claude.com/claude-code)