### PR TITLE
feat(ux): dirty-form-defer — preserve unsaved edits on session expiry (P0 9/9)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -308,7 +308,7 @@ Deeper pass over the improved UI (5 agents: aesthetics, deep interaction/edge
 cases, responsive, a11y+design-system, workflows+perf). Several P0s are
 **regressions the fix-waves introduced** — fix first.
 
-### P0 — regressions & broken (8/9)
+### P0 — regressions & broken (9/9)
 
 - [x] **Theme switcher shows raw token names** — `THEME_LABELS` (MainLayout) still maps the removed `cyberpunk`/`synthwave`, so `corporate/business/emerald/nord` fall through to lowercase ids; key the labels to `AVAILABLE_THEMES` + title-case fallback ([`MainLayout.tsx`](webui/frontend/src/components/MainLayout.tsx))  ✅ (#716)
 - [x] **Config "General" theme `<select>` lists dead themes** — it hardcodes `dark/light/cyberpunk/synthwave`; picking cyberpunk/synthwave sets a non-existent `data-theme`, and the 4 real themes are missing. Drive the options from `AVAILABLE_THEMES`/`useTheme()` ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))  ✅ (#716)
@@ -318,7 +318,7 @@ cases, responsive, a11y+design-system, workflows+perf). Several P0s are
 - [x] **WS reconnect-exhausted is dead state** — `WebSocketProvider` exposes `reconnectExhausted`/`reconnect()` but no UI consumes them; after 10 attempts the user is dead-ended. Surface a "Reconnect" button in the dashboard WS card + command-log offline notice ([`DashboardPage.tsx`](webui/frontend/src/pages/DashboardPage.tsx))  ✅ (#716)
 - [x] **Commands table has no mobile fallback** — only `overflow-x-auto`; at ~375px the Actions column scrolls off-screen. Add a stacked-card list `md:hidden`, table at `md+` ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))  ✅ (#716)
 - [x] **Config tabs overflow on mobile** — `tabs tabs-bordered` non-wrapping row clips "LLM" at ~360px; add `overflow-x-auto`/scroll or a `max-sm` `<select>` ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))  ✅ (#716)
-- [ ] **Expiry mid-form destroys unsaved edits** — a 401 (incl. background polling) clears auth and unmounts the form via ProtectedRoute with no guard; defer redirect when a dirty form/modal is open, or stash a returnTo+draft ([`useAuth.tsx`](webui/frontend/src/hooks/useAuth.tsx), [`apiService.js`](webui/frontend/src/services/apiService.js))
+- [x] **Expiry mid-form destroys unsaved edits** — a 401 (incl. background polling) clears auth and unmounts the form via ProtectedRoute with no guard; defer redirect when a dirty form/modal is open, or stash a returnTo+draft ([`useAuth.tsx`](webui/frontend/src/hooks/useAuth.tsx), [`apiService.js`](webui/frontend/src/services/apiService.js))  ✅ (#721)
 
 ### P1 — quality (11/13)
 

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import MainLayout from "./components/MainLayout";
 import ProtectedRoute from "./components/ProtectedRoute";
+import SessionExpiredModal from "./components/SessionExpiredModal";
 import { WebSocketProvider } from "./components/WebSocketProvider";
 import { useAuth, AuthProvider } from "./hooks/useAuth";
 import { ThemeProvider } from "./components/ThemeProvider";
@@ -67,6 +68,10 @@ function AppContent() {
 
   return (
     <Router>
+      {/* Blocking modal shown when the session expires while a form has unsaved
+          edits. Mounted inside Router (it navigates) and AuthProvider (it reads
+          the blocking state). It self-hides when not blocking. */}
+      <SessionExpiredModal />
       <Suspense fallback={<PageSpinner />}>
         <Routes>
           {/* Public Routes */}

--- a/webui/frontend/src/components/SessionExpiredModal.test.tsx
+++ b/webui/frontend/src/components/SessionExpiredModal.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import SessionExpiredModal from "./SessionExpiredModal";
+
+// Mock useNavigate so we can assert the redirect target without a real router.
+const navigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigate,
+}));
+
+// Mock useAuth so each test can drive the blocking state and observe the
+// actions the modal invokes.
+const confirmSessionExpiredSignIn = vi.fn();
+const dismissSessionExpiredBlocking = vi.fn();
+let blocking = true;
+vi.mock("../hooks/useAuth", () => ({
+  useAuth: () => ({
+    sessionExpiredBlocking: blocking,
+    confirmSessionExpiredSignIn,
+    dismissSessionExpiredBlocking,
+  }),
+}));
+
+describe("SessionExpiredModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    blocking = true;
+  });
+
+  test("renders nothing when not blocking", () => {
+    blocking = false;
+    const { container } = render(<SessionExpiredModal />);
+    expect(container).toBeEmptyDOMElement();
+    expect(
+      screen.queryByTestId("session-expired-modal"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows the dialog with the unsaved-changes copy when blocking", () => {
+    render(<SessionExpiredModal />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(
+      screen.getByText(/Your unsaved changes are still here on this page/i),
+    ).toBeInTheDocument();
+  });
+
+  test("'Sign in again' confirms the sign-out and navigates to /login", () => {
+    render(<SessionExpiredModal />);
+    fireEvent.click(screen.getByTestId("session-expired-signin"));
+    expect(confirmSessionExpiredSignIn).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/login");
+  });
+
+  test("'Dismiss' hides the modal without signing out or navigating", () => {
+    render(<SessionExpiredModal />);
+    fireEvent.click(screen.getByTestId("session-expired-dismiss"));
+    expect(dismissSessionExpiredBlocking).toHaveBeenCalledTimes(1);
+    expect(confirmSessionExpiredSignIn).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test("Escape does not dismiss the blocking modal", () => {
+    render(<SessionExpiredModal />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(dismissSessionExpiredBlocking).not.toHaveBeenCalled();
+    expect(confirmSessionExpiredSignIn).not.toHaveBeenCalled();
+    // Still on screen.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/webui/frontend/src/components/SessionExpiredModal.tsx
+++ b/webui/frontend/src/components/SessionExpiredModal.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
+import { useAuth } from "../hooks/useAuth";
+
+/**
+ * Blocking modal shown when the session expires *while a form has unsaved
+ * changes*. Unlike the silent redirect of the no-unsaved-changes path, this
+ * keeps the page (and the user's in-progress edits) mounted and warns them, so
+ * nothing is lost without notice.
+ *
+ * It is deliberately *not* Escape-dismissable and traps focus: the user must
+ * make a choice ("Sign in again" or "Dismiss"). "Dismiss" hides the modal but
+ * keeps them on the expired page so they can still copy/save their edits; the
+ * modal re-shows on the next 401.
+ *
+ * Mounted once at the app root, inside the auth + router context.
+ */
+const SessionExpiredModal: React.FC = () => {
+  const {
+    sessionExpiredBlocking,
+    confirmSessionExpiredSignIn,
+    dismissSessionExpiredBlocking,
+  } = useAuth();
+  const navigate = useNavigate();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const signInButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the primary action on open and trap Tab within the dialog. Escape is
+  // intentionally swallowed (not dismissable) since this is a blocking choice.
+  useEffect(() => {
+    if (!sessionExpiredBlocking) return;
+    signInButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        // Blocking: don't let Escape close it.
+        event.preventDefault();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [sessionExpiredBlocking]);
+
+  if (!sessionExpiredBlocking) return null;
+
+  const handleSignIn = () => {
+    // Commit the deferred sign-out, then send the user to the login screen.
+    confirmSessionExpiredSignIn();
+    navigate("/login");
+  };
+
+  return (
+    <div className="modal modal-open" data-testid="session-expired-modal">
+      <div
+        className="modal-box"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="session-expired-title"
+        aria-describedby="session-expired-body"
+        ref={dialogRef}
+      >
+        <h3
+          id="session-expired-title"
+          className="font-bold text-lg flex items-center gap-2 text-warning"
+        >
+          <AlertTriangle size={20} aria-hidden="true" />
+          Session expired
+        </h3>
+        <p id="session-expired-body" className="py-4 text-sm">
+          Your session has expired. Your unsaved changes are still here on this
+          page. Copy anything you need, then sign in again.
+        </p>
+        <div className="modal-action">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={dismissSessionExpiredBlocking}
+            data-testid="session-expired-dismiss"
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleSignIn}
+            ref={signInButtonRef}
+            data-testid="session-expired-signin"
+          >
+            Sign in again
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SessionExpiredModal;

--- a/webui/frontend/src/hooks/useAuth.test.tsx
+++ b/webui/frontend/src/hooks/useAuth.test.tsx
@@ -3,6 +3,10 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 import { AuthProvider, useAuth } from "./useAuth";
 import { authService } from "../services/authService";
+import {
+  __resetUnsavedChanges,
+  useUnsavedChanges,
+} from "./useUnsavedChanges";
 
 // Captures the session-expiry listener the hook registers, so tests can drive
 // the expiry path directly. The mock's subscribe stores the latest listener and
@@ -36,6 +40,7 @@ describe("useAuth Hook", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    __resetUnsavedChanges();
   });
 
   test("throws when used outside an AuthProvider", () => {
@@ -282,5 +287,95 @@ describe("useAuth Hook", () => {
     expect(result.current.user).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
     expect(localStorage.getItem("auth_token")).toBeNull();
+  });
+
+  test("expiry with NO unsaved changes redirects immediately (user cleared, not blocking)", async () => {
+    const mockUser = { username: "testuser", is_active: true, roles: ["user"] };
+    mockedAuthService.getCurrentUser.mockResolvedValue(mockUser);
+    localStorage.setItem("auth_token", "test-token");
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    act(() => sessionExpiredListener?.("expired"));
+
+    // Unchanged behaviour: user cleared so ProtectedRoute redirects; no modal.
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.sessionExpiredBlocking).toBe(false);
+  });
+
+  test("expiry WITH unsaved changes shows blocking modal without clearing the user", async () => {
+    const mockUser = { username: "testuser", is_active: true, roles: ["user"] };
+    mockedAuthService.getCurrentUser.mockResolvedValue(mockUser);
+    localStorage.setItem("auth_token", "test-token");
+
+    // Render the auth hook alongside a registered "dirty form".
+    const { result } = renderHook(
+      () => {
+        useUnsavedChanges(true);
+        return useAuth();
+      },
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    act(() => sessionExpiredListener?.("expired"));
+
+    // Deferred: the user (and their page/edits) stay mounted; modal blocks.
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.sessionExpiredBlocking).toBe(true);
+    expect(result.current.sessionExpiredNotice).toBe("expired");
+  });
+
+  test("confirmSessionExpiredSignIn clears the user and lifts the block", async () => {
+    const mockUser = { username: "testuser", is_active: true, roles: ["user"] };
+    mockedAuthService.getCurrentUser.mockResolvedValue(mockUser);
+    localStorage.setItem("auth_token", "test-token");
+
+    const { result } = renderHook(
+      () => {
+        useUnsavedChanges(true);
+        return useAuth();
+      },
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    act(() => sessionExpiredListener?.("expired"));
+    expect(result.current.sessionExpiredBlocking).toBe(true);
+
+    act(() => result.current.confirmSessionExpiredSignIn());
+
+    expect(result.current.sessionExpiredBlocking).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test("dismissSessionExpiredBlocking hides the modal but keeps the user signed in", async () => {
+    const mockUser = { username: "testuser", is_active: true, roles: ["user"] };
+    mockedAuthService.getCurrentUser.mockResolvedValue(mockUser);
+    localStorage.setItem("auth_token", "test-token");
+
+    const { result } = renderHook(
+      () => {
+        useUnsavedChanges(true);
+        return useAuth();
+      },
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    act(() => sessionExpiredListener?.("expired"));
+    expect(result.current.sessionExpiredBlocking).toBe(true);
+
+    act(() => result.current.dismissSessionExpiredBlocking());
+
+    // Modal hidden, but the user stays on the page (still "authenticated" in
+    // memory) so they can copy/save their edits.
+    expect(result.current.sessionExpiredBlocking).toBe(false);
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.isAuthenticated).toBe(true);
   });
 });

--- a/webui/frontend/src/hooks/useAuth.tsx
+++ b/webui/frontend/src/hooks/useAuth.tsx
@@ -4,6 +4,7 @@ import {
   subscribeSessionExpired,
   User,
 } from "../services/authService";
+import { hasUnsavedChanges } from "./useUnsavedChanges";
 import { logger } from "../utils/logger";
 
 /**
@@ -27,6 +28,27 @@ interface AuthContextType {
   sessionExpiredNotice: string | null;
   /** Dismiss the {@link sessionExpiredNotice}. */
   clearSessionExpiredNotice: () => void;
+  /**
+   * True when the session has expired *while a form had unsaved changes* and we
+   * have deliberately deferred clearing the user, so the page (and its
+   * in-progress edits) stay mounted. A blocking modal is shown to the user
+   * instead of an immediate redirect. False in the common case (no dirty forms),
+   * where expiry behaves exactly as before — the user is cleared and
+   * ProtectedRoute redirects to /login.
+   */
+  sessionExpiredBlocking: boolean;
+  /**
+   * Commit the deferred sign-out: clear the in-memory user so ProtectedRoute
+   * redirects to /login. Called from the blocking modal's "Sign in again"
+   * action once the user has had a chance to copy/save their edits.
+   */
+  confirmSessionExpiredSignIn: () => void;
+  /**
+   * Hide the blocking modal without signing out, keeping the user on the page in
+   * the expired state so they can copy/save-attempt their edits. The modal
+   * re-shows on the next 401.
+   */
+  dismissSessionExpiredBlocking: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -37,6 +59,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [sessionExpiredNotice, setSessionExpiredNotice] = useState<
     string | null
   >(null);
+  // True when we've deferred the forced sign-out because a form had unsaved
+  // edits; drives the blocking SessionExpiredModal instead of an immediate
+  // redirect.
+  const [sessionExpiredBlocking, setSessionExpiredBlocking] = useState(false);
   const retryCount = useRef(0);
   // Track the pending retry timer and mount state so we can cancel in-flight
   // retries on unmount and avoid setting state on an unmounted component.
@@ -80,15 +106,25 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, [checkAuth]); // Include checkAuth per exhaustive-deps rule
 
   // Centralised session-expiry handling. The token has already been cleared by
-  // authService.notifySessionExpired(); here we drop the in-memory user (which
-  // makes ProtectedRoute redirect to /login), surface a notice, and broadcast a
+  // authService.notifySessionExpired(); here we surface a notice and broadcast a
   // window event so any toast surface mounted elsewhere in the tree can react.
+  //
+  // The branch: if NO form has unsaved edits (the common case), behave exactly
+  // as before — drop the in-memory user so ProtectedRoute redirects to /login.
+  // If a dirty form IS mounted, do NOT clear the user yet: keep the page (and
+  // its unsaved edits) on screen and raise a blocking modal instead, so the
+  // user can copy/save before signing in again.
   useEffect(() => {
     const unsubscribe = subscribeSessionExpired((message) => {
       if (!isMountedRef.current) return;
-      setUser(null);
-      setLoading(false);
       setSessionExpiredNotice(message);
+      if (hasUnsavedChanges()) {
+        // Defer the sign-out; the modal drives confirmSessionExpiredSignIn().
+        setSessionExpiredBlocking(true);
+      } else {
+        setUser(null);
+        setLoading(false);
+      }
       try {
         window.dispatchEvent(
           new CustomEvent(SESSION_EXPIRED_EVENT, { detail: { message } }),
@@ -129,6 +165,22 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setSessionExpiredNotice(null);
   }, []);
 
+  // Commit the deferred sign-out: now that the user has had a chance to copy
+  // their edits, drop the in-memory user so ProtectedRoute redirects to /login.
+  const confirmSessionExpiredSignIn = useCallback(() => {
+    setSessionExpiredBlocking(false);
+    setUser(null);
+    setLoading(false);
+  }, []);
+
+  // Hide the blocking modal but keep the user on the page in the expired state.
+  // We deliberately leave the user non-null so the route stays mounted; the
+  // modal re-shows on the next 401 (the expiry latch re-arms only on a fresh
+  // successful auth).
+  const dismissSessionExpiredBlocking = useCallback(() => {
+    setSessionExpiredBlocking(false);
+  }, []);
+
   const login = async (username: string, password: string): Promise<boolean> => {
     try {
       setLoading(true);
@@ -137,8 +189,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       const userData = await authService.getCurrentUser();
       setUser(userData);
-      // A successful sign-in supersedes any stale expiry notice.
+      // A successful sign-in supersedes any stale expiry notice / blocking modal.
       setSessionExpiredNotice(null);
+      setSessionExpiredBlocking(false);
       return true;
     } catch (error) {
       logger.error("Login failed:", error);
@@ -163,6 +216,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         loading,
         sessionExpiredNotice,
         clearSessionExpiredNotice,
+        sessionExpiredBlocking,
+        confirmSessionExpiredSignIn,
+        dismissSessionExpiredBlocking,
       }}
     >
       {children}

--- a/webui/frontend/src/hooks/useUnsavedChanges.test.tsx
+++ b/webui/frontend/src/hooks/useUnsavedChanges.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  __resetUnsavedChanges,
+  hasUnsavedChanges,
+  subscribeUnsavedChanges,
+  useUnsavedChanges,
+} from "./useUnsavedChanges";
+
+afterEach(() => {
+  __resetUnsavedChanges();
+});
+
+describe("useUnsavedChanges", () => {
+  test("does not register while clean", () => {
+    renderHook(() => useUnsavedChanges(false));
+    expect(hasUnsavedChanges()).toBe(false);
+  });
+
+  test("registers while dirty and unregisters when it goes clean", () => {
+    const { rerender } = renderHook(
+      ({ dirty }: { dirty: boolean }) => useUnsavedChanges(dirty),
+      { initialProps: { dirty: false } },
+    );
+    expect(hasUnsavedChanges()).toBe(false);
+
+    rerender({ dirty: true });
+    expect(hasUnsavedChanges()).toBe(true);
+
+    rerender({ dirty: false });
+    expect(hasUnsavedChanges()).toBe(false);
+  });
+
+  test("unregisters on unmount", () => {
+    const { unmount } = renderHook(() => useUnsavedChanges(true));
+    expect(hasUnsavedChanges()).toBe(true);
+    unmount();
+    expect(hasUnsavedChanges()).toBe(false);
+  });
+
+  test("stays dirty while any one of several forms is dirty", () => {
+    const a = renderHook(() => useUnsavedChanges(true));
+    const b = renderHook(() => useUnsavedChanges(true));
+    expect(hasUnsavedChanges()).toBe(true);
+
+    a.unmount();
+    // Still dirty: the second form is registered.
+    expect(hasUnsavedChanges()).toBe(true);
+
+    b.unmount();
+    expect(hasUnsavedChanges()).toBe(false);
+  });
+
+  test("notifies subscribers on registration changes", () => {
+    let notifications = 0;
+    const unsubscribe = subscribeUnsavedChanges(() => {
+      notifications += 1;
+    });
+
+    const { rerender, unmount } = renderHook(
+      ({ dirty }: { dirty: boolean }) => useUnsavedChanges(dirty),
+      { initialProps: { dirty: false } },
+    );
+    rerender({ dirty: true });
+    expect(notifications).toBeGreaterThan(0);
+
+    const after = notifications;
+    unmount();
+    expect(notifications).toBeGreaterThan(after);
+
+    unsubscribe();
+  });
+});

--- a/webui/frontend/src/hooks/useUnsavedChanges.ts
+++ b/webui/frontend/src/hooks/useUnsavedChanges.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+
+/**
+ * Tracks, across the whole app, whether *any* mounted form currently has unsaved
+ * edits. This is intentionally a module-level registry (not React state): the
+ * code that needs to *read* "is anything dirty?" lives in the session-expiry
+ * path inside the auth layer (`useAuth`), which sits at a different point in the
+ * provider tree than the forms that are dirty. A plain registry lets a form
+ * advertise its dirtiness without prop-drilling a flag up to the auth provider.
+ *
+ * Each registration is an opaque token (a fresh object) so two forms that are
+ * both dirty don't collide — membership is by identity, and the set is empty
+ * exactly when nothing is dirty.
+ */
+const dirtyRegistrations = new Set<object>();
+
+type Subscriber = () => void;
+const subscribers = new Set<Subscriber>();
+
+function notify(): void {
+  for (const subscriber of subscribers) {
+    try {
+      subscriber();
+    } catch {
+      /* a misbehaving subscriber must not block the others */
+    }
+  }
+}
+
+/**
+ * Whether any currently-mounted form has registered itself as dirty. Read from
+ * the session-expiry path to decide whether to defer the forced sign-out so the
+ * user's in-progress edits survive on the page.
+ */
+export function hasUnsavedChanges(): boolean {
+  return dirtyRegistrations.size > 0;
+}
+
+/**
+ * Subscribe to changes in the global "anything dirty?" state. Returns an
+ * unsubscribe function. Useful for components that want to render reactively off
+ * {@link hasUnsavedChanges} rather than poll it.
+ */
+export function subscribeUnsavedChanges(subscriber: Subscriber): () => void {
+  subscribers.add(subscriber);
+  return () => {
+    subscribers.delete(subscriber);
+  };
+}
+
+/**
+ * Test-only escape hatch to clear the registry between tests so module-level
+ * state doesn't leak across cases. Not used in app code.
+ */
+export function __resetUnsavedChanges(): void {
+  dirtyRegistrations.clear();
+  notify();
+}
+
+/**
+ * Register this component as having unsaved changes while `dirty` is true.
+ *
+ * The registration is added when `dirty` becomes true and removed when it
+ * becomes false again or the component unmounts (whichever comes first), so the
+ * global {@link hasUnsavedChanges} flag always reflects what's actually on
+ * screen. SSR-safe: the registry is a plain JS Set with no DOM/`window` access.
+ */
+export function useUnsavedChanges(dirty: boolean): void {
+  useEffect(() => {
+    if (!dirty) return;
+    // A unique token per active registration so concurrent dirty forms coexist.
+    const token = {};
+    dirtyRegistrations.add(token);
+    notify();
+    return () => {
+      dirtyRegistrations.delete(token);
+      notify();
+    };
+  }, [dirty]);
+}

--- a/webui/frontend/src/pages/CommandAuthoringPage.tsx
+++ b/webui/frontend/src/pages/CommandAuthoringPage.tsx
@@ -20,6 +20,7 @@ import {
   Shield,
 } from 'lucide-react';
 import { useReducedMotionPref } from '../hooks/useReducedMotionPref';
+import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
 import { useToast } from '../components/ToastProvider';
 
 // --- TypeScript Interfaces ---
@@ -431,6 +432,12 @@ export default function CommandAuthoringPage() {
     wakeword: '',
     actions: [],
   });
+  // The pristine baseline of the manual editor: the empty form for a new
+  // command, or the loaded definition when editing (?edit=). Used to derive a
+  // "has unsaved edits" signal without storing a separate dirty flag.
+  const manualBaselineRef = useRef<string>(
+    JSON.stringify({ name: '', display_name: '', wakeword: '', actions: [] }),
+  );
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
@@ -472,12 +479,16 @@ export default function CommandAuthoringPage() {
             ? [cmd.action]
             : [];
         if (!cancelled) {
-          setManualCommand({
+          const loaded: GeneratedCommand = {
             name: editName,
             display_name: cmd.name || editName,
             wakeword: cmd.wakeword || '',
             actions,
-          });
+          };
+          // The loaded definition is the pristine baseline, so preloading an
+          // existing command for editing doesn't count as an unsaved edit.
+          manualBaselineRef.current = JSON.stringify(loaded);
+          setManualCommand(loaded);
           setMode('manual');
         }
       } catch (e: unknown) {
@@ -522,6 +533,19 @@ export default function CommandAuthoringPage() {
   }, []);
 
   const hasFormErrors = useMemo(() => Object.keys(formErrors).length > 0, [formErrors]);
+
+  // Whether the author has unsaved work in progress. True when the manual editor
+  // diverges from its pristine baseline (new-command empty form, or the loaded
+  // definition when editing), or when the AI flow has a typed description or a
+  // generated-but-unsaved command. Used to defer a mid-edit session expiry so
+  // these edits aren't silently discarded.
+  const isDirty = useMemo(() => {
+    const manualDirty =
+      JSON.stringify(manualCommand) !== manualBaselineRef.current;
+    const aiDirty = description.trim().length > 0 || generatedCommand !== null;
+    return manualDirty || aiDirty;
+  }, [manualCommand, description, generatedCommand]);
+  useUnsavedChanges(isDirty);
 
   // Generate command mutation
   const generateMutation = useMutation({

--- a/webui/frontend/src/pages/ConfigurationPage.tsx
+++ b/webui/frontend/src/pages/ConfigurationPage.tsx
@@ -23,6 +23,7 @@ import {
 import { fetchLLMModels, fetchVoiceModels, uploadVoiceModel, deleteVoiceModel, ModelFileInfo } from "../services/api";
 import { useTheme, AVAILABLE_THEMES } from "../components/ThemeProvider";
 import { useToast } from "../components/ToastProvider";
+import { useUnsavedChanges } from "../hooks/useUnsavedChanges";
 import { runMicTest, playTestTone } from "../utils/audioTest";
 
 // In-browser audio test tuning.
@@ -284,6 +285,11 @@ const ConfigurationPage: React.FC = () => {
     () => JSON.stringify(config) !== JSON.stringify(baseline),
     [config, baseline],
   );
+
+  // Advertise dirtiness to the global registry so a mid-edit session expiry
+  // defers the forced sign-out (keeping these unsaved edits on screen) instead
+  // of silently unmounting this page.
+  useUnsavedChanges(dirty);
 
   // True when a refetch brought new remote data we couldn't auto-apply because
   // the form has unsaved edits — the baseline is now older than the server.


### PR DESCRIPTION
The last round-2 P0. A background-poll 401 no longer silently unmounts a dirty form: `useUnsavedChanges` tracks form dirtiness, and on expiry `useAuth` defers the clear + shows a blocking SessionExpiredModal when there are unsaved changes (unchanged immediate-redirect when clean). vitest **248** (+14), type-check, build, full e2e **138 pass / 0 fail / 3 skip**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)