### PR TITLE
docs(roadmap): UX backlog round 3

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -353,6 +353,41 @@ cases, responsive, a11y+design-system, workflows+perf). Several P0s are
 
 ---
 
+## UX backlog — round 3 (from 2026-06-20 re-audit, post-wave-8)
+
+Deeper pass that found real bugs (several in the recent session-modal + bulk-ops
+work). Fix highest-confidence bugs first.
+
+### P0/P1 — real bugs (0/13)
+
+- [ ] **Clearing search wipes the sort** — the X / "Clear search" calls `setSearchParams({})`, discarding `?sort`/`?dir`; build from `prev` and only delete `q` ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Bulk delete aborts on partial failure** — sequential `await` with no per-item catch; a mid-loop failure skips the rest, mis-reports total failure, leaves stale selection. Use `Promise.allSettled`, refetch unconditionally, clear only succeeded names, report "Deleted X, failed Y" ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Import/export shape incompatible** — export emits the flat `/api/v1/commands` shape but import only accepts `actions[]`/legacy, so the app's own export is rejected on re-import; and `actions[]` commands don't render type/detail in the table. Normalize one schema on read+write ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Single delete doesn't deselect** — a deleted command stays in `selected`, so the bulk bar lingers and a later bulk delete 404s; remove it from the set on delete success ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Duplicate Ctrl/Cmd+K handlers** — MainLayout (navigate to /commands) and CommandsPage (focus search) both bind it and both fire on /commands; consolidate (MainLayout focuses search when already on /commands; drop the CommandsPage one) ([`MainLayout.tsx`](webui/frontend/src/components/MainLayout.tsx), [`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **SessionExpiredModal "Dismiss" traps the user on a dead page** — hides the modal but leaves `user` set + token gone, so the page looks logged-in while every call 401s and re-summons the modal. After dismiss show a persistent "Session expired — sign in to save" banner; disable the page's save bar while blocking ([`useAuth.tsx`](webui/frontend/src/hooks/useAuth.tsx), [`SessionExpiredModal.tsx`](webui/frontend/src/components/SessionExpiredModal.tsx), [`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **Session-modal copy oversells recovery** — "your unsaved changes are still here" but the token is already cleared so a save re-401s; reword honestly ("Copy your changes before signing in") and relabel the ambiguous "Dismiss" ([`SessionExpiredModal.tsx`](webui/frontend/src/components/SessionExpiredModal.tsx))
+- [ ] **Theme source-of-truth drift** — the sidebar ThemeSwitcher (`useTheme`/localStorage) and Configuration's Theme `<select>` (`config.theme` from backend) are independent and can show different values at once; make Config read live `useTheme().theme` ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx), [`MainLayout.tsx`](webui/frontend/src/components/MainLayout.tsx))
+- [ ] **Config seeds in the render body** (re-flagged) — `setConfig`/`setBaseline` run during render off `remoteConfig`; a background refetch mid-edit can clobber in-flight edits. Move to a `useEffect` keyed on the remote JSON ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **CommandAuthoring isDirty false-positive** — typing one char into the AI description marks dirty (triggers the unsaved-changes deferral) with no savable work; only treat AI dirty when `generatedCommand !== null` ([`CommandAuthoringPage.tsx`](webui/frontend/src/pages/CommandAuthoringPage.tsx))
+- [ ] **CommandAuthoring isDirty false-negative** — the manual baseline is the raw server shape, not normalized through `saveCommand`'s mapper, so edit-then-revert reads as phantom dirty; normalize the loaded baseline through the same mapper ([`CommandAuthoringPage.tsx`](webui/frontend/src/pages/CommandAuthoringPage.tsx))
+- [ ] **VoiceTest prefill auto-send not reset on auto-reconnect** — `autoSentRef` is only reset in manual `reconnect()`, so after a transient drop the "Testing: <name>" banner lies (no re-test); reset on each fresh `onopen`. Also clamp `deltaMs >= 0` and don't clear the input for an auto-sent prefill ([`VoiceTestPage.tsx`](webui/frontend/src/pages/VoiceTestPage.tsx))
+- [ ] **CommandAuthoring collision guard uses a stale snapshot** — `existingNames` fetched once on mount; re-fetch at save time so a concurrently-created key isn't silently clobbered ([`CommandAuthoringPage.tsx`](webui/frontend/src/pages/CommandAuthoringPage.tsx))
+
+### P2 — responsive / perf / polish (0/9)
+
+- [ ] **Commands header buttons overflow on phones** — `flex` no-wrap clips Refresh/Export/Import/New; add `flex-wrap` (or icon-only `<sm`) ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Bulk-action bar not sticky** — scrolls off-screen on long mobile lists; `sticky` it ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Bulk-bar `aria-live` too broad** — wraps the buttons too, re-announcing on every toggle; scope it to the "{n} selected" count ([`CommandsPage.tsx`](webui/frontend/src/pages/CommandsPage.tsx))
+- [ ] **Config tooltips overflow on mobile** — `tooltip-right` near the right edge clips; make direction responsive ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **Config mic-test result row clips long errors** — fixed `h-7 overflow-hidden`; allow wrap/grow ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **Config dirty/seed `JSON.stringify` churn** — 4-5 full serializations per keystroke; memoize/compare smarter ([`ConfigurationPage.tsx`](webui/frontend/src/pages/ConfigurationPage.tsx))
+- [ ] **VoiceTest reverse-scan derivations + index keys** — `[...events].reverse().find` per change and index-based timeline keys; single backward pass + stable ids ([`VoiceTestPage.tsx`](webui/frontend/src/pages/VoiceTestPage.tsx))
+- [ ] **SessionExpiredModal actions don't stack on narrow** — add `flex-col sm:flex-row`; lock body scroll + inert background while blocking ([`SessionExpiredModal.tsx`](webui/frontend/src/components/SessionExpiredModal.tsx))
+- [ ] **Dead `pattern-isometric` class on Login** — referenced but undefined; define it or remove the dead class ([`LoginPage.tsx`](webui/frontend/src/pages/LoginPage.tsx))
+
+---
+
 ## Done (recent)
 
 2026-06-11 (continued):


### PR DESCRIPTION
Post-wave-8 re-audit — 22 items (13 real bugs incl. session-modal + bulk-ops issues, 9 responsive/perf). 🤖 Generated with [Claude Code](https://claude.com/claude-code)