### PR TITLE
fix: round-6 — avatar auth, preferences allow-list, rate limit, metrics correctness, thread-safety

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -467,27 +467,27 @@ The last-uncritiqued surfaces still had real bugs. Most of the reviewed code was
 confirmed solid (trusted-proxy handling, security headers, agents/audio/version
 routes, rate-limiter pruning) — these are the genuine issues.
 
-### Security (0/4)
+### Security (4/4)
 
-- [ ] **`/avatar/*` routes bypass auth** — `AuthMiddleware` only gates `path.startswith("/api/")`, but the avatar routes live at `/avatar/...`; in particular **`/avatar/launch` spawns a host subprocess unauthenticated** (local DoS / process spawn). Gate `/avatar/launch` (and the other state-changing avatar routes) behind auth + add an idempotency/single-instance guard — without breaking the avatar client that connects to `/avatar/ws` ([`web/routes/avatar_api.py`](src/chatty_commander/web/routes/avatar_api.py), [`web/middleware/auth.py`](src/chatty_commander/web/middleware/auth.py))
-- [ ] **`/api/preferences` + `/api/restore` dead allow-list** — `if k in ALLOWED_PREF_KEYS or True:` always passes, so any config key (`auth`, `web_server`) can be overwritten + persisted; drop the `or True`, actually filter ([`web/routes/system.py`](src/chatty_commander/web/routes/system.py))
-- [ ] **Rate-limit default effectively off** — `requests_per_minute=10000`; lower to a sane default (e.g. 600) and/or make it `web_server.rate_limit_rpm`-configurable ([`web/web_mode.py`](src/chatty_commander/web/web_mode.py))
-- [ ] **`apply_cors` wildcard in no-auth** — `allow_origins=["*"]` when `no_auth=True` (credentials correctly dropped, but still readable by any site); default to a localhost allowlist like web_mode already does ([`web/auth.py`](src/chatty_commander/web/auth.py))
+- [x] **`/avatar/*` routes bypass auth** — `AuthMiddleware` only gates `path.startswith("/api/")`, but the avatar routes live at `/avatar/...`; in particular **`/avatar/launch` spawns a host subprocess unauthenticated** (local DoS / process spawn). Gate `/avatar/launch` (and the other state-changing avatar routes) behind auth + add an idempotency/single-instance guard — without breaking the avatar client that connects to `/avatar/ws` ([`web/routes/avatar_api.py`](src/chatty_commander/web/routes/avatar_api.py), [`web/middleware/auth.py`](src/chatty_commander/web/middleware/auth.py))  ✅ (#731)
+- [x] **`/api/preferences` + `/api/restore` dead allow-list** — `if k in ALLOWED_PREF_KEYS or True:` always passes, so any config key (`auth`, `web_server`) can be overwritten + persisted; drop the `or True`, actually filter ([`web/routes/system.py`](src/chatty_commander/web/routes/system.py))  ✅ (#731)
+- [x] **Rate-limit default effectively off** — `requests_per_minute=10000`; lower to a sane default (e.g. 600) and/or make it `web_server.rate_limit_rpm`-configurable ([`web/web_mode.py`](src/chatty_commander/web/web_mode.py))  ✅ (#731)
+- [x] **`apply_cors` wildcard in no-auth** — `allow_origins=["*"]` when `no_auth=True` (credentials correctly dropped, but still readable by any site); default to a localhost allowlist like web_mode already does ([`web/auth.py`](src/chatty_commander/web/auth.py))  ✅ (#731)
 
-### Metrics correctness (0/4)
+### Metrics correctness (4/4)
 
-- [ ] **obs/metrics readers race the writers** — `Counter/Gauge/Histogram` readers iterate `_values`/`_counts` without the lock while request threads mutate under it → "dictionary changed size during iteration" 500 on a concurrent `/metrics` scrape; snapshot under the lock ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))
-- [ ] **Prometheus `+Inf` histogram bucket invalid** — `+Inf` is emitted as `counts[-1]` (only over-all-edges count), not the cumulative total, producing a non-monotonic histogram that breaks Prometheus parsing; emit the running total and make finite buckets cumulative ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))
-- [ ] **request-duration histogram always `route:"unknown"`** — the `Timer` closes before the route is resolved; resolve the route after `call_next` and observe with the real label ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))
-- [ ] **metrics middleware no try/finally** — a raising handler skips the request counter (undercounts errors) and breaks the "metrics never affect the app path" guarantee; wrap in try/finally ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))
+- [x] **obs/metrics readers race the writers** — `Counter/Gauge/Histogram` readers iterate `_values`/`_counts` without the lock while request threads mutate under it → "dictionary changed size during iteration" 500 on a concurrent `/metrics` scrape; snapshot under the lock ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))  ✅ (#731)
+- [x] **Prometheus `+Inf` histogram bucket invalid** — `+Inf` is emitted as `counts[-1]` (only over-all-edges count), not the cumulative total, producing a non-monotonic histogram that breaks Prometheus parsing; emit the running total and make finite buckets cumulative ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))  ✅ (#731)
+- [x] **request-duration histogram always `route:"unknown"`** — the `Timer` closes before the route is resolved; resolve the route after `call_next` and observe with the real label ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))  ✅ (#731)
+- [x] **metrics middleware no try/finally** — a raising handler skips the request counter (undercounts errors) and breaks the "metrics never affect the app path" guarantee; wrap in try/finally ([`obs/metrics.py`](src/chatty_commander/obs/metrics.py))  ✅ (#731)
 
-### Avatar / GUI robustness (0/5)
+### Avatar / GUI robustness (5/5)
 
-- [ ] **avatar_ws connection list mutated cross-thread** — `active_connections` (a list) is mutated from the loop and from `broadcast_state_change` invoked off-thread via `asyncio.run`; guard with a lock or marshal onto the server loop ([`web/routes/avatar_ws.py`](src/chatty_commander/web/routes/avatar_ws.py))
-- [ ] **thinking_state broadcasts via `asyncio.run` per call** — spins a fresh loop per state change (sockets bound to the server loop → dropped sends); capture the server loop + `run_coroutine_threadsafe`, and make `set_agent_state` auto-register atomic ([`avatars/thinking_state.py`](src/chatty_commander/avatars/thinking_state.py))
-- [ ] **avatar_ws audio queue bound to import-time loop** — `asyncio.Queue()` created at import may belong to a closed/other loop; create it lazily in the running loop ([`web/routes/avatar_ws.py`](src/chatty_commander/web/routes/avatar_ws.py))
-- [ ] **web_mode `_on_state_change` + duplicate asset mount** — `_on_state_change` builds a non-running loop (silent drop + leak); route it through `_schedule_broadcast`; remove the duplicated `app.mount("/assets", ...)` block ([`web/web_mode.py`](src/chatty_commander/web/web_mode.py))
-- [ ] **GUI degrade-not-crash** — `pyqt5_avatar` references `pyqtSignal` at class-definition when PyQt5 is absent → `NameError` on import (should degrade); `tray_popup` resolves `icon.png` from CWD (silent miss) + leaks the webview thread on quit ([`gui/pyqt5_avatar.py`](src/chatty_commander/gui/pyqt5_avatar.py), [`gui/tray_popup.py`](src/chatty_commander/gui/tray_popup.py))
+- [x] **avatar_ws connection list mutated cross-thread** — `active_connections` (a list) is mutated from the loop and from `broadcast_state_change` invoked off-thread via `asyncio.run`; guard with a lock or marshal onto the server loop ([`web/routes/avatar_ws.py`](src/chatty_commander/web/routes/avatar_ws.py))  ✅ (#731)
+- [x] **thinking_state broadcasts via `asyncio.run` per call** — spins a fresh loop per state change (sockets bound to the server loop → dropped sends); capture the server loop + `run_coroutine_threadsafe`, and make `set_agent_state` auto-register atomic ([`avatars/thinking_state.py`](src/chatty_commander/avatars/thinking_state.py))  ✅ (#731)
+- [x] **avatar_ws audio queue bound to import-time loop** — `asyncio.Queue()` created at import may belong to a closed/other loop; create it lazily in the running loop ([`web/routes/avatar_ws.py`](src/chatty_commander/web/routes/avatar_ws.py))  ✅ (#731)
+- [x] **web_mode `_on_state_change` + duplicate asset mount** — `_on_state_change` builds a non-running loop (silent drop + leak); route it through `_schedule_broadcast`; remove the duplicated `app.mount("/assets", ...)` block ([`web/web_mode.py`](src/chatty_commander/web/web_mode.py))  ✅ (#731)
+- [x] **GUI degrade-not-crash** — `pyqt5_avatar` references `pyqtSignal` at class-definition when PyQt5 is absent → `NameError` on import (should degrade); `tray_popup` resolves `icon.png` from CWD (silent miss) + leaks the webview thread on quit ([`gui/pyqt5_avatar.py`](src/chatty_commander/gui/pyqt5_avatar.py), [`gui/tray_popup.py`](src/chatty_commander/gui/tray_popup.py))  ✅ (#731)
 
 ---
 

--- a/src/chatty_commander/avatars/thinking_state.py
+++ b/src/chatty_commander/avatars/thinking_state.py
@@ -33,10 +33,10 @@ import inspect
 import logging
 import threading
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +99,24 @@ class ThinkingStateManager:
         # the in-memory mutations and snapshots, never while invoking broadcast
         # callbacks, so a callback may safely re-enter the manager.
         self._lock = threading.RLock()
+        # The server event loop that async broadcast callbacks (WS sends) are
+        # bound to. Captured the first time a broadcast is scheduled from inside
+        # a running loop (e.g. the FastAPI server loop at startup / first state
+        # change). Sync callers on other threads then marshal coroutines onto
+        # this loop via ``run_coroutine_threadsafe`` rather than spinning a
+        # throwaway loop with ``asyncio.run`` — mirrors the dograh
+        # ``DograhCallStatePoller`` / ``run_coroutine_threadsafe`` bridge.
+        self._server_loop: asyncio.AbstractEventLoop | None = None
+
+    def set_server_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Explicitly bind the server event loop used for async broadcasts.
+
+        Optional: the loop is also captured lazily the first time a broadcast is
+        scheduled from within a running loop. Provided so a server can pin its
+        loop at startup if desired.
+        """
+        with self._lock:
+            self._server_loop = loop
 
     def register_agent(
         self, agent_id: str, persona_id: str, avatar_id: str | None = None
@@ -125,11 +143,22 @@ class ThinkingStateManager:
         progress: float | None = None,
     ) -> None:
         """Update an agent's thinking state."""
-        if agent_id not in self.agent_states:
-            logger.warning(f"Agent {agent_id} not registered, creating default entry")
-            self.register_agent(agent_id, "default")
-
+        # Membership-check-and-register must be atomic: two threads racing the
+        # same new id would otherwise both pass the ``not in`` check and both
+        # register. Do the check, lazy-register and mutation under one lock
+        # acquisition (the lock is reentrant, so the nested register is safe).
         with self._lock:
+            if agent_id not in self.agent_states:
+                logger.warning(
+                    f"Agent {agent_id} not registered, creating default entry"
+                )
+                self.agent_states[agent_id] = AgentStateInfo(
+                    agent_id=agent_id,
+                    avatar_id=None,
+                    persona_id="default",
+                    state=ThinkingState.IDLE,
+                )
+
             agent_info = self.agent_states[agent_id]
             agent_info.state = state
             agent_info.message = message
@@ -186,19 +215,72 @@ class ThinkingStateManager:
         # callback may safely re-enter the manager without deadlocking.
         with self._lock:
             callbacks = list(self.broadcast_callbacks)
+            server_loop = self._server_loop
         for callback in callbacks:
             try:
                 if inspect.iscoroutinefunction(callback):
-                    # If we're in an event loop, schedule the coroutine, else run it
-                    try:
-                        loop = asyncio.get_running_loop()
-                        loop.create_task(callback(message))
-                    except RuntimeError:
-                        asyncio.run(callback(message))
+                    self._dispatch_async(callback, message, server_loop)
                 else:
                     callback(message)
             except Exception as e:
                 logger.error(f"Error in broadcast callback: {e}")
+
+    def _dispatch_async(
+        self,
+        callback: Callable[[dict[str, Any]], Awaitable[None]],
+        message: dict[str, Any],
+        server_loop: asyncio.AbstractEventLoop | None,
+    ) -> None:
+        """Run an async broadcast callback on the correct event loop.
+
+        Three cases, in order:
+
+        1. Called from inside a running loop — schedule on it directly. We also
+           capture that loop as the server loop (first-write wins) so later
+           cross-thread callers know where the WS sockets live.
+        2. Called from a thread with no running loop but a server loop is known
+           — marshal onto it via ``run_coroutine_threadsafe`` (sockets are bound
+           to that loop). This mirrors the dograh ``run_coroutine_threadsafe``
+           bridge and avoids dropping sends.
+        3. No loop available at all — log and skip rather than spinning a
+           throwaway loop with ``asyncio.run`` (a fresh loop owns no sockets, so
+           the send would be silently lost anyway).
+        """
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is not None:
+            if self._server_loop is None:
+                with self._lock:
+                    if self._server_loop is None:
+                        self._server_loop = running_loop
+            coro = cast("Coroutine[Any, Any, None]", callback(message))
+            try:
+                running_loop.create_task(coro)
+            except Exception:
+                coro.close()
+                raise
+            return
+
+        if server_loop is not None:
+            coro = cast("Coroutine[Any, Any, None]", callback(message))
+            try:
+                asyncio.run_coroutine_threadsafe(coro, server_loop)
+            except Exception as e:
+                coro.close()
+                logger.error(f"Failed to schedule broadcast on server loop: {e}")
+            return
+
+        # No running loop here and no server loop captured yet: a throwaway
+        # ``asyncio.run`` loop would own none of the WS sockets, so the send
+        # would be dropped regardless. Degrade gracefully.
+        logger.debug(
+            "No server event loop available for async broadcast callback; "
+            "skipping (callback=%r)",
+            getattr(callback, "__qualname__", callback),
+        )
 
     def _broadcast_state_change(self, agent_id: str) -> None:
         """Broadcast state change to all registered callbacks."""

--- a/src/chatty_commander/gui/pyqt5_avatar.py
+++ b/src/chatty_commander/gui/pyqt5_avatar.py
@@ -53,7 +53,24 @@ try:
 except ImportError:
     PYQT5_AVAILABLE = False
 
-    # Create dummy classes for type hints
+    # PyQt5 is an OPTIONAL dependency. When it is absent the module must still
+    # import cleanly so callers can degrade gracefully (see run_pyqt5_avatar).
+    # The class body of TransparentBrowser references several PyQt5 names at
+    # *definition* time (notably ``pyqtSignal`` for the ``window_closed`` signal,
+    # plus ``Qt``/``QUrl`` in method bodies), so every name referenced at import
+    # time needs a stub here, otherwise importing the module raises NameError
+    # before the availability guard can run.
+
+    # Names referenced at class-definition time.
+    def pyqtSignal(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef]
+        return None
+
+    # Placeholder objects for names used inside method bodies / class attributes.
+    Qt = None  # type: ignore[assignment]
+    QUrl = None  # type: ignore[assignment]
+    QIcon = None  # type: ignore[assignment]
+
+    # Create dummy classes for type hints / base classes.
     class QMainWindow:  # type: ignore[no-redef]
         pass
 
@@ -64,6 +81,18 @@ except ImportError:
         pass
 
     class QApplication:  # type: ignore[no-redef]
+        pass
+
+    class QWidget:  # type: ignore[no-redef]
+        pass
+
+    class QVBoxLayout:  # type: ignore[no-redef]
+        pass
+
+    class QMenu:  # type: ignore[no-redef]
+        pass
+
+    class QAction:  # type: ignore[no-redef]
         pass
 
 

--- a/src/chatty_commander/gui/tray_popup.py
+++ b/src/chatty_commander/gui/tray_popup.py
@@ -75,18 +75,33 @@ def _load_settings(config: Any) -> dict[str, Any]:
     return settings
 
 
+def _icon_candidate_paths() -> list[Path]:
+    """Return possible icon locations resolved relative to the package.
+
+    Resolving relative to this file (rather than the process CWD) means the
+    tray icon loads regardless of which directory the app was launched from.
+    Mirrors ``pyqt5_avatar._get_icon_path``.
+    """
+    here = Path(__file__).resolve().parent
+    repo_root = here.parent.parent.parent
+    return [
+        here.parent / "assets" / "icon.png",
+        repo_root / "icon.png",
+    ]
+
+
 def _icon_image() -> Image.Image | None:
     try:
         from PIL import Image  # type: ignore
     except Exception:
         return None
 
-    icon_path_png = Path("icon.png")
-    if icon_path_png.exists():
-        try:
-            return Image.open(icon_path_png)
-        except Exception:
-            return None
+    for icon_path_png in _icon_candidate_paths():
+        if icon_path_png.exists():
+            try:
+                return Image.open(icon_path_png)
+            except Exception:
+                return None
     # If only SVG exists, we skip rasterization here (no cairosvg dependency in core)
     return None
 
@@ -172,8 +187,29 @@ def run_tray_popup(config: Any, logger) -> int:
         """On Quit handler."""
         _icon.stop()
         # Best-effort graceful shutdown of the webview worker thread.
+        #
+        # ``webview.start()`` (inside the worker thread) blocks until its window
+        # is closed, so simply joining the thread would always time out and leak
+        # the daemon thread. Signal pywebview to tear down its window(s) first so
+        # the worker returns from ``start()`` and the join completes cleanly.
         t = window_thread["t"]
         if t is not None and t.is_alive():
+            if webview is not None:
+                try:
+                    # Destroy any open windows so webview.start() returns.
+                    windows = list(getattr(webview, "windows", []) or [])
+                    for win in windows:
+                        try:
+                            win.destroy()
+                        except Exception:  # pragma: no cover - backend-specific
+                            logger.warning("Failed to destroy webview window", exc_info=True)
+                    if not windows:
+                        # Older pywebview API: module-level destroy helper.
+                        destroy = getattr(webview, "destroy_window", None)
+                        if callable(destroy):
+                            destroy()
+                except Exception:  # pragma: no cover - backend-specific
+                    logger.warning("Failed to signal webview shutdown", exc_info=True)
             t.join(timeout=2.0)
 
     menu = Menu(

--- a/src/chatty_commander/obs/metrics.py
+++ b/src/chatty_commander/obs/metrics.py
@@ -96,11 +96,14 @@ class Counter(Metric):
             self._values[key] = self._values.get(key, 0) + amount
 
     def get(self, labels: dict[str, str] | None = None) -> int:
-        return self._values.get(self._key(labels), 0)
+        with self._lock:
+            return self._values.get(self._key(labels), 0)
 
     def samples(self) -> list[tuple[dict[str, str], int]]:
+        with self._lock:
+            snapshot = list(self._values.items())
         out: list[tuple[dict[str, str], int]] = []
-        for key, value in self._values.items():
+        for key, value in snapshot:
             labels = dict(key)
             out.append((labels, value))
         return out
@@ -119,11 +122,14 @@ class Gauge(Metric):
             self._values[key] = float(value)
 
     def get(self, labels: dict[str, str] | None = None) -> float:
-        return self._values.get(self._key(labels), 0.0)
+        with self._lock:
+            return self._values.get(self._key(labels), 0.0)
 
     def samples(self) -> list[tuple[dict[str, str], float]]:
+        with self._lock:
+            snapshot = list(self._values.items())
         out: list[tuple[dict[str, str], float]] = []
-        for key, value in self._values.items():
+        for key, value in snapshot:
             labels = dict(key)
             out.append((labels, value))
         return out
@@ -189,14 +195,25 @@ class Histogram(Metric):
 
     def snapshot(self) -> dict[str, Any]:
         out: dict[str, Any] = {"buckets": self._buckets.edges, "series": []}
-        for key, counts in self._counts.items():
-            labels = dict(key)
+        with self._lock:
+            # Copy the per-series state inside the lock so a concurrent
+            # observe() can't mutate the dicts while we iterate them.
+            snapshot = [
+                (
+                    dict(key),
+                    list(counts),
+                    self._sum.get(key, 0.0),
+                    self._count.get(key, 0),
+                )
+                for key, counts in self._counts.items()
+            ]
+        for labels, counts, sum_val, count_val in snapshot:
             out["series"].append(
                 {
                     "labels": labels,
-                    "counts": list(counts),
-                    "sum": self._sum.get(key, 0.0),
-                    "count": self._count.get(key, 0),
+                    "counts": counts,
+                    "sum": sum_val,
+                    "count": count_val,
                 }
             )
         return out
@@ -297,27 +314,36 @@ class RequestMetricsMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
     async def dispatch(
         self, request: Request, call_next: Callable[[Request], Any]
     ) -> Response:  # type: ignore[name-defined]
-        # path variable intentionally unused to minimize attribute access overhead
         method = getattr(request, "method", "GET")
-        # Measure with unknown route first; route set after call_next
-        with Timer(
-            self.h_latency,
-            labels={"route": "unknown", "method": method, "service": self.service},
-        ):
+        t0 = monotonic()
+        status = 0
+        response = None
+        try:
             response = await call_next(request)
-        status = getattr(response, "status_code", 0)
-        route = getattr(request, "scope", {}).get("route", None)
-        route_path = getattr(route, "path", "unknown") if route else "unknown"
-        self.c_req.inc(
-            1,
-            labels={
-                "route": route_path,
-                "method": method,
-                "status": str(status),
-                "service": self.service,
-            },
-        )
-        return response  # type: ignore[no-any-return]
+            status = getattr(response, "status_code", 0)
+            return response  # type: ignore[no-any-return]
+        finally:
+            # Resolve the route only after call_next so the matched route is
+            # available on request.scope. Record duration manually with the
+            # real route label rather than the fixed-label Timer wrapper.
+            # Metrics collection is best-effort and must never break the app
+            # request path, so swallow any errors here.
+            try:
+                elapsed = monotonic() - t0
+                route = getattr(request, "scope", {}).get("route", None)
+                route_path = getattr(route, "path", "unknown") if route else "unknown"
+                labels = {
+                    "route": route_path,
+                    "method": method,
+                    "service": self.service,
+                }
+                self.h_latency.observe(elapsed, labels=labels)
+                self.c_req.inc(
+                    1,
+                    labels={**labels, "status": str(status)},
+                )
+            except Exception:  # pragma: no cover - defensive
+                pass
 
 
 def create_metrics_router(registry: MetricsRegistry | None = None) -> APIRouter | None:  # type: ignore[misc]
@@ -376,7 +402,10 @@ def create_metrics_router(registry: MetricsRegistry | None = None) -> APIRouter 
                 counts = series.get("counts", [])
                 sum_val = series.get("sum", 0.0)
                 count_val = series.get("count", 0)
-                # Emit cumulative buckets
+                # observe() stores per-finite-edge counts that are already
+                # cumulative (each counts[idx] == observations <= edges[idx]).
+                # Emit them as-is, then the +Inf bucket which, per the
+                # Prometheus spec, must equal the total observation count.
                 for idx, edge in enumerate(snap.get("buckets", [])):
                     bucket_lbl = {**labels, "le": str(edge)}
                     lines.append(
@@ -384,7 +413,7 @@ def create_metrics_router(registry: MetricsRegistry | None = None) -> APIRouter 
                     )
                 bucket_lbl_inf = {**labels, "le": "+Inf"}
                 lines.append(
-                    f"{name}_bucket{{{_lbl(bucket_lbl_inf)}}} {counts[-1] if counts else 0}"
+                    f"{name}_bucket{{{_lbl(bucket_lbl_inf)}}} {count_val}"
                 )
                 lines.append(f"{name}_sum{{{_lbl(labels)}}} {sum_val}")
                 lines.append(f"{name}_count{{{_lbl(labels)}}} {count_val}")

--- a/src/chatty_commander/web/auth.py
+++ b/src/chatty_commander/web/auth.py
@@ -61,17 +61,29 @@ def apply_cors(
     app: FastAPI, *, no_auth: bool, origins: Iterable[str] | None = None
 ) -> None:
     """
-    Apply CORS middleware consistent with legacy behavior.
+    Apply CORS middleware with a localhost-only default.
 
-    - When no_auth is True: fully permissive for local/dev usage.
-    - Otherwise: restrict to provided origins, defaulting to localhost:3000.
+    - When explicit ``origins`` are provided: use them verbatim (the caller is
+      responsible for the policy, e.g. web_mode.py's CHATTY_CORS_ORIGINS logic).
+    - When no_auth is True and no origins given: pin to a localhost allowlist
+      (NOT a wildcard). no_auth disables authentication entirely, so a wildcard
+      origin would let any website the user visits drive this API from their
+      browser and read the responses (drive-by attack). Mirrors the localhost
+      defaults web_mode.py passes through.
+    - Otherwise: default to localhost:3000.
     """
-    if no_auth:
-        allow_origins = ["*"]
+    if origins is not None:
+        allow_origins = list(origins)
+    elif no_auth:
+        # Localhost-only defaults (vite dev server on :3000 + API port :8100).
+        allow_origins = [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:8100",
+            "http://127.0.0.1:8100",
+        ]
     else:
-        allow_origins = (
-            list(origins) if origins is not None else ["http://localhost:3000"]
-        )
+        allow_origins = ["http://localhost:3000"]
 
     # Remove existing CORS middleware if already present to avoid duplicates.
     app.user_middleware = [

--- a/src/chatty_commander/web/routes/avatar_api.py
+++ b/src/chatty_commander/web/routes/avatar_api.py
@@ -28,10 +28,29 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from chatty_commander.web.deps.auth import require_role
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+# Single-instance / idempotency guard for /avatar/launch. The launch endpoint
+# spawns a host subprocess, so repeated POSTs must not be able to fork unlimited
+# GUI processes. We remember the most recently launched child and, while it is
+# still alive, return that existing instance (200) instead of spawning another.
+_LAUNCHED_PROCESS: Any | None = None
+
+
+def _existing_running_process() -> Any | None:
+    """Return the tracked launch subprocess if it is still running, else None."""
+    proc = _LAUNCHED_PROCESS
+    if proc is None:
+        return None
+    # asyncio subprocess: returncode is None while the child is alive.
+    if getattr(proc, "returncode", 0) is None:
+        return proc
+    return None
 
 
 _ALLOWED_EXTS = {
@@ -133,8 +152,31 @@ async def list_animations(
 
 
 @router.post("/avatar/launch")
-async def launch_avatar() -> dict[str, Any]:
+async def launch_avatar(
+    _principal: Any = Depends(require_role("user")),
+) -> dict[str, Any]:
+    # SECURITY: /avatar/launch spawns a host subprocess and lives outside the
+    # /api/ prefix that AuthMiddleware gates, so it would otherwise be reachable
+    # unauthenticated. require_role("user") enforces an authenticated user when
+    # auth is active and is a pass-through in --no-auth / no-auth-configured
+    # mode (web/deps/auth.py degradation rule), so dev usage is unchanged.
+    global _LAUNCHED_PROCESS
     try:
+        # Idempotency / single-instance guard: if a previously launched avatar
+        # is still running, return it instead of forking another process. This
+        # prevents repeated POSTs from spawning unlimited GUI subprocesses.
+        existing = _existing_running_process()
+        if existing is not None:
+            logger.info(
+                "Avatar already running (PID: %s); returning existing instance",
+                existing.pid,
+            )
+            return {
+                "status": "already_running",
+                "message": "Avatar already running",
+                "pid": existing.pid,
+            }
+
         # Get the current Python executable and project root
         python_exe = sys.executable
         project_root = Path(__file__).resolve().parents[4]  # Go up to project root
@@ -158,6 +200,8 @@ async def launch_avatar() -> dict[str, Any]:
         await asyncio.sleep(0.1)  # Give it a moment to start
 
         if process.returncode is None:  # Process is still running
+            # Track the live child so subsequent launches are idempotent.
+            _LAUNCHED_PROCESS = process
             logger.info(f"Avatar process started successfully with PID: {process.pid}")
             return {
                 "status": "success",

--- a/src/chatty_commander/web/routes/avatar_ws.py
+++ b/src/chatty_commander/web/routes/avatar_ws.py
@@ -29,6 +29,7 @@ control messages from the avatar client.
 import asyncio
 import json
 import logging
+import threading
 from collections.abc import Callable
 from typing import Any
 
@@ -44,6 +45,14 @@ router = APIRouter()
 class AvatarWSConnectionManager:
     def __init__(self, theme_resolver: Callable[[str], str] | None = None):
         self.active_connections: list[WebSocket] = []
+        # ``active_connections`` is mutated from ``connect``/``disconnect`` on
+        # the server event loop AND read/mutated from ``broadcast_state_change``,
+        # which ThinkingStateManager may invoke from a DIFFERENT thread when a
+        # sync command/advisor thread changes state. A plain list mutated
+        # cross-thread can corrupt, so all access goes through this lock. We only
+        # ever hold it around the list operation itself (append/remove/snapshot),
+        # never while awaiting a send.
+        self._connections_lock = threading.Lock()
         # optional persona -> theme resolver
         self.theme_resolver = theme_resolver
         # Track the manager instance we've registered with to survive resets in tests
@@ -71,7 +80,8 @@ class AvatarWSConnectionManager:
 
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
-        self.active_connections.append(websocket)
+        with self._connections_lock:
+            self.active_connections.append(websocket)
         # ensure we are bound to the current manager (handles reset in tests)
         mgr = self._ensure_manager()
         # send snapshot of current states (enrich with theme if available)
@@ -91,10 +101,11 @@ class AvatarWSConnectionManager:
             logger.error(f"Failed to send snapshot to avatar client: {e}")
 
     def disconnect(self, websocket: WebSocket):
-        try:
-            self.active_connections.remove(websocket)
-        except ValueError:
-            pass
+        with self._connections_lock:
+            try:
+                self.active_connections.remove(websocket)
+            except ValueError:
+                pass
 
     async def send_personal_message(
         self, message: dict[str, Any], websocket: WebSocket
@@ -119,8 +130,13 @@ class AvatarWSConnectionManager:
 
         # Schedule broadcast (simple inline to avoid broken nested def)
         async def _do_broadcast():
+            # Snapshot the connection list under the lock, then send outside it
+            # so a concurrent connect/disconnect (possibly on another thread)
+            # can't mutate the list while we iterate it.
+            with self._connections_lock:
+                connections = list(self.active_connections)
             dead: list[WebSocket] = []
-            for connection in list(self.active_connections):
+            for connection in connections:
                 try:
                     await connection.send_text(json.dumps(message))
                 except Exception:
@@ -154,9 +170,27 @@ class AvatarAudioQueue:
 
     def __init__(self, ws_manager: AvatarWSConnectionManager) -> None:
         self.manager = ws_manager
-        self.queue: asyncio.Queue[tuple[str, str, bytes | None]] = asyncio.Queue()
+        # The queue is created lazily on first access (see the ``queue``
+        # property) rather than at construction. ``asyncio.Queue`` binds to the
+        # running loop at creation time; building it here — at import time for
+        # the module-level singleton — would bind it to whatever loop happened
+        # to be current then (often a closed/foreign loop under uvicorn or the
+        # test harness), causing "got Future attached to a different loop"
+        # errors. Creating it on first use inside the running loop avoids this.
+        self._queue: asyncio.Queue[tuple[str, str, bytes | None]] | None = None
         self._processor_task: asyncio.Task | None = None
         self._current_play_task: asyncio.Task | None = None
+
+    @property
+    def queue(self) -> asyncio.Queue[tuple[str, str, bytes | None]]:
+        """Return the message queue, creating it lazily on first use.
+
+        Created inside the (running) loop of the first caller so the queue binds
+        to the correct event loop rather than an import-time one.
+        """
+        if self._queue is None:
+            self._queue = asyncio.Queue()
+        return self._queue
 
     @property
     def is_speaking(self) -> bool:

--- a/src/chatty_commander/web/routes/system.py
+++ b/src/chatty_commander/web/routes/system.py
@@ -251,14 +251,18 @@ def include_system_routes(
             try:
                 cfg_mgr = get_config_manager()
                 if hasattr(cfg_mgr, "config"):
+                    # SECURITY: only persist keys on the allow-list. Without
+                    # this filter any config key (auth, web_server, ...) could
+                    # be overwritten via the preferences endpoint.
                     for k, v in payload.items():
-                        if k in ALLOWED_PREF_KEYS or True:  # permissive for UI prefs
+                        if k in ALLOWED_PREF_KEYS:
                             cfg_mgr.config[k] = v
                     if hasattr(cfg_mgr, "save_config"):
                         cfg_mgr.save_config()
             except Exception as e:
                 logger.warning(f"Failed to update preferences: {e}")
-        return {"success": True, "message": "Preferences updated", "preferences": payload}
+        accepted = {k: v for k, v in payload.items() if k in ALLOWED_PREF_KEYS}
+        return {"success": True, "message": "Preferences updated", "preferences": accepted}
 
     # --- Backup / Restore (stubs, functional enough for UI; persist config snapshot) ---
     @router.post("/api/backup", response_model=ActionResponse)
@@ -290,8 +294,11 @@ def include_system_routes(
                 data = payload.get("data") if isinstance(payload, dict) else None
                 data = data if isinstance(data, dict) else (payload if isinstance(payload, dict) else {})
                 if hasattr(cfg_mgr, "config"):
+                    # SECURITY: same allow-list filter as PUT /api/preferences —
+                    # a restore payload must not be able to overwrite arbitrary
+                    # config keys (auth, web_server, ...).
                     for k, v in data.items():
-                        if k in ALLOWED_PREF_KEYS or True:
+                        if k in ALLOWED_PREF_KEYS:
                             cfg_mgr.config[k] = v
                     if hasattr(cfg_mgr, "save_config"):
                         cfg_mgr.save_config()

--- a/src/chatty_commander/web/web_mode.py
+++ b/src/chatty_commander/web/web_mode.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -246,6 +247,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._last_cleanup = time.time()
 
     async def dispatch(self, request: Request, call_next):
+        # Explicit opt-out for test harnesses / trusted local runs: parallel
+        # clients share one source IP and would otherwise trip the limit. Same
+        # CHATTY_DISABLE_RATE_LIMIT control used by the command rate limiter
+        # (a stray PYTEST_CURRENT_TEST must NOT silently disable prod limiting).
+        raw = os.environ.get("CHATTY_DISABLE_RATE_LIMIT")
+        if raw is not None and raw.strip().lower() in {"1", "true", "yes", "on"}:
+            return await call_next(request)
+
         # Use secure IP extraction to prevent spoofing
         client_ip = get_client_ip(request, self.trusted_proxies)
 
@@ -575,9 +584,23 @@ class WebModeServer:
                 "192.168.0.0/16",
             ]
 
+        # Rate limit: sane default (600/min), configurable via
+        # web_server.rate_limit_rpm. A non-positive / unparseable config value
+        # falls back to the default rather than disabling the limiter.
+        rate_limit_rpm = 600
+        if hasattr(self.config_manager, "web_server"):
+            try:
+                configured = int(
+                    self.config_manager.web_server.get("rate_limit_rpm", rate_limit_rpm)
+                )
+                if configured > 0:
+                    rate_limit_rpm = configured
+            except (TypeError, ValueError):
+                pass
+
         app.add_middleware(
             RateLimitMiddleware,
-            requests_per_minute=10000,
+            requests_per_minute=rate_limit_rpm,
             trusted_proxies=trusted_proxies,
         )
 
@@ -691,10 +714,6 @@ class WebModeServer:
 
         if frontend_path.exists():
             static_assets = frontend_path / "assets"
-            if static_assets.exists():
-                app.mount(
-                    "/assets", StaticFiles(directory=str(static_assets)), name="assets"
-                )
             if static_assets.exists():
                 app.mount(
                     "/assets", StaticFiles(directory=str(static_assets)), name="assets"
@@ -975,43 +994,22 @@ class WebModeServer:
                     pass
 
     def _on_state_change(self, old_state: str, new_state: str) -> None:
+        # Synchronous bookkeeping always happens; the live broadcast is routed
+        # through _schedule_broadcast which already tolerates a missing / closed
+        # / not-yet-running event loop (degrading to a debug-logged skip).
+        # Building a fresh non-running loop here, as the old code did, only
+        # leaked a loop and silently dropped the message anyway.
         self.last_state_change = datetime.now()
-        try:
-            loop = asyncio.get_event_loop()
-            loop.create_task(
-                self._broadcast_message(
-                    WebSocketMessage(
-                        type="state_change",
-                        data={
-                            "old_state": old_state,
-                            "new_state": new_state,
-                            "timestamp": self.last_state_change.isoformat(),
-                        },
-                    )
-                )
+        self._schedule_broadcast(
+            WebSocketMessage(
+                type="state_change",
+                data={
+                    "old_state": old_state,
+                    "new_state": new_state,
+                    "timestamp": self.last_state_change.isoformat(),
+                },
             )
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                loop.create_task(
-                    self._broadcast_message(
-                        WebSocketMessage(
-                            type="state_change",
-                            data={
-                                "old_state": old_state,
-                                "new_state": new_state,
-                                "timestamp": self.last_state_change.isoformat(),
-                            },
-                        )
-                    )
-                )
-            except Exception as e:  # noqa: BLE001
-                logger.debug("state_change broadcast scheduling failed: %s", e)
-        except Exception as e:  # noqa: BLE001
-            # e.g. the event loop is closed — fail gracefully rather than
-            # propagating into the state manager callback chain.
-            logger.debug("state_change broadcast scheduling failed: %s", e)
+        )
 
     # --------------------------
     # dograh availability status (push-driven UI card)

--- a/tests/test_avatar_launch_api.py
+++ b/tests/test_avatar_launch_api.py
@@ -9,11 +9,19 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from chatty_commander.web.routes import avatar_api
 from chatty_commander.web.routes.avatar_api import router as avatar_router
 
 
 class TestAvatarLaunchAPI:
     """Test suite for the avatar launch API endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_launch_guard(self):
+        """Reset the single-instance guard between tests."""
+        avatar_api._LAUNCHED_PROCESS = None
+        yield
+        avatar_api._LAUNCHED_PROCESS = None
 
     @pytest.fixture
     def app(self):
@@ -131,27 +139,62 @@ class TestAvatarLaunchAPI:
         mock_sleep.assert_called_once_with(0.1)
 
     @patch("asyncio.create_subprocess_exec")
-    def test_launch_avatar_multiple_calls(self, mock_subprocess, client):
-        """Test multiple avatar launch calls."""
-        # Mock successful process creation
+    def test_launch_avatar_idempotent_while_running(self, mock_subprocess, client):
+        """Repeated launches while a child is alive return the existing instance.
+
+        Single-instance guard: the subprocess must only be spawned once so
+        repeated POSTs can't fork unlimited GUI processes.
+        """
+        # Mock successful process creation (returncode=None => still running)
         mock_process = AsyncMock()
         mock_process.pid = 12345
         mock_process.returncode = None
         mock_subprocess.return_value = mock_process
 
-        # First call
+        # First call spawns the process.
         response1 = client.post("/avatar/launch")
         assert response1.status_code == 200
+        assert response1.json()["status"] == "success"
+        assert response1.json()["pid"] == 12345
 
-        # Second call should also succeed (new process)
-        mock_process.pid = 12346  # Different PID
+        # Second call returns the existing instance without spawning again.
         response2 = client.post("/avatar/launch")
         assert response2.status_code == 200
-
         data2 = response2.json()
-        assert data2["pid"] == 12346
+        assert data2["status"] == "already_running"
+        assert data2["pid"] == 12345
 
-        # Verify subprocess was called twice
+        # Verify subprocess was only created once.
+        assert mock_subprocess.call_count == 1
+
+    @patch("asyncio.create_subprocess_exec")
+    def test_launch_avatar_relaunches_after_exit(self, mock_subprocess, client):
+        """Once the tracked child has exited, a new launch spawns a fresh one."""
+        # First process is running.
+        running = AsyncMock()
+        running.pid = 12345
+        running.returncode = None
+
+        # After it "exits" (returncode set), a second launch should spawn again.
+        exited = AsyncMock()
+        exited.pid = 12345
+        exited.returncode = 0
+
+        fresh = AsyncMock()
+        fresh.pid = 999
+        fresh.returncode = None
+
+        mock_subprocess.return_value = running
+        assert client.post("/avatar/launch").status_code == 200
+        assert mock_subprocess.call_count == 1
+
+        # Simulate the tracked process having exited.
+        running.returncode = 0
+        mock_subprocess.return_value = fresh
+        resp = client.post("/avatar/launch")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
+        assert resp.json()["pid"] == 999
         assert mock_subprocess.call_count == 2
 
     @patch("asyncio.create_subprocess_exec")

--- a/tests/test_avatar_launch_auth.py
+++ b/tests/test_avatar_launch_auth.py
@@ -1,0 +1,111 @@
+"""Auth gating for the state-changing /avatar/launch endpoint.
+
+/avatar/launch spawns a host subprocess and lives outside the /api/ prefix that
+AuthMiddleware gates, so without an explicit dependency it would be reachable
+unauthenticated. It now declares require_role("user"), which enforces an
+authenticated user when auth is active and is a pass-through otherwise (the
+web/deps/auth.py degradation rule).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import jwt
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+except ImportError:  # pragma: no cover
+    pytest.skip("FastAPI not available", allow_module_level=True)
+
+from chatty_commander.app.config import Config
+from chatty_commander.web.deps.auth import (
+    JWT_ALGORITHM,
+    configure_auth_context,
+    get_auth_context,
+)
+from chatty_commander.web.routes import avatar_api
+from chatty_commander.web.web_mode import create_app
+
+SECRET = "avatar-launch-secret"
+
+
+def _token(roles: list[str]) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "sub": "alice",
+            "roles": roles,
+            "type": "access",
+            "jti": f"jti-{'-'.join(roles)}",
+            "iat": now,
+            "exp": now + 600,
+        },
+        SECRET,
+        algorithm=JWT_ALGORITHM,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.delenv("CHATTY_JWT_SECRET", raising=False)
+    monkeypatch.delenv("CHATTY_API_KEY", raising=False)
+    get_auth_context().reset()
+    avatar_api._LAUNCHED_PROCESS = None
+    yield
+    get_auth_context().reset()
+    avatar_api._LAUNCHED_PROCESS = None
+
+
+def _active_client() -> TestClient:
+    cfg = Config(config_file="")
+    cfg.config["auth"] = {
+        "jwt_secret": SECRET,
+        "users": {"alice": {"password_hash": "x", "roles": ["user"]}},
+    }
+    app = create_app(config=cfg, no_auth=True)
+    # Re-configure the context to no_auth=False so role enforcement is active
+    # while the coarse X-API-Key middleware (bypassed by no_auth=True at build)
+    # stays out of the way — we isolate the require_role gate.
+    configure_auth_context(config_manager=cfg, no_auth=False)
+    assert get_auth_context().is_auth_active() is True
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_launch_requires_auth_when_active():
+    """No Bearer token => 401 when user auth is active."""
+    client = _active_client()
+    resp = client.post("/avatar/launch")
+    assert resp.status_code == 401
+
+
+def test_launch_allowed_with_user_token():
+    client = _active_client()
+    with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        proc = AsyncMock()
+        proc.pid = 4242
+        proc.returncode = None
+        mock_subprocess.return_value = proc
+
+        resp = client.post(
+            "/avatar/launch",
+            headers={"Authorization": f"Bearer {_token(['user'])}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["pid"] == 4242
+
+
+def test_launch_passthrough_in_no_auth_mode():
+    """--no-auth (no users configured) => guard is a pass-through, no 401."""
+    app = create_app(no_auth=True)
+    assert get_auth_context().is_auth_active() is False
+    client = TestClient(app, raise_server_exceptions=False)
+    with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        proc = AsyncMock()
+        proc.pid = 7
+        proc.returncode = None
+        mock_subprocess.return_value = proc
+        resp = client.post("/avatar/launch")
+    assert resp.status_code == 200

--- a/tests/test_avatar_ws_components.py
+++ b/tests/test_avatar_ws_components.py
@@ -1,6 +1,7 @@
 """Comprehensive tests for Avatar WebSocket components and audio queue."""
 
 import asyncio
+import threading
 from typing import Any
 
 from chatty_commander.web.routes.avatar_ws import (
@@ -110,6 +111,73 @@ class TestAvatarWSConnectionManager:
         asyncio.run(run())
         assert ws1 in manager.active_connections
         assert ws2 not in manager.active_connections
+
+    def test_active_connections_concurrent_mutation_no_corruption(self) -> None:
+        """Stress active_connections under concurrent cross-thread mutation.
+
+        Reproduces the original bug class: ``connect``/``disconnect`` mutate the
+        connection list on one thread while ``broadcast_state_change`` snapshots
+        and iterates it from another (mirroring ThinkingStateManager invoking the
+        callback from a sync command/advisor thread). With the lock in place the
+        list must stay internally consistent — no lost/duplicated entries, no
+        ``RuntimeError`` from mutating-while-iterating, no crash.
+        """
+        manager = AvatarWSConnectionManager()
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        class _FakeWS:
+            def __init__(self, idx: int) -> None:
+                self.idx = idx
+
+            async def send_text(self, message: str) -> None:  # pragma: no cover
+                # Not exercised here; broadcast snapshots are read-only of state.
+                return None
+
+        sockets = [_FakeWS(i) for i in range(50)]
+
+        def mutator() -> None:
+            try:
+                # Repeatedly add then remove every socket. After this returns the
+                # net effect on the list is zero additions, so a corruption-free
+                # run leaves exactly the sockets added by the (still-running)
+                # other mutators — which we drain at the end.
+                for _ in range(200):
+                    for ws in sockets:
+                        with manager._connections_lock:
+                            manager.active_connections.append(ws)
+                    for ws in sockets:
+                        manager.disconnect(ws)
+            except BaseException as exc:  # noqa: BLE001 - capture for assertion
+                errors.append(exc)
+
+        def reader() -> None:
+            try:
+                while not stop.is_set():
+                    # Snapshot exactly as broadcast does, then iterate the copy.
+                    with manager._connections_lock:
+                        snapshot = list(manager.active_connections)
+                    for _ws in snapshot:
+                        pass
+            except BaseException as exc:  # noqa: BLE001 - capture for assertion
+                errors.append(exc)
+
+        mutators = [threading.Thread(target=mutator) for _ in range(4)]
+        readers = [threading.Thread(target=reader) for _ in range(2)]
+        for t in mutators:
+            t.start()
+        for t in readers:
+            t.start()
+        for t in mutators:
+            t.join()
+        stop.set()
+        for t in readers:
+            t.join()
+
+        assert errors == []
+        # Every mutator added and removed each socket the same number of times,
+        # so the list must be empty (and uncorrupted) at the end.
+        assert manager.active_connections == []
 
     def test_theme_resolver_enriches_messages(self) -> None:
         """Test that theme resolver adds theme to messages."""

--- a/tests/test_gui_optional_deps.py
+++ b/tests/test_gui_optional_deps.py
@@ -1,0 +1,199 @@
+# MIT License
+#
+# Copyright (c) 2024 mhand
+#
+# Tests for GUI optional-dependency degradation (PyQt5 / pystray / pywebview).
+"""Regression tests for the GUI modules' optional-dependency handling.
+
+PyQt5, pystray and pywebview are all OPTIONAL. These tests ensure the modules
+import cleanly (degrade, not crash) when those libraries are absent, that the
+tray icon is resolved relative to the package rather than the process CWD, and
+that quitting the tray tears the webview window down instead of leaking the
+worker thread.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_pyqt5_avatar_imports_without_pyqt5(monkeypatch):
+    """The module must import with PyQt5 absent without raising NameError.
+
+    Previously ``TransparentBrowser`` referenced ``pyqtSignal`` at class
+    definition time while the ImportError fallback only stubbed a handful of
+    classes, so importing the module crashed with NameError when PyQt5 was not
+    installed.
+    """
+    # Simulate PyQt5 (and its submodules) being unavailable.
+    for name in list(sys.modules):
+        if name == "PyQt5" or name.startswith("PyQt5."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "PyQt5", None)
+    monkeypatch.delitem(
+        sys.modules, "chatty_commander.gui.pyqt5_avatar", raising=False
+    )
+
+    module = importlib.import_module("chatty_commander.gui.pyqt5_avatar")
+
+    # Imports cleanly and reports PyQt5 as unavailable.
+    assert module.PYQT5_AVAILABLE is False
+    # The class object exists (definition succeeded) and its signal attribute
+    # was stubbed rather than blowing up.
+    assert module.TransparentBrowser is not None
+    # run_pyqt5_avatar degrades to a clean False rather than crashing.
+    assert module.run_pyqt5_avatar() is False
+
+
+def test_tray_popup_imports_without_optional_deps(monkeypatch):
+    """tray_popup imports with pystray/pywebview absent and reports failure."""
+    for name in ("pystray", "webview"):
+        monkeypatch.setitem(sys.modules, name, None)
+    monkeypatch.delitem(
+        sys.modules, "chatty_commander.gui.tray_popup", raising=False
+    )
+
+    module = importlib.import_module("chatty_commander.gui.tray_popup")
+
+    # pystray is treated as missing -> return code 2 (deps missing).
+    rc = module.run_tray_popup(SimpleNamespace(config_data={}), logger=_DummyLogger())
+    assert rc == 2
+
+
+def test_tray_icon_paths_are_package_relative():
+    """Icon candidate paths must be resolved relative to the package, not CWD."""
+    from chatty_commander.gui import tray_popup
+
+    paths = tray_popup._icon_candidate_paths()
+    assert paths, "expected at least one candidate icon path"
+    pkg_dir = Path(tray_popup.__file__).resolve().parent
+    for p in paths:
+        assert p.is_absolute()
+        # None of the candidates should be a bare CWD-relative "icon.png".
+        assert p != Path("icon.png")
+    # At least one candidate lives under the package tree.
+    assert any(str(pkg_dir.parent) in str(p) or str(pkg_dir) in str(p) for p in paths)
+
+
+def test_icon_image_resolves_relative_to_package(monkeypatch, tmp_path):
+    """_icon_image loads from a package-relative path regardless of CWD."""
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    from chatty_commander.gui import tray_popup
+
+    # Create a fake icon at a controlled candidate location.
+    fake_icon = tmp_path / "icon.png"
+    Image.new("RGBA", (4, 4)).save(fake_icon)
+    monkeypatch.setattr(
+        tray_popup, "_icon_candidate_paths", lambda: [fake_icon]
+    )
+
+    # Change CWD to somewhere without an icon.png to prove CWD is irrelevant.
+    monkeypatch.chdir(tmp_path / "..")
+
+    img = tray_popup._icon_image()
+    assert img is not None
+
+
+def test_on_quit_destroys_webview_before_join(monkeypatch):
+    """Quitting signals pywebview to close so the worker thread is not leaked.
+
+    The worker thread runs a blocking ``_open_window`` (emulating
+    ``webview.start()``). ``on_quit`` must destroy the webview window so the
+    worker returns and the subsequent ``join`` completes, leaving no live
+    daemon thread behind.
+    """
+    import threading
+
+    from chatty_commander.gui import tray_popup
+
+    destroyed = {"called": False}
+    stop_event = threading.Event()
+
+    class _FakeWindow:
+        def destroy(self):
+            destroyed["called"] = True
+            stop_event.set()
+
+    fake_webview = SimpleNamespace(
+        windows=[_FakeWindow()],
+        destroy_window=lambda: None,
+    )
+    monkeypatch.setattr(tray_popup, "webview", fake_webview)
+
+    worker_done = threading.Event()
+
+    # Replace _open_window with a blocking stub that returns only once the
+    # window is destroyed (mirrors webview.start() blocking semantics).
+    def _blocking_open(_settings, _logger):
+        try:
+            stop_event.wait(timeout=5.0)
+        finally:
+            worker_done.set()
+
+    monkeypatch.setattr(tray_popup, "_open_window", _blocking_open)
+
+    captured: dict[str, object] = {}
+
+    class _FakeMenuItem:
+        def __init__(self, text, callback=None, default=False):
+            self.text = text
+            self.callback = callback
+
+    class _FakeMenu:
+        def __init__(self, *items):
+            self.items = items
+
+    class _FakeIcon:
+        def __init__(self, *a, **k):
+            self.menu = k.get("menu")
+
+        def run(self):
+            for item in self.menu.items:
+                if item.text == "Open":
+                    captured["open"] = item.callback
+                if item.text == "Quit":
+                    captured["quit"] = item.callback
+
+        def stop(self):
+            pass
+
+    fake_pystray = SimpleNamespace(Icon=_FakeIcon)
+    monkeypatch.setattr(tray_popup, "pystray", fake_pystray)
+    # Menu / MenuItem only exist as module globals when pystray imported
+    # successfully; inject them for this test (raising=False handles absence).
+    monkeypatch.setattr(tray_popup, "Menu", _FakeMenu, raising=False)
+    monkeypatch.setattr(tray_popup, "MenuItem", _FakeMenuItem, raising=False)
+
+    rc = tray_popup.run_tray_popup(SimpleNamespace(config_data={}), _DummyLogger())
+    assert rc == 0
+
+    open_handler = captured["open"]
+    quit_handler = captured["quit"]
+
+    # Open a popup -> spawns the blocking worker thread.
+    open_handler(_FakeIcon(), None)
+
+    # Quit -> must destroy the window and join the worker cleanly.
+    quit_handler(_FakeIcon(), None)
+
+    assert destroyed["called"] is True
+    # The worker returned (was not abandoned): its finally-block fired.
+    assert worker_done.wait(timeout=2.0) is True
+
+
+class _DummyLogger:
+    def info(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+    def error(self, *a, **k):
+        pass

--- a/tests/test_obs_metrics.py
+++ b/tests/test_obs_metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from unittest.mock import MagicMock
 
@@ -13,6 +14,7 @@ from chatty_commander.obs.metrics import (
     HistogramBuckets,
     MetricsRegistry,
     Timer,
+    create_metrics_router,
 )
 
 # ─── Counter ────────────────────────────────────────────────────────────────
@@ -331,3 +333,179 @@ class TestMetricsEndpoints:
         text = response.text
         assert "http_requests_total" in text
         assert "http_request_duration_seconds" in text
+
+
+# ─── Concurrency / reader-writer race regression ─────────────────────────────
+
+
+class TestMetricsConcurrency:
+    def test_scrape_during_concurrent_observes_no_exception(self):
+        """A /metrics scrape that reads while many threads mutate the metrics
+        must never raise 'dictionary changed size during iteration'.
+
+        Readers (samples/snapshot/to_json) must snapshot the underlying dicts
+        under the lock; this stresses that guarantee.
+        """
+        registry = MetricsRegistry()
+        counter = registry.counter("race_counter", "race counter")
+        gauge = registry.gauge("race_gauge", "race gauge")
+        hist = registry.histogram("race_hist", "race hist")
+
+        stop = threading.Event()
+        errors: list[BaseException] = []
+
+        def writer(n: int) -> None:
+            i = 0
+            try:
+                while not stop.is_set():
+                    # Use distinct label values to keep growing the dicts,
+                    # which is what triggers "changed size during iteration".
+                    labels = {"worker": str(n), "iter": str(i)}
+                    counter.inc(1, labels=labels)
+                    gauge.set(float(i), labels=labels)
+                    hist.observe(0.001 * (i % 50), labels=labels)
+                    i += 1
+            except BaseException as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        def reader() -> None:
+            try:
+                while not stop.is_set():
+                    # Exercise every reader path that iterates the dicts.
+                    counter.samples()
+                    counter.get({"worker": "0", "iter": "0"})
+                    gauge.samples()
+                    gauge.get({"worker": "0", "iter": "0"})
+                    hist.snapshot()
+                    registry.to_json()
+            except BaseException as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(n,)) for n in range(6)]
+        threads += [threading.Thread(target=reader) for _ in range(4)]
+        for t in threads:
+            t.start()
+        time.sleep(0.5)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"concurrent access raised: {errors!r}"
+
+
+# ─── Prometheus cumulative-histogram correctness ─────────────────────────────
+
+
+def _parse_prom_buckets(text: str, name: str) -> list[tuple[str, float]]:
+    """Return [(le, value), ...] for the given histogram metric name."""
+    out: list[tuple[str, float]] = []
+    prefix = f"{name}_bucket{{"
+    for line in text.splitlines():
+        if not line.startswith(prefix):
+            continue
+        labelpart, _, value = line.rpartition(" ")
+        # Extract le="..." label
+        le_idx = labelpart.find('le="')
+        le = labelpart[le_idx + len('le="') : labelpart.find('"', le_idx + len('le="'))]
+        out.append((le, float(value)))
+    return out
+
+
+class TestPrometheusHistogramCumulative:
+    def test_prom_histogram_is_valid_cumulative_with_inf_equals_count(self):
+        registry = MetricsRegistry()
+        buckets = HistogramBuckets([0.1, 0.5, 1.0])
+        hist = registry.histogram("lat", "latency", buckets=buckets)
+
+        # Observations spread across and beyond the buckets.
+        for v in [0.05, 0.05, 0.3, 0.7, 0.7, 5.0]:  # total 6
+            hist.observe(v)
+
+        router = create_metrics_router(registry=registry)
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        text = client.get("/metrics/prom").text
+        bkts = _parse_prom_buckets(text, "lat")
+        assert bkts, "expected histogram buckets in prom output"
+
+        by_le = dict(bkts)
+        # le="0.1": v<=0.1 -> the two 0.05 obs = 2
+        assert by_le["0.1"] == 2
+        # le="0.5": <=0.5 -> two 0.05 + one 0.3 = 3
+        assert by_le["0.5"] == 3
+        # le="1.0": <=1.0 -> + two 0.7 = 5
+        assert by_le["1.0"] == 5
+        # +Inf must equal the total observation count (6).
+        assert by_le["+Inf"] == 6
+
+        # Cumulative invariant: non-decreasing in bucket order, +Inf is max.
+        finite_in_order = [by_le["0.1"], by_le["0.5"], by_le["1.0"]]
+        assert finite_in_order == sorted(finite_in_order)
+        assert by_le["+Inf"] >= finite_in_order[-1]
+
+        # _count line must also equal +Inf bucket.
+        count_line = [
+            line for line in text.splitlines() if line.startswith("lat_count")
+        ]
+        assert count_line
+        assert float(count_line[0].rpartition(" ")[2]) == 6
+
+
+# ─── Duration histogram gets a real route label ──────────────────────────────
+
+
+def test_duration_histogram_uses_real_route_label():
+    """The http_request_duration_seconds histogram must be labeled with the
+    resolved route path (e.g. '/ping'), not the placeholder 'unknown'.
+    """
+    from fastapi import FastAPI
+
+    from chatty_commander.obs.metrics import RequestMetricsMiddleware
+
+    registry = MetricsRegistry()
+    app = FastAPI()
+    app.add_middleware(RequestMetricsMiddleware, registry=registry)
+    app.include_router(create_metrics_router(registry=registry))
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/ping")
+
+    snap = registry.histogram("http_request_duration_seconds").snapshot()
+    routes = {s["labels"].get("route") for s in snap["series"]}
+    assert "/ping" in routes, f"expected real route label, got {routes!r}"
+    assert "unknown" not in routes, "duration histogram still labeled 'unknown'"
+
+
+def test_request_counter_increments_on_handler_exception():
+    """If a downstream handler raises, the request counter must still be
+    incremented (try/finally guarantee) so errors are not undercounted.
+    """
+    from fastapi import FastAPI
+
+    from chatty_commander.obs.metrics import RequestMetricsMiddleware
+
+    registry = MetricsRegistry()
+    app = FastAPI()
+    app.add_middleware(RequestMetricsMiddleware, registry=registry)
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("kaboom")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    try:
+        client.get("/boom")
+    except Exception:
+        pass
+
+    counter = registry.counter("http_requests_total")
+    total = sum(value for _labels, value in counter.samples())
+    assert total > 0, "request counter must increment even when handler raises"

--- a/tests/test_state_and_memory.py
+++ b/tests/test_state_and_memory.py
@@ -155,6 +155,45 @@ class TestThinkingStateManager:
         assert state is not None
         assert state.state == ThinkingState.ERROR
 
+    def test_set_state_concurrent_auto_register_registers_once(self) -> None:
+        """Racing set_agent_state on a brand-new id must register it exactly once.
+
+        The auto-register membership check and the register itself happen under
+        a single lock acquisition, so two threads hitting the same new id can't
+        both create an entry (which would clobber the other's state writes). We
+        run many threads against the same fresh id and assert the entry is
+        created once and survives intact.
+        """
+        import threading
+
+        mgr = get_thinking_manager()
+        agent_id = "race-agent"
+        ready = threading.Barrier(16)
+        errors: list[BaseException] = []
+
+        def worker() -> None:
+            try:
+                ready.wait()  # maximise overlap on the membership check
+                mgr.set_agent_state(agent_id, ThinkingState.THINKING)
+            except BaseException as exc:  # noqa: BLE001 - capture for assertion
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # Exactly one entry for the raced id, and it reflects a valid state
+        # (proving no thread's register wiped a concurrent state write).
+        all_states = mgr.get_all_states()
+        matching = [aid for aid in all_states if aid == agent_id]
+        assert matching == [agent_id]
+        state = mgr.get_agent_state(agent_id)
+        assert state is not None
+        assert state.state == ThinkingState.THINKING
+
     def test_get_all_states(self) -> None:
         """Test getting all agent states."""
         mgr = get_thinking_manager()

--- a/tests/test_system_preferences_allowlist.py
+++ b/tests/test_system_preferences_allowlist.py
@@ -1,0 +1,82 @@
+"""PUT /api/preferences + /api/restore (system.py) must honor the allow-list.
+
+The guard previously read ``if k in ALLOWED_PREF_KEYS or True:`` — the ``or
+True`` made it a no-op, so any config key (auth, web_server, ...) could be
+overwritten and persisted. These tests pin the real filtering behavior.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from chatty_commander.web.routes.system import ALLOWED_PREF_KEYS, include_system_routes
+
+
+class FakeConfigManager:
+    def __init__(self, config=None):
+        self.config = config if config is not None else {}
+        self.save_calls = 0
+
+    def save_config(self):
+        self.save_calls += 1
+
+
+def _client(cfg_mgr):
+    app = FastAPI()
+    app.include_router(
+        include_system_routes(
+            get_start_time=lambda: 0.0,
+            get_config_manager=lambda: cfg_mgr,
+        )
+    )
+    return TestClient(app)
+
+
+def test_put_preferences_persists_allowed_key():
+    cfg_mgr = FakeConfigManager()
+    client = _client(cfg_mgr)
+    resp = client.put("/api/preferences", json={"ui": {"theme": "light"}})
+    assert resp.status_code == 200
+    assert cfg_mgr.config["ui"] == {"theme": "light"}
+    assert "ui" in ALLOWED_PREF_KEYS
+
+
+def test_put_preferences_rejects_disallowed_key():
+    cfg_mgr = FakeConfigManager({"auth": {"api_key": "secret"}})
+    client = _client(cfg_mgr)
+    resp = client.put(
+        "/api/preferences",
+        json={"auth": {"api_key": "attacker"}, "web_server": {"host": "0.0.0.0"}},
+    )
+    assert resp.status_code == 200
+    # Disallowed keys were NOT written.
+    assert cfg_mgr.config["auth"] == {"api_key": "secret"}
+    assert "web_server" not in cfg_mgr.config
+    # And not echoed back as accepted preferences.
+    assert resp.json()["preferences"] == {}
+
+
+def test_put_preferences_mixed_keys_only_allowed_persisted():
+    cfg_mgr = FakeConfigManager()
+    client = _client(cfg_mgr)
+    resp = client.put(
+        "/api/preferences",
+        json={"ui": {"theme": "dark"}, "auth": {"api_key": "x"}},
+    )
+    assert resp.status_code == 200
+    assert cfg_mgr.config.get("ui") == {"theme": "dark"}
+    assert "auth" not in cfg_mgr.config
+
+
+def test_restore_rejects_disallowed_key():
+    cfg_mgr = FakeConfigManager({"auth": {"api_key": "secret"}})
+    client = _client(cfg_mgr)
+    resp = client.post(
+        "/api/restore",
+        json={"data": {"general": {"x": 1}, "auth": {"api_key": "attacker"}}},
+    )
+    assert resp.status_code == 200
+    assert cfg_mgr.config["general"] == {"x": 1}
+    # auth must remain untouched by a restore payload.
+    assert cfg_mgr.config["auth"] == {"api_key": "secret"}

--- a/tests/test_web_mode_rate_limit_default.py
+++ b/tests/test_web_mode_rate_limit_default.py
@@ -1,0 +1,54 @@
+"""The RateLimitMiddleware default must be sane and config-overridable.
+
+Previously it was wired with requests_per_minute=10000, which effectively
+disabled the limiter. It now defaults to 600/min and reads
+web_server.rate_limit_rpm from config when present.
+"""
+
+from __future__ import annotations
+
+from chatty_commander.app.command_executor import CommandExecutor
+from chatty_commander.app.config import Config
+from chatty_commander.app.model_manager import ModelManager
+from chatty_commander.app.state_manager import StateManager
+from chatty_commander.web.web_mode import RateLimitMiddleware, WebModeServer
+
+
+def _build_server(rate_limit_rpm=None) -> WebModeServer:
+    config = Config()
+    if rate_limit_rpm is not None:
+        config.web_server["rate_limit_rpm"] = rate_limit_rpm
+    state_manager = StateManager(config)
+    model_manager = ModelManager(config)
+    command_executor = CommandExecutor(config, model_manager, state_manager)
+    return WebModeServer(
+        config, state_manager, model_manager, command_executor, no_auth=True
+    )
+
+
+def _rate_limit_rpm(app) -> int:
+    mw = next(m for m in app.user_middleware if m.cls is RateLimitMiddleware)
+    return mw.kwargs["requests_per_minute"]
+
+
+def test_default_rate_limit_is_sane():
+    server = _build_server()
+    rpm = _rate_limit_rpm(server.app)
+    assert rpm == 600
+    # Sanity: nowhere near the old effectively-off value.
+    assert rpm < 10000
+
+
+def test_rate_limit_is_configurable():
+    server = _build_server(rate_limit_rpm=120)
+    assert _rate_limit_rpm(server.app) == 120
+
+
+def test_invalid_rate_limit_falls_back_to_default():
+    server = _build_server(rate_limit_rpm="not-a-number")
+    assert _rate_limit_rpm(server.app) == 600
+
+
+def test_nonpositive_rate_limit_falls_back_to_default():
+    server = _build_server(rate_limit_rpm=0)
+    assert _rate_limit_rpm(server.app) == 600

--- a/webui/frontend/playwright.config.ts
+++ b/webui/frontend/playwright.config.ts
@@ -46,7 +46,10 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: "cd ../.. && PYTHONPATH=src uv run python -m chatty_commander.cli.main --web --test-mode --port 8100 --no-auth",
+    // CHATTY_DISABLE_RATE_LIMIT: parallel Playwright workers share one source
+    // IP and would otherwise trip the 600/min limiter; the harness must not be
+    // throttled (prod default stays intact).
+    command: "cd ../.. && CHATTY_DISABLE_RATE_LIMIT=1 PYTHONPATH=src uv run python -m chatty_commander.cli.main --web --test-mode --port 8100 --no-auth",
     url: "http://localhost:8100/health",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,


### PR DESCRIPTION
Fixes all 13 round-6 items from the middleware/metrics/avatars/GUI audit.

**Security:** `/avatar/launch` (unauthenticated subprocess spawn) now requires auth + is idempotent; `/api/preferences`+`/api/restore` dead `or True` allow-list fixed (no more overwriting `auth`/`web_server`); rate-limit default 10000→600/min (configurable + `CHATTY_DISABLE_RATE_LIMIT` opt-out for the test harness); CORS no longer wildcards in no-auth.

**Metrics:** reader/writer lock snapshots (no 500 on concurrent scrape); valid cumulative Prometheus histogram (`+Inf == count`); real route label; try/finally so errors are counted.

**Avatar/GUI:** avatar_ws connection-list lock + lazy audio queue; thinking_state `run_coroutine_threadsafe` + atomic register; GUI degrades (no PyQt5-absent import NameError) + clean webview teardown.

Gates: ruff + mypy clean · pytest **2219 / 0 fail** · full e2e **138 / 0 fail / 3 skip** (rate-limit opt-out keeps the parallel harness from being throttled while prod stays at 600/min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)