### PR TITLE
Round-8: remove shadowed duplicate routes, fix 500 leaks, reconcile doc version (#737)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -523,6 +523,31 @@ Fix those first.
 
 ---
 
+## Backlog — round 8 (from 2026-06-20 audit: API-surface hygiene + docs accuracy)
+
+Two read-only critique passes (route-registration hygiene + docs-vs-code). The
+duplicate-route findings were real dead code that produced duplicate OpenAPI
+operation IDs and were the structural cause of the round-7 "shadowed handler"
+bug class.
+
+### Fixed (#737)
+
+- [x] **Duplicate `/api/preferences` GET+PUT** — `system.py` re-registered handlers already owned by `preferences.py` (which wins dispatch); removed the dead `system.py` copies (kept `ALLOWED_PREF_KEYS`, still used by `/api/restore`) ([`web/routes/system.py`](src/chatty_commander/web/routes/system.py))
+- [x] **Duplicate `/api/themes` + `/api/theme`** — `system.py` copies (which skipped the `AVAILABLE_THEMES` validation in `themes.py`) were dead and removed ([`web/routes/system.py`](src/chatty_commander/web/routes/system.py))
+- [x] **Duplicate `/api/audio/devices` + `/api/audio/device`** — `audio.py` "legacy" wrappers re-registered paths the stacked decorators already cover; removed ([`web/routes/audio.py`](src/chatty_commander/web/routes/audio.py))
+- [x] **4 duplicate OpenAPI operation-ID warnings** eliminated as a result (verified 0 in the full test run)
+- [x] **`str(e)` leaked in 500 responses** — `avatar_api.py` (`/avatar/animations`) and `avatar_settings.py` (`GET`/`PUT /avatar/config`) returned the raw exception (could carry filesystem paths) to clients; now log server-side + return a generic message ([`web/routes/avatar_api.py`](src/chatty_commander/web/routes/avatar_api.py), [`web/routes/avatar_settings.py`](src/chatty_commander/web/routes/avatar_settings.py))
+- [x] **Docs API version drift** — `docs/API.md`, `docs/openapi.json`, `docs/developer/openapi.json` hardcoded `0.2.0`; updated to `0.6.0` to match the now-dynamic runtime version ([`docs/API.md`](docs/API.md))
+
+### Still open
+
+- [ ] **`POST /avatar/animation/choose` is an unauthenticated POST** — it's a stateless classifier (no persistence), so low risk, but for consistency with the other `/avatar/*` mutating routes it should carry `Depends(require_role("user"))` (verify the avatar UI sends a token before gating) ([`web/routes/avatar_selector.py`](src/chatty_commander/web/routes/avatar_selector.py))
+- [ ] **`/bridge/event` registered in two factories** — `server.py:create_app` and `web_mode.py` define it separately with slightly divergent response bodies and auth handling; consolidate into one shared registration ([`web/server.py`](src/chatty_commander/web/server.py), [`web/web_mode.py`](src/chatty_commander/web/web_mode.py))
+- [ ] **`docs/API.md` config-schema example is inaccurate** — shows `default_state` as a top-level key (it lives under `general_settings`) and claims optional `advisors`/`voice`/`ui` blocks that the loaded config dict doesn't contain; fix the example to match `Config().config` ([`docs/API.md`](docs/API.md))
+- [ ] **Undocumented endpoints in `docs/API.md`** — `GET /api/v1/health` and `GET /api/v1/version` (with `git_sha`) exist and are in the OpenAPI spec but absent from the markdown ([`docs/API.md`](docs/API.md))
+
+---
+
 ## Done (recent)
 
 2026-06-11 (continued):

--- a/docs/API.md
+++ b/docs/API.md
@@ -111,7 +111,7 @@ Returns the current system status including active state and loaded models.
   "current_state": "idle",
   "active_models": ["hey_chat_tee", "hey_khum_puter"],
   "uptime": "2h 15m 30s",
-  "version": "0.2.0"
+  "version": "0.6.0"
 }
 ```
 

--- a/docs/developer/openapi.json
+++ b/docs/developer/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "ChattyCommander API",
     "description": "Voice command automation system with web interface",
-    "version": "0.2.0",
+    "version": "0.6.0",
     "contact": {
       "name": "ChattyCommander",
       "url": "https://github.com/your-repo/chatty-commander"
@@ -38,7 +38,7 @@
                   "current_state": "idle",
                   "active_models": ["hey_chat_tee", "hey_khum_puter"],
                   "uptime": "2h 15m 30s",
-                  "version": "0.2.0"
+                  "version": "0.6.0"
                 }
               }
             }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "ChattyCommander API",
     "description": "Voice command automation system with web interface",
-    "version": "0.2.0",
+    "version": "0.6.0",
     "contact": {
       "name": "ChattyCommander",
       "url": "https://github.com/your-repo/chatty-commander"
@@ -43,7 +43,7 @@
                     "hey_khum_puter"
                   ],
                   "uptime": "2h 15m 30s",
-                  "version": "0.2.0"
+                  "version": "0.6.0"
                 }
               }
             }

--- a/src/chatty_commander/web/routes/audio.py
+++ b/src/chatty_commander/web/routes/audio.py
@@ -123,13 +123,9 @@ def include_audio_routes(
 
         return {"success": True, "device": device_id, "persisted": persisted}
 
-    # Legacy paths (no /v1) for compatibility with apiService.js and listed gaps
-    @router.get("/api/audio/devices", response_model=AudioDevices)
-    async def get_audio_devices_legacy():
-        return await get_audio_devices()
-
-    @router.post("/api/audio/device")
-    async def set_audio_device_legacy(request: AudioDeviceRequest):
-        return await set_audio_device(request)
+    # NOTE: the unversioned /api/audio/devices + /api/audio/device paths are
+    # already registered above via the stacked decorators on get_audio_devices /
+    # set_audio_device, so no separate "legacy" wrappers are needed — they only
+    # produced shadowed duplicate registrations.
 
     return router

--- a/src/chatty_commander/web/routes/avatar_api.py
+++ b/src/chatty_commander/web/routes/avatar_api.py
@@ -148,7 +148,12 @@ async def list_animations(
     except HTTPException:
         raise
     except Exception as e:  # pragma: no cover - unexpected
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        # Don't leak the raw exception (may carry filesystem paths/internals) to
+        # the client; log it server-side and return a generic message.
+        logger.exception("Failed to list avatar animations")
+        raise HTTPException(
+            status_code=500, detail="Failed to list animations"
+        ) from e
 
 
 @router.post("/avatar/launch")

--- a/src/chatty_commander/web/routes/avatar_settings.py
+++ b/src/chatty_commander/web/routes/avatar_settings.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -29,6 +30,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
 from chatty_commander.web.deps.auth import require_role
+
+logger = logging.getLogger(__name__)
 
 
 class AvatarConfigModel(BaseModel):
@@ -98,7 +101,10 @@ def include_avatar_settings_routes(
             avatar = _get_avatar_cfg(cfg_mgr)
             return AvatarConfigModel(**avatar)
         except Exception as e:  # noqa: BLE001
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            logger.exception("Failed to read avatar config")
+            raise HTTPException(
+                status_code=500, detail="Failed to read avatar config"
+            ) from e
 
     @router.put("/avatar/config", response_model=AvatarConfigModel)
     async def update_avatar_config(
@@ -125,7 +131,12 @@ def include_avatar_settings_routes(
                 except TypeError:
                     save(getattr(cfg_mgr, "config", {}))  # type: ignore[misc]
             return AvatarConfigModel(**avatar)
+        except HTTPException:
+            raise
         except Exception as e:  # noqa: BLE001
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            logger.exception("Failed to update avatar config")
+            raise HTTPException(
+                status_code=500, detail="Failed to update avatar config"
+            ) from e
 
     return router

--- a/src/chatty_commander/web/routes/system.py
+++ b/src/chatty_commander/web/routes/system.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Body
+from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
@@ -86,26 +86,6 @@ class SystemInfo(BaseModel):
         default_factory=list,
         description="Recognised environment variables and whether they are set",
     )
-
-
-class ThemeInfo(BaseModel):
-    """Response for available UI themes and currently active one."""
-
-    themes: list[str] = Field(..., description="List of supported theme identifiers")
-    current: str | None = Field(None, description="Currently selected theme (from persisted config if available)")
-
-
-class ThemeSetRequest(BaseModel):
-    """Request payload for setting active theme (permissive for frontend variations)."""
-
-    theme: str | None = Field(None, description="Theme name to activate")
-    name: str | None = Field(None, description="Alternative key for theme name")
-
-
-class PreferencesResponse(BaseModel):
-    """Response wrapper for user preferences."""
-
-    preferences: dict[str, Any] = Field(default_factory=dict, description="Active preferences (ui, audio, voice, etc)")
 
 
 class ActionResponse(BaseModel):
@@ -191,78 +171,13 @@ def include_system_routes(
 
         return info
 
-    # --- Themes (legacy /api/ for apiService.js + frontend) ---
-    @router.get("/api/themes", response_model=ThemeInfo)
-    async def get_themes():
-        # Supported themes match ConfigurationPage and ThemeProvider usage + Audio/UX needs.
-        # NOTE: This and sibling endpoints live under /api/* so AuthMiddleware applies
-        # (rejects unauthed unless no_auth=True in WebModeServer/create_app).
-        themes_list: list[str] = ["dark", "light", "cyberpunk", "synthwave", "dracula", "night"]
-        current: str | None = None
-        if get_config_manager:
-            try:
-                cfg_mgr = get_config_manager()
-                cfg = getattr(cfg_mgr, "config", {}) or {}
-                ui = cfg.get("ui", {}) if isinstance(cfg.get("ui"), dict) else {}
-                current = ui.get("theme")
-                if current and current not in themes_list:
-                    themes_list = list(themes_list) + [current]
-            except Exception as e:
-                logger.warning(f"Could not read current theme from config: {e}")
-        return {"themes": themes_list, "current": current}
-
-    @router.post("/api/theme", response_model=ActionResponse)
-    async def set_theme(payload: dict[str, Any] = Body(default={})):
-        theme_name = payload.get("theme") or payload.get("name") or "dark"
-        logger.info(f"Setting theme to: {theme_name}")
-        if get_config_manager:
-            try:
-                cfg_mgr = get_config_manager()
-                if hasattr(cfg_mgr, "config"):
-                    if "ui" not in cfg_mgr.config or not isinstance(cfg_mgr.config.get("ui"), dict):
-                        cfg_mgr.config["ui"] = {}
-                    cfg_mgr.config["ui"]["theme"] = theme_name
-                    if hasattr(cfg_mgr, "save_config"):
-                        cfg_mgr.save_config()
-            except Exception as e:
-                logger.warning(f"Could not persist theme to config: {e}")
-        return {"success": True, "message": f"Theme set to {theme_name}", "theme": theme_name}
-
-    # --- Preferences (legacy /api/ ) ---
-    @router.get("/api/preferences", response_model=PreferencesResponse)
-    async def get_preferences():
-        # NOTE: Protected by global AuthMiddleware when no_auth=False (see web_mode.py + middleware/auth.py).
-        # Works with --no-auth as middleware short-circuits.
-        prefs: dict[str, Any] = {}
-        if get_config_manager:
-            try:
-                cfg_mgr = get_config_manager()
-                cfg = getattr(cfg_mgr, "config", {}) or {}
-                # Expose ui + some top level as "preferences"
-                prefs = {k: v for k, v in cfg.items() if k in ("ui", "general", "audio_settings", "voice")}
-                prefs.setdefault("ui", cfg.get("ui", {"theme": "dark"}))
-            except Exception:
-                pass
-        return {"preferences": prefs}
-
-    @router.put("/api/preferences", response_model=ActionResponse)
-    async def update_preferences(payload: dict[str, Any] = Body(default={})):
-        if get_config_manager:
-            try:
-                cfg_mgr = get_config_manager()
-                if hasattr(cfg_mgr, "config"):
-                    # SECURITY: only persist keys on the allow-list. Without
-                    # this filter any config key (auth, web_server, ...) could
-                    # be overwritten via the preferences endpoint.
-                    for k, v in payload.items():
-                        if k in ALLOWED_PREF_KEYS:
-                            cfg_mgr.config[k] = v
-                    if hasattr(cfg_mgr, "save_config"):
-                        cfg_mgr.save_config()
-            except Exception as e:
-                logger.warning(f"Failed to update preferences: {e}")
-        accepted = {k: v for k, v in payload.items() if k in ALLOWED_PREF_KEYS}
-        return {"success": True, "message": "Preferences updated", "preferences": accepted}
+    # NOTE: GET/POST /api/themes + /api/theme and GET/PUT /api/preferences are
+    # NOT registered here — they are owned by web/routes/themes.py and
+    # web/routes/preferences.py, which register first in register_shared_routers
+    # (so they win FastAPI dispatch) and carry the real validation/allow-list.
+    # Duplicating them here only produced shadowed dead code + duplicate
+    # OpenAPI operation IDs (and was the root of the round-7 "shadowed
+    # allow-list" bug). ALLOWED_PREF_KEYS below is still used by /api/restore.
 
     # --- Backup / Restore (stubs, functional enough for UI; persist config snapshot) ---
     @router.post("/api/backup", response_model=ActionResponse)

--- a/tests/test_core_routes.py
+++ b/tests/test_core_routes.py
@@ -153,7 +153,9 @@ def test_webui_missing_endpoints_now_implemented():
 
     from chatty_commander.web.routes.audio import include_audio_routes
     from chatty_commander.web.routes.models import router as models_router
+    from chatty_commander.web.routes.preferences import include_preferences_routes
     from chatty_commander.web.routes.system import include_system_routes
+    from chatty_commander.web.routes.themes import include_theme_routes
 
     cfg = MagicMock()
     cfg.config = {"ui": {"theme": "dark"}}
@@ -162,6 +164,11 @@ def test_webui_missing_endpoints_now_implemented():
     app = FastAPI()
     app.include_router(include_audio_routes(get_config_manager=lambda: cfg))
     app.include_router(models_router)
+    # /api/themes + /api/theme and /api/preferences are owned by the themes /
+    # preferences routers (system.py's duplicates were removed); mount them the
+    # same way register_shared_routers does.
+    app.include_router(include_theme_routes(get_config_manager=lambda: cfg))
+    app.include_router(include_preferences_routes(get_config_manager=lambda: cfg))
     app.include_router(include_system_routes(get_start_time=lambda: 0.0, get_config_manager=lambda: cfg))
     client = TestClient(app)
 

--- a/tests/test_system_preferences_allowlist.py
+++ b/tests/test_system_preferences_allowlist.py
@@ -1,8 +1,12 @@
-"""PUT /api/preferences + /api/restore (system.py) must honor the allow-list.
+"""POST /api/restore (system.py) must honor the ALLOWED_PREF_KEYS allow-list.
 
-The guard previously read ``if k in ALLOWED_PREF_KEYS or True:`` — the ``or
-True`` made it a no-op, so any config key (auth, web_server, ...) could be
-overwritten and persisted. These tests pin the real filtering behavior.
+A restore payload must not be able to overwrite arbitrary config keys (auth,
+web_server, ...) — only allow-listed preference keys are applied.
+
+Note: GET/PUT /api/preferences are owned by web/routes/preferences.py (which
+registers first and wins dispatch); their allow-list is pinned in
+``tests/test_preferences_routes.py``. system.py no longer registers those
+duplicate handlers, so the only allow-list surface left here is /api/restore.
 """
 
 from __future__ import annotations
@@ -33,40 +37,13 @@ def _client(cfg_mgr):
     return TestClient(app)
 
 
-def test_put_preferences_persists_allowed_key():
+def test_restore_persists_allowed_key():
     cfg_mgr = FakeConfigManager()
     client = _client(cfg_mgr)
-    resp = client.put("/api/preferences", json={"ui": {"theme": "light"}})
+    resp = client.post("/api/restore", json={"data": {"ui": {"theme": "light"}}})
     assert resp.status_code == 200
     assert cfg_mgr.config["ui"] == {"theme": "light"}
     assert "ui" in ALLOWED_PREF_KEYS
-
-
-def test_put_preferences_rejects_disallowed_key():
-    cfg_mgr = FakeConfigManager({"auth": {"api_key": "secret"}})
-    client = _client(cfg_mgr)
-    resp = client.put(
-        "/api/preferences",
-        json={"auth": {"api_key": "attacker"}, "web_server": {"host": "0.0.0.0"}},
-    )
-    assert resp.status_code == 200
-    # Disallowed keys were NOT written.
-    assert cfg_mgr.config["auth"] == {"api_key": "secret"}
-    assert "web_server" not in cfg_mgr.config
-    # And not echoed back as accepted preferences.
-    assert resp.json()["preferences"] == {}
-
-
-def test_put_preferences_mixed_keys_only_allowed_persisted():
-    cfg_mgr = FakeConfigManager()
-    client = _client(cfg_mgr)
-    resp = client.put(
-        "/api/preferences",
-        json={"ui": {"theme": "dark"}, "auth": {"api_key": "x"}},
-    )
-    assert resp.status_code == 200
-    assert cfg_mgr.config.get("ui") == {"theme": "dark"}
-    assert "auth" not in cfg_mgr.config
 
 
 def test_restore_rejects_disallowed_key():


### PR DESCRIPTION
## Summary
Round-8 audit — two read-only critique passes (API-surface hygiene + docs-vs-code).

### Removed shadowed duplicate routes (dead code)
`register_shared_routers` includes the canonical owner first, so these `system.py`/`audio.py` copies were unreachable and only produced **4 duplicate OpenAPI operation-ID warnings** — and were the structural cause of the round-7 "shadowed handler" bug class:
- `GET/PUT /api/preferences` — owned by `preferences.py` (has the `ALLOWED_PREF_KEYS` filter)
- `GET /api/themes` + `POST /api/theme` — owned by `themes.py` (validates against `AVAILABLE_THEMES`; the `system.py` copy skipped that)
- `GET /api/audio/devices` + `POST /api/audio/device` — `audio.py` "legacy" wrappers the stacked decorators already cover

Kept `ALLOWED_PREF_KEYS` (still used by `/api/restore`), backup/restore/system-control. Removed orphaned models + unused `Body` import. Verified **0 duplicate operation-ID warnings** in the full run.

### Hardened 500 error leaks
`/avatar/animations` and `GET/PUT /avatar/config` returned raw `str(e)` (could carry filesystem paths) to clients → now log server-side + return a generic message.

### Docs version reconcile
`docs/API.md` + both `openapi.json` snapshots hardcoded `0.2.0` → updated to `0.6.0` to match the now-dynamic runtime version.

### Still open (logged in ROADMAP round 8)
`/avatar/animation/choose` unauthenticated POST · `/bridge/event` dual registration · `docs/API.md` config-schema accuracy · two undocumented endpoints.

## Verification
- `ruff` ✅ · `mypy` ✅ · `pytest --no-cov` → **2238 passed, 0 failed, 2 skipped** (random order) ✅
- 0 duplicate OpenAPI operation-ID warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)