### PR TITLE
docs(api): fix config-schema description + document health/version endpoints (#738)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -543,8 +543,8 @@ bug class.
 
 - [ ] **`POST /avatar/animation/choose` is an unauthenticated POST** — it's a stateless classifier (no persistence), so low risk, but for consistency with the other `/avatar/*` mutating routes it should carry `Depends(require_role("user"))` (verify the avatar UI sends a token before gating) ([`web/routes/avatar_selector.py`](src/chatty_commander/web/routes/avatar_selector.py))
 - [ ] **`/bridge/event` registered in two factories** — `server.py:create_app` and `web_mode.py` define it separately with slightly divergent response bodies and auth handling; consolidate into one shared registration ([`web/server.py`](src/chatty_commander/web/server.py), [`web/web_mode.py`](src/chatty_commander/web/web_mode.py))
-- [ ] **`docs/API.md` config-schema example is inaccurate** — shows `default_state` as a top-level key (it lives under `general_settings`) and claims optional `advisors`/`voice`/`ui` blocks that the loaded config dict doesn't contain; fix the example to match `Config().config` ([`docs/API.md`](docs/API.md))
-- [ ] **Undocumented endpoints in `docs/API.md`** — `GET /api/v1/health` and `GET /api/v1/version` (with `git_sha`) exist and are in the OpenAPI spec but absent from the markdown ([`docs/API.md`](docs/API.md))
+- [x] **`docs/API.md` config-schema example is inaccurate** — showed `default_state` as a top-level key (it lives under `general_settings`) and claimed `advisors`/`voice`/`ui` blocks the loaded config dict doesn't contain ✅ (#738 — corrected the top-level key list against `Config().config` and noted `default_state` nests under `general_settings`) ([`docs/API.md`](docs/API.md))
+- [x] **Undocumented endpoints in `docs/API.md`** — `GET /api/v1/health` and `GET /api/v1/version` (with `git_sha`) existed in the OpenAPI spec but not the markdown ✅ (#738 — both now documented with response examples matching `HealthStatus`/`VersionInfo`) ([`docs/API.md`](docs/API.md))
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -115,14 +115,49 @@ Returns the current system status including active state and loaded models.
 }
 ```
 
+#### GET /api/v1/health
+
+Lightweight liveness/health probe. Always returns `200` with an honest body
+(degrades gracefully when `psutil`/DB are unavailable).
+
+**Response Example:**
+```json
+{
+  "status": "healthy",
+  "uptime": "2h 15m 30s",
+  "version": "0.6.0",
+  "database": "ok",
+  "memory_usage": 41.2,
+  "cpu_usage": 3.0,
+  "last_health_check": "2026-06-20T15:00:00"
+}
+```
+
+#### GET /api/v1/version
+
+Returns the application version (sourced from package metadata) plus the short
+git SHA when available (`null` if git isn't present).
+
+**Response Example:**
+```json
+{
+  "version": "0.6.0",
+  "git_sha": "a8ddda36"
+}
+```
+
 ### Configuration Management
 
 #### GET /api/v1/config
 
 Retrieves the current system configuration. The shape mirrors `config.json`
-(loaded by `src/chatty_commander/app/config.py`). Top-level keys include
-`model_paths`, `commands`, `state_models`, `default_state`, `general`,
-`web_server`, and the optional `advisors`/`voice`/`ui` blocks.
+(loaded by `src/chatty_commander/app/config.py`). Top-level keys are
+`model_paths`, `commands`, `state_models`, `state_transitions`, `keybindings`,
+`command_sequences`, `api_endpoints`, `audio_settings`, `general_settings`,
+`general`, `logging`, `web_server`, `voice_only`, and `wakeword_state_map`.
+Note `default_state` lives **inside** `general_settings` (alongside
+`debug_mode`, `inference_framework`, `start_on_boot`, `check_for_updates`),
+not at the top level.
 
 **Response Example:**
 ```json


### PR DESCRIPTION
Round-8 doc-accuracy items (no risky decision needed):

- **GET /api/v1/config** — top-level key list was wrong: `default_state` was shown at the top level (it nests under `general_settings`) and `advisors`/`voice`/`ui` blocks were claimed but don't exist in the loaded config. Corrected against `Config().config`.
- **Documented GET /api/v1/health and GET /api/v1/version** (with `git_sha`) — both existed and were in the OpenAPI spec but missing from the markdown; examples match the `HealthStatus`/`VersionInfo` models.

Markdown-only; no code/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)