### PR TITLE
💎 Hone: UX Engineering Refactor [Dialog Accessibility & Focus Restoration]

### DIFF
--- a/.Jules/hone.md
+++ b/.Jules/hone.md
@@ -1,0 +1,1 @@
+## 2024-10-25 | [Architectural Audit] | Insight: Native HTML5 dialogs do not auto-restore focus to triggers, and DaisyUI modal backdrops hide close buttons from screen readers. | Protocol: Manually store and restore trigger element focus via useRef when managing native dialog states, and explicitly add aria-labels to visually hidden backdrop close buttons.

--- a/webui/frontend/src/pages/CommandsPage.tsx
+++ b/webui/frontend/src/pages/CommandsPage.tsx
@@ -174,6 +174,7 @@ export default function CommandsPage() {
   const deleteDialogRef = useRef<HTMLDialogElement>(null);
   const importDialogRef = useRef<HTMLDialogElement>(null);
   const bulkDeleteDialogRef = useRef<HTMLDialogElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { data: commands, isLoading, isFetching, isError, error, refetch } = useQuery<Record<string, CommandConfig>>({
@@ -255,6 +256,7 @@ export default function CommandsPage() {
 
   const handleDeleteClick = (commandName: string) => {
     setPendingDeleteCommand(commandName);
+    triggerRef.current = document.activeElement as HTMLElement | null;
     deleteDialogRef.current?.showModal();
   };
 
@@ -277,6 +279,7 @@ export default function CommandsPage() {
       });
       deleteDialogRef.current?.close();
       setPendingDeleteCommand(null);
+      triggerRef.current?.focus();
     } catch (err) {
       // Surface the failure via a toast (consistent with the rest of the app)
       // and keep the dialog open so the user can retry or cancel.
@@ -289,6 +292,7 @@ export default function CommandsPage() {
   const handleDeleteCancel = () => {
     deleteDialogRef.current?.close();
     setPendingDeleteCommand(null);
+    triggerRef.current?.focus();
   };
 
   // Memoize the derived array to prevent expensive Object.entries() and array reallocation
@@ -359,6 +363,7 @@ export default function CommandsPage() {
           (n) => n in current && JSON.stringify(current[n]) !== JSON.stringify(next[n]),
         );
         setPendingImport({ parsed: next, added, removed, changed });
+        triggerRef.current = document.activeElement as HTMLElement | null;
         importDialogRef.current?.showModal();
       } catch (err) {
         addToast(`Import failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
@@ -377,6 +382,7 @@ export default function CommandsPage() {
       refetch();
       importDialogRef.current?.close();
       setPendingImport(null);
+      triggerRef.current?.focus();
       addToast('Commands imported successfully.', 'success');
     } catch (err) {
       addToast(`Import failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
@@ -388,6 +394,7 @@ export default function CommandsPage() {
   const handleImportCancel = () => {
     importDialogRef.current?.close();
     setPendingImport(null);
+    triggerRef.current?.focus();
   };
 
   // Clear the selection whenever the (debounced) search filter changes, so the
@@ -484,11 +491,13 @@ export default function CommandsPage() {
 
   const handleBulkDeleteClick = () => {
     if (selected.size === 0) return;
+    triggerRef.current = document.activeElement as HTMLElement | null;
     bulkDeleteDialogRef.current?.showModal();
   };
 
   const handleBulkDeleteCancel = () => {
     bulkDeleteDialogRef.current?.close();
+    triggerRef.current?.focus();
   };
 
   const handleBulkDeleteConfirm = async () => {
@@ -519,6 +528,7 @@ export default function CommandsPage() {
 
       if (failedCount === 0) {
         bulkDeleteDialogRef.current?.close();
+        triggerRef.current?.focus();
         addToast(
           `Deleted ${succeeded.length} command${succeeded.length === 1 ? '' : 's'}.`,
           'success',
@@ -1004,7 +1014,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleDeleteCancel}>close</button>
+          <button onClick={handleDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
 
@@ -1025,7 +1035,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleBulkDeleteCancel}>close</button>
+          <button onClick={handleBulkDeleteCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
 
@@ -1052,7 +1062,7 @@ export default function CommandsPage() {
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button onClick={handleImportCancel}>close</button>
+          <button onClick={handleImportCancel} aria-label="Close dialog">close</button>
         </form>
       </dialog>
     </div>

--- a/webui/frontend/src/pages/ConfigurationPage.test.tsx
+++ b/webui/frontend/src/pages/ConfigurationPage.test.tsx
@@ -612,7 +612,7 @@ describe("ConfigurationPage fetch-models error handling", () => {
     await screen.findByRole("tab", { name: /LLM/ });
     goToTab(/LLM/);
 
-    fireEvent.click(screen.getByRole("button", { name: /Fetch list/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Fetch available models from endpoint/ }));
 
     // Inline error + toast, instead of silently doing nothing.
     await screen.findByTestId("model-fetch-error");

--- a/webui/frontend/src/pages/ConfigurationPage.tsx
+++ b/webui/frontend/src/pages/ConfigurationPage.tsx
@@ -1200,6 +1200,7 @@ const ConfigurationPage: React.FC = () => {
                           className="btn btn-xs btn-ghost gap-1"
                           onClick={handleFetchModels}
                           disabled={fetchingModels || !config.llmBaseUrl || config.envOverrides.baseUrl || config.envOverrides.model}
+                          aria-label={fetchingModels ? "Fetching models" : "Fetch available models from endpoint"}
                           title="Fetch available models from endpoint"
                         >
                           {fetchingModels ? <span className="loading loading-spinner loading-xs"></span> : <RefreshIcon size={16} />}


### PR DESCRIPTION
This PR addresses significant UI friction and structural accessibility defects identified during an architectural audit, focusing on keyboard operability and screen reader compatibility:

1. **Native Dialog Focus Restoration:** Native HTML5 `<dialog>` elements do not automatically return focus to the triggering element when closed, creating a jarring experience for keyboard users. Added robust `useRef`-based trigger capturing and focus restoration across all management modals in `CommandsPage.tsx`.
2. **DaisyUI Backdrop Semantics:** The standard DaisyUI `<form method=\"dialog\" className=\"modal-backdrop\">` pattern visually hides a close button but leaves it exposed to screen readers as an unlabeled \"close\" button. Explicit `aria-label=\"Close dialog\"` attributes have been bound to these elements to provide deterministic semantic meaning.
3. **Dynamic State Announcements:** The 'Fetch list' button in `ConfigurationPage.tsx` dynamically changes its visual text during data fetching, but its static label hid this state transition from assistive technologies. The `aria-label` is now dynamically bound to match the visual loading state.

A detailed architectural breakdown of these prevention strategies has been logged to `.Jules/hone.md`. All test suites, linting, and build validation have passed via CI checks.

---
*PR created automatically by Jules for task [6585187786448825589](https://jules.google.com/task/6585187786448825589) started by @matthewhand*