### PR TITLE
release: v0.6.0 — security hardening + packaging

### DIFF
--- a/docs/developer/CHANGELOG.md
+++ b/docs/developer/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## \[0.6.0\] - 2026-06-20 — security hardening + packaging
+
+Rounds 6–7 of the deep audit (PRs #731, #733–#735) plus packaging fixes. Focus:
+close the auth/validation holes that earlier rounds fixed only partially, and
+make the build/version story honest.
+
+### Security
+
+- **Avatar config write now gated** — `PUT /avatar/config` required no auth (same
+  bypass as the previously-fixed `/avatar/launch`, registered outside `/api/`);
+  it is now behind `require_role("user")`.
+- **Preferences allow-list enforced on the real handler** — an `extra="allow"`
+  `PUT /api/preferences` handler in `preferences.py` shadowed the `system.py`
+  allow-list and won dispatch, leaving arbitrary config-write open; the
+  `ALLOWED_PREF_KEYS` filter now runs on the winning handler.
+- **WebSocket endpoints authenticated** — `/ws`, `/avatar/ws`, and the
+  state-changing `/ws/voice-test` bypassed `AuthMiddleware` entirely. They now
+  run `authorize_websocket` before `accept()`: open in no-auth/dev mode, and
+  requiring a valid JWT via `?token=` (matching the frontend) when auth is
+  active, closing with policy-violation `1008` otherwise.
+- **dograh phone validation centralized** — the E.164 guard lived only in the
+  LLM tool; it now lives in `DograhClient.initiate_call` (new
+  `DograhValidationError`, plus `workflow_id` int validation) so the
+  config/wake-word path is covered too.
+- **No billable health check** — `advisors/providers.health_check` no longer
+  issues a real `generate("Test")`; it's a cheap local readiness check.
+
+### Packaging / build
+
+- **Explicit build backend** — added a `[build-system]` (hatchling) block with
+  the wheel target pinned to the src-layout, so `uv build` / `python -m build`
+  produce a wheel + sdist instead of silently falling back to setuptools.
+- **Version drift reconciled to a single source of truth** — `pyproject`
+  (`0.2.0`→`0.6.0`) and `package.json` (`1.0.0`→`0.6.0`) realigned, and every
+  runtime version reporter (`core.py`, `web_mode.py`, `version.py`,
+  `api_docs.builder`) now reads `chatty_commander.__version__` (package
+  metadata) instead of a hardcoded literal.
+
+### Test infrastructure / CI
+
+- **`pytest.ini` consolidated** into `pyproject.toml` (it had been overriding the
+  documented `-q --no-cov` gate and dropping strict flags).
+- **Order-dependence eliminated** — moved leaking module-level `sys.modules`
+  stubs to autouse fixtures, de-flaked sleep-based WebSocket tests, and added
+  `pytest-randomly`; the random ordering immediately surfaced (and we fixed) an
+  isinstance-across-`importlib.reload` coupling in the advisor-provider tests.
+- **CI fixes** — `screenshots.yml` no longer double-binds `:8100`; perf-smoke /
+  screenshots disable the rate limiter; `@playwright/test` floor bumped to
+  `^1.58.0`.
+
+### Known deferrals
+
+- Auth middleware remains a prefix-allowlist for the legacy `X-API-Key`; the
+  exploitable exposure is closed (every mutating non-`/api/` route is now
+  individually gated, and `/bridge/event` keeps its own `X-Bridge-Token`), so a
+  blanket default-deny rewrite is deferred as net-negative.
+- Two frontend lockfiles (`package-lock.json` + `pnpm-lock.yaml`) remain;
+  consolidating needs a CI-workflow audit + green run.
+
 ## \[Unreleased\] - 2026-06-02
 
 Hardening, bug-fix, and feature-completion rounds (PRs #572–#588), grouped by area.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/chatty_commander"]
 
 [project]
 name = "chatty-commander"
-version = "0.5.0"
+version = "0.6.0"
 description = "Advanced AI-powered voice command system with web interface and real-time communication"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "chatty-commander"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/webui/frontend/package-lock.json
+++ b/webui/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatty-commander-webui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatty-commander-webui",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.8",
         "@tanstack/react-query": "^5.101.0",

--- a/webui/frontend/package.json
+++ b/webui/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatty-commander-webui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Web-based interface for ChattyCommander voice control system",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Cuts **v0.6.0**. Version bump (0.5.0→0.6.0) across `pyproject` / `package.json` / lockfiles + CHANGELOG entry.

Milestone since `v0.5.0` (round-5):
- **Round 6 (#731):** avatar auth, preferences allow-list, rate limit, metrics correctness, thread-safety
- **Round 7 (#733):** closed the *incomplete* round-6 fixes (avatar config-write twin, shadowed preferences handler), **WebSocket authentication** (new), centralized dograh E.164 validation, no-billable health check, test-infra + CI fixes
- **Packaging (#734):** `[build-system]` backend + version single-source-of-truth
- **Test-infra (#735):** `pytest-randomly` + the order-dependence it surfaced

Minor (not patch) bump because WebSocket auth is a new capability.

Verified green this session: ruff · mypy · pytest (2240, multi-seed) · frontend type-check/vitest/build · e2e 138 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)